### PR TITLE
feat: store the proxy connection string and expose it

### DIFF
--- a/rds/outputs.tf
+++ b/rds/outputs.tf
@@ -1,1 +1,8 @@
+output "proxy_connection_string_arn" {
+  description = "The arn for the connectionstring to the RDS proxy"
+  value       = aws_secretsmanager_secret.proxy_connection_string.arn
+}
 
+output "proxy_endpoint" {
+  value = aws_db_proxy.proxy.endpoint
+}

--- a/rds/secret.tf
+++ b/rds/secret.tf
@@ -7,3 +7,13 @@ resource "aws_secretsmanager_secret_version" "connection_string" {
   secret_id     = aws_secretsmanager_secret.connection_string.id
   secret_string = "postgres://${var.username}:${var.password}@${aws_rds_cluster.cluster.endpoint}/${var.database_name}"
 }
+
+resource "aws_secretsmanager_secret" "proxy_connection_string" {
+  name = "${var.name}-${random_string.random.result}"
+  tags = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "proxy_connection_string" {
+  secret_id     = aws_secretsmanager_secret.proxy_connection_string.id
+  secret_string = "postgres://${var.username}:${var.password}@${aws_db_proxy.proxy.endpoint}/${var.database_name}"
+}


### PR DESCRIPTION
Exposes the proxy endpoint and the connection string as outputs. 
Adds the proxy connection string as a secret
