### PR TITLE
feat: add a module that creates a pub/priv vpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   - [How to use modules in this repo](#how-to-use-modules-in-this-repo)
 ## Module List
 - [User Login Alarm](user_login_alarm)
+- [Public/Private VPC](pub_priv_vpc)
 
 ## How to use modules in this repo
 

--- a/bin/generate-docs.sh
+++ b/bin/generate-docs.sh
@@ -10,4 +10,6 @@ function generate_docs  {
 }
 
 generate_docs "user_login_alarm"
+#generate_docs "rds"
+generate_docs "pub_priv_vpc"
 echo "✅ Done generating docs"

--- a/pub_priv_vpc/README.md
+++ b/pub_priv_vpc/README.md
@@ -1,0 +1,57 @@
+This module creates a vpc with 2 subnets, one public and one private.
+The public subnet is attached to an internet gateway and a public IP address.
+The private subnet is connected to the public through a nat gateway.
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_default_network_acl.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_network_acl) | resource |
+| [aws_default_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) | resource |
+| [aws_eip.public_ip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_flow_log.flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) | resource |
+| [aws_iam_role.flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_internet_gateway.gw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
+| [aws_nat_gateway.nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
+| [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
+| [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
+| [aws_route_table_association.a](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
+| [aws_iam_policy_document.vpc_flow_logs_service_principal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vpc_metrics_flow_logs_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | The name of the billing tag | `string` | `"CostCentre"` | no |
+| <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (required) The value of the billing tag | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | (required) the name of the vpc | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_private_route_table_id"></a> [private\_route\_table\_id](#output\_private\_route\_table\_id) | n/a |
+| <a name="output_private_subnet_id"></a> [private\_subnet\_id](#output\_private\_subnet\_id) | n/a |
+| <a name="output_public_ip"></a> [public\_ip](#output\_public\_ip) | n/a |
+| <a name="output_public_subnet_id"></a> [public\_subnet\_id](#output\_public\_subnet\_id) | n/a |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | n/a |

--- a/pub_priv_vpc/defaults.tf
+++ b/pub_priv_vpc/defaults.tf
@@ -1,0 +1,25 @@
+
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.main.id
+  tags = merge(local.common_tags, {
+    Name = "${var.name}_default_sg"
+  })
+}
+
+resource "aws_default_network_acl" "default" {
+  default_network_acl_id = aws_vpc.main.default_network_acl_id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name}_default_nacl"
+  })
+}
+
+resource "aws_default_route_table" "default" {
+  default_route_table_id = aws_vpc.main.default_route_table_id
+
+  route = []
+
+  tags = merge(local.common_tags, {
+    name = "${var.name}_default_route_table"
+  })
+}

--- a/pub_priv_vpc/flowlogs.tf
+++ b/pub_priv_vpc/flowlogs.tf
@@ -1,0 +1,50 @@
+resource "aws_flow_log" "flow_logs" {
+  iam_role_arn    = aws_iam_role.flow_logs.arn
+  log_destination = aws_cloudwatch_log_group.flow_logs.arn
+  traffic_type    = "ALL"
+  vpc_id          = aws_vpc.main.id
+}
+
+resource "aws_cloudwatch_log_group" "flow_logs" {
+  # checkov:skip=CKV_AWS_158:Encryption using default CloudWatch service key is acceptable
+  name              = "${var.name}_flow_logs"
+  retention_in_days = 30
+}
+
+resource "aws_iam_role" "flow_logs" {
+  name               = "${var.name}_flow_logs"
+  assume_role_policy = data.aws_iam_policy_document.vpc_flow_logs_service_principal.json
+}
+
+data "aws_iam_policy_document" "vpc_flow_logs_service_principal" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["vpc-flow-logs.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "vpc_metrics_flow_logs_write" {
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams"
+    ]
+
+    resources = [
+      aws_cloudwatch_log_group.flow_logs.arn,
+      "${aws_cloudwatch_log_group.flow_logs.arn}:log-stream:*"
+    ]
+  }
+}

--- a/pub_priv_vpc/inputs.tf
+++ b/pub_priv_vpc/inputs.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  description = "(required) the name of the vpc"
+  type        = string
+}
+
+variable "billing_tag_key" {
+  description = "The name of the billing tag"
+  type        = string
+  default     = "CostCentre"
+}
+
+variable "billing_tag_value" {
+  description = "(required) The value of the billing tag"
+  type        = string
+}

--- a/pub_priv_vpc/locals.tf
+++ b/pub_priv_vpc/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  common_tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = "true"
+  }
+}

--- a/pub_priv_vpc/main.tf
+++ b/pub_priv_vpc/main.tf
@@ -1,0 +1,73 @@
+/* Public/Private VPC
+* This module creates a vpc with 2 subnets, one public and one private.
+* The public subnet is attached to an internet gateway and a public IP address.
+* The private subnet is connected to the public through a nat gateway.
+*/
+
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name}_vpc"
+  })
+
+}
+
+resource "aws_nat_gateway" "nat_gateway" {
+
+  allocation_id = aws_eip.public_ip.id
+  subnet_id     = aws_subnet.public.id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name}-natgw"
+  })
+
+  depends_on = [
+    aws_internet_gateway.gw
+  ]
+}
+
+resource "aws_eip" "public_ip" {
+  # checkov:skip=CKV2_AWS_19:EIP is used by NAT Gateway
+  vpc = true
+}
+
+resource "aws_subnet" "private" {
+
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name}_private_subnet"
+  })
+
+  availability_zone = "ca-central-1a"
+  cidr_block        = "10.0.1.0/24"
+
+  timeouts {
+    delete = "40m"
+  }
+}
+
+resource "aws_subnet" "public" {
+
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name}_public_subnet"
+  })
+
+  cidr_block = "10.0.0.0/24"
+}
+
+resource "aws_internet_gateway" "gw" {
+
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name}_internet_gateway"
+  })
+
+}
+

--- a/pub_priv_vpc/outputs.tf
+++ b/pub_priv_vpc/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "public_ip" {
+  value = aws_eip.public_ip.public_ip
+}
+
+output "public_subnet_id" {
+  value = aws_subnet.public.id
+}
+
+output "private_subnet_id" {
+  value = aws_subnet.private.id
+}
+
+output "private_route_table_id" {
+  value = aws_route_table.private.id
+}

--- a/pub_priv_vpc/routetable.tf
+++ b/pub_priv_vpc/routetable.tf
@@ -1,0 +1,37 @@
+resource "aws_route_table" "public" {
+
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gw.id
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name}_public_route_table"
+  })
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.nat_gateway.id
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name}_private_route_table"
+  })
+}
+
+resource "aws_route_table_association" "a" {
+  subnet_id      = aws_subnet.private.id
+  route_table_id = aws_route_table.private.id
+}


### PR DESCRIPTION
# Summary | Résumé

- Creates a VPC that has two subnets 1 public and 1 private.
- Adds an Inet gateway to the public subnet, adds a nat gateway to the
private subnet.
- Attaches an elastic IP to the VPC.
- Cleasr out default sg, route table, and nacl
- Add flowlogs

