### PR TITLE
feat: add a nacl to the vpc

### DIFF
--- a/vpc/README.md
+++ b/vpc/README.md
@@ -47,6 +47,9 @@ No modules.
 | [aws_iam_role.flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_internet_gateway.gw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
 | [aws_nat_gateway.nat_gw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
+| [aws_network_acl.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
+| [aws_network_acl_rule.block_rdp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.block_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_route.private_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.public_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
@@ -66,6 +69,8 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (required) The value of the billing tag | `string` | n/a | yes |
+| <a name="input_block_rdp"></a> [block\_rdp](#input\_block\_rdp) | Whether or not to block Port 3389 | `bool` | `true` | no |
+| <a name="input_block_ssh"></a> [block\_ssh](#input\_block\_ssh) | Whether or not to block Port 22 | `bool` | `true` | no |
 | <a name="input_enable_flow_log"></a> [enable\_flow\_log](#input\_enable\_flow\_log) | Whether or not to enable VPC Flow Logs | `bool` | `false` | no |
 | <a name="input_high_availability"></a> [high\_availability](#input\_high\_availability) | Create either one set of subnets or as many as there are VPCs | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | (required) the name of the vpc | `string` | n/a | yes |
@@ -74,8 +79,9 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_main_nacl_id"></a> [main\_nacl\_id](#output\_main\_nacl\_id) | n/a |
 | <a name="output_private_route_table_ids"></a> [private\_route\_table\_ids](#output\_private\_route\_table\_ids) | n/a |
 | <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | n/a |
-| <a name="output_public_ip"></a> [public\_ip](#output\_public\_ip) | n/a |
+| <a name="output_public_ips"></a> [public\_ips](#output\_public\_ips) | n/a |
 | <a name="output_public_subnet_ids"></a> [public\_subnet\_ids](#output\_public\_subnet\_ids) | n/a |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | n/a |

--- a/vpc/inputs.tf
+++ b/vpc/inputs.tf
@@ -25,3 +25,16 @@ variable "enable_flow_log" {
   type        = bool
   default     = false
 }
+
+variable "block_ssh" {
+  description = "Whether or not to block Port 22"
+  type        = bool
+  default     = true
+
+}
+
+variable "block_rdp" {
+  description = "Whether or not to block Port 3389"
+  type        = bool
+  default     = true
+}

--- a/vpc/nacl.tf
+++ b/vpc/nacl.tf
@@ -1,0 +1,32 @@
+resource "aws_network_acl" "main" {
+  vpc_id     = aws_vpc.main.id
+  subnet_ids = concat(aws_subnet.public.*.id, aws_subnet.private.*.id)
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name}_main_nacl"
+  })
+}
+
+resource "aws_network_acl_rule" "block_ssh" {
+  count          = var.block_ssh ? 1 : 0
+  network_acl_id = aws_network_acl.main.id
+  rule_number    = 50
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "deny"
+  cidr_block     = aws_vpc.main.cidr_block
+  from_port      = 22
+  to_port        = 22
+}
+
+resource "aws_network_acl_rule" "block_rdp" {
+  count          = var.block_rdp ? 1 : 0
+  network_acl_id = aws_network_acl.main.id
+  rule_number    = 51
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "deny"
+  cidr_block     = aws_vpc.main.cidr_block
+  from_port      = 3389
+  to_port        = 3389
+}

--- a/vpc/outputs.tf
+++ b/vpc/outputs.tf
@@ -2,7 +2,7 @@ output "vpc_id" {
   value = aws_vpc.main.id
 }
 
-output "public_ip" {
+output "public_ips" {
   value = aws_eip.nat.*.public_ip
 }
 
@@ -16,4 +16,8 @@ output "private_subnet_ids" {
 
 output "private_route_table_ids" {
   value = aws_route_table.private.*.id
+}
+
+output "main_nacl_id" {
+  value = aws_network_acl.main.id
 }


### PR DESCRIPTION
# Summary | Résumé

Adds a NACL that is connected to all subnets. 
Allows the user to unblock ssh and rdp ports
Exports the nacl id so we can attach more rules
