### PR TITLE
feat: alarm for when user logins using console

### DIFF
--- a/user_login_alarm/input.tf
+++ b/user_login_alarm/input.tf
@@ -1,0 +1,20 @@
+variable "account_name" {
+  description = "(required) The account name to alarm on if it's found"
+  type = string
+}
+
+variable "namespace" {
+  description = "The namespace for the metric"
+  type    = string
+  default = "common-metrics"
+}
+
+variable "log_group_name" {
+  description = "(required) The log group to search for cloudtrail ConsoleLogin events in."
+  type = string
+}
+
+variable "alarm_actions" { 
+  description = "(required) The list of actions to execute when this alarm transitions to alarm state. Takes a set (array) of ARNs"
+  type = set(string)
+}

--- a/user_login_alarm/main.tf
+++ b/user_login_alarm/main.tf
@@ -1,0 +1,25 @@
+resource "aws_cloudwatch_log_metric_filter" "user_alarm" {
+  name           = "${var.account_name}_login"
+  pattern        = "{ $.eventName = \"ConsoleLogin\" && $.userIdentity.userName = \"${var.account_name}\" }"
+  log_group_name = var.log_group_name
+
+  metric_transformation {
+    name      = "${var.account_name}_alarm"
+    namespace = var.namespace
+    value     = 1
+  }
+
+}
+
+resource "aws_cloudwatch_metric_alarm" "alarm" {
+  alarm_name          = "${aws_cloudwatch_log_metric_filter.user_alarm.name}_alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  period              = 10
+  metric_name         = aws_cloudwatch_log_metric_filter.user_alarm.name
+  namespace           = var.namespace
+  statistic           = "Maximum"
+  threshold           = 1
+  treat_missing_data  = "ignore"
+  alarm_actions       = var.alarm_actions
+}


### PR DESCRIPTION
This is mainly used to notify us when a break-glass account logs into an
AWS account but can be used to track any accounts we want to.

This is related to https://github.com/cds-snc/site-reliability-engineering/issues/203