### PR TITLE
fix: handle success/failures and use proper metric

### DIFF
--- a/user_login_alarm/README.md
+++ b/user_login_alarm/README.md
@@ -16,17 +16,21 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_cloudwatch_log_metric_filter.user_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
-| [aws_cloudwatch_metric_alarm.alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_log_metric_filter.user_alarm_failure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
+| [aws_cloudwatch_log_metric_filter.user_alarm_success](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
+| [aws_cloudwatch_metric_alarm.alarm_failure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.alarm_success](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_names"></a> [account\_names](#input\_account\_names) | (required) The account name to alarm on if it's found | `set(string)` | n/a | yes |
-| <a name="input_alarm_actions"></a> [alarm\_actions](#input\_alarm\_actions) | (required) The list of actions to execute when this alarm transitions to alarm state. Takes a set (array) of ARNs | `set(string)` | n/a | yes |
+| <a name="input_alarm_actions_failure"></a> [alarm\_actions\_failure](#input\_alarm\_actions\_failure) | (required) The list of actions to execute when this failure alarm transitions to alarm state. Takes a set (array) of ARNs | `set(string)` | n/a | yes |
+| <a name="input_alarm_actions_success"></a> [alarm\_actions\_success](#input\_alarm\_actions\_success) | (required) The list of actions to execute when this success alarm transitions to alarm state. Takes a set (array) of ARNs | `set(string)` | n/a | yes |
 | <a name="input_log_group_name"></a> [log\_group\_name](#input\_log\_group\_name) | (required) The log group to search for cloudtrail ConsoleLogin events in. | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | The namespace for the metric | `string` | `"common-metrics"` | no |
+| <a name="input_num_attempts"></a> [num\_attempts](#input\_num\_attempts) | (required) The number of failed attempts to login before the alarm triggers | `number` | n/a | yes |
 
 ## Outputs
 

--- a/user_login_alarm/input.tf
+++ b/user_login_alarm/input.tf
@@ -14,7 +14,17 @@ variable "log_group_name" {
   type        = string
 }
 
-variable "alarm_actions" {
-  description = "(required) The list of actions to execute when this alarm transitions to alarm state. Takes a set (array) of ARNs"
+variable "alarm_actions_success" {
+  description = "(required) The list of actions to execute when this success alarm transitions to alarm state. Takes a set (array) of ARNs"
   type        = set(string)
+}
+
+variable "alarm_actions_failure" {
+  description = "(required) The list of actions to execute when this failure alarm transitions to alarm state. Takes a set (array) of ARNs"
+  type        = set(string)
+}
+
+variable "num_attempts" {
+  description = "(required) The number of failed attempts to login before the alarm triggers"
+  type = number
 }

--- a/user_login_alarm/input.tf
+++ b/user_login_alarm/input.tf
@@ -26,5 +26,5 @@ variable "alarm_actions_failure" {
 
 variable "num_attempts" {
   description = "(required) The number of failed attempts to login before the alarm triggers"
-  type = number
+  type        = number
 }

--- a/user_login_alarm/main.tf
+++ b/user_login_alarm/main.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_log_metric_filter" "user_alarm_success" {
   for_each       = var.account_names
   name           = "${each.value}_ConsoleLogin_Success"
-  pattern        = "{ $.eventName = \"ConsoleLogin\" && $.userIdentity.userName = \"${each.value}\" $$ $.responseElements.ConsoleLogin = \"Success\" }"
+  pattern        = "{ $.eventName = \"ConsoleLogin\" && $.userIdentity.userName = \"${each.value}\" && $.responseElements.ConsoleLogin = \"Success\" }"
   log_group_name = var.log_group_name
 
   metric_transformation {
@@ -31,7 +31,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm_success" {
 resource "aws_cloudwatch_log_metric_filter" "user_alarm_failure" {
   for_each       = var.account_names
   name           = "${each.value}_ConsoleLogin_Failure"
-  pattern        = "{ $.eventName = \"ConsoleLogin\" && $.userIdentity.userName = \"${each.value}\" $$ $.responseElements.ConsoleLogin = \"Success\" }"
+  pattern        = "{ $.eventName = \"ConsoleLogin\" && $.userIdentity.userName = \"${each.value}\" && $.responseElements.ConsoleLogin = \"Success\" }"
   log_group_name = var.log_group_name
 
   metric_transformation {

--- a/user_login_alarm/main.tf
+++ b/user_login_alarm/main.tf
@@ -1,27 +1,59 @@
-resource "aws_cloudwatch_log_metric_filter" "user_alarm" {
+resource "aws_cloudwatch_log_metric_filter" "user_alarm_success" {
   for_each       = var.account_names
-  name           = "${each.value}_ConsoleLogin"
-  pattern        = "{ $.eventName = \"ConsoleLogin\" && $.userIdentity.userName = \"${each.value}\" }"
+  name           = "${each.value}_ConsoleLogin_Success"
+  pattern        = "{ $.eventName = \"ConsoleLogin\" && $.userIdentity.userName = \"${each.value}\" $$ $.responseElements.ConsoleLogin = \"Success\" }"
   log_group_name = var.log_group_name
 
   metric_transformation {
-    name      = "${each.value}_alarm"
+    # The name of the metric has to be the same as the filter name otherwise the alarm won't work
+    name      = "${each.value}_ConsoleLogin_Success"
     namespace = var.namespace
     value     = 1
+    unit      = "Count"
   }
 
 }
 
-resource "aws_cloudwatch_metric_alarm" "alarm" {
+resource "aws_cloudwatch_metric_alarm" "alarm_success" {
   for_each            = aws_cloudwatch_log_metric_filter.user_alarm
-  alarm_name          = "${each.value.name}_alarm"
+  alarm_name          = "${each.value.name}_alarm_success"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
-  period              = 10
+  period              = 300
   metric_name         = each.value.name
   namespace           = var.namespace
-  statistic           = "Maximum"
+  statistic           = "Sum"
   threshold           = 1
-  treat_missing_data  = "ignore"
-  alarm_actions       = var.alarm_actions
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_actions_success
+}
+
+resource "aws_cloudwatch_log_metric_filter" "user_alarm_failure" {
+  for_each       = var.account_names
+  name           = "${each.value}_ConsoleLogin_Failure"
+  pattern        = "{ $.eventName = \"ConsoleLogin\" && $.userIdentity.userName = \"${each.value}\" $$ $.responseElements.ConsoleLogin = \"Success\" }"
+  log_group_name = var.log_group_name
+
+  metric_transformation {
+    # The name of the metric has to be the same as the filter name otherwise the alarm won't work
+    name      = "${each.value}_ConsoleLogin_Failure"
+    namespace = var.namespace
+    value     = 1
+    unit      = "Count"
+  }
+
+}
+
+resource "aws_cloudwatch_metric_alarm" "alarm_failure" {
+  for_each            = aws_cloudwatch_log_metric_filter.user_alarm
+  alarm_name          = "${each.value.name}_alarm_failure"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  period              = 300
+  metric_name         = each.value.name
+  namespace           = var.namespace
+  statistic           = "Sum"
+  threshold           = var.num_attempts
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.alarm_actions_failure
 }

--- a/user_login_alarm/main.tf
+++ b/user_login_alarm/main.tf
@@ -31,7 +31,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm_success" {
 resource "aws_cloudwatch_log_metric_filter" "user_alarm_failure" {
   for_each       = var.account_names
   name           = "${each.value}_ConsoleLogin_Failure"
-  pattern        = "{ $.eventName = \"ConsoleLogin\" && $.userIdentity.userName = \"${each.value}\" && $.responseElements.ConsoleLogin = \"Success\" }"
+  pattern        = "{ $.eventName = \"ConsoleLogin\" && $.userIdentity.userName = \"${each.value}\" && $.responseElements.ConsoleLogin = \"Failure\" }"
   log_group_name = var.log_group_name
 
   metric_transformation {

--- a/user_login_alarm/main.tf
+++ b/user_login_alarm/main.tf
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_log_metric_filter" "user_alarm_success" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "alarm_success" {
-  for_each            = aws_cloudwatch_log_metric_filter.user_alarm
+  for_each            = aws_cloudwatch_log_metric_filter.user_alarm_success
   alarm_name          = "${each.value.name}_alarm_success"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -45,7 +45,7 @@ resource "aws_cloudwatch_log_metric_filter" "user_alarm_failure" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "alarm_failure" {
-  for_each            = aws_cloudwatch_log_metric_filter.user_alarm
+  for_each            = aws_cloudwatch_log_metric_filter.user_alarm_failure
   alarm_name          = "${each.value.name}_alarm_failure"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"


### PR DESCRIPTION
# Summary | Résumé
- Fix the alarm so it uses the metric name not the alarm name
- Split up the alarm so we have one for success and one for failures
- Allow the user to set the number of failed attempts before an alarm
  goes off
- Change the unit to a Count (not sure we actually need to do this)


