### PR TITLE
feat: CI workflow to run Terratests

### DIFF
--- a/.github/workflows/terratest.yml
+++ b/.github/workflows/terratest.yml
@@ -1,0 +1,56 @@
+name: "Terratest modules"
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+env:
+  GO_VERSION: 1.16.6
+  TERRAFORM_VERSION: 1.0.3
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+jobs:
+  terratest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - user_login_alarm
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # v2.10.2
+      id: changes
+      with:
+        filters: |
+          module:
+            - "${{ matrix.module }}/**/*.tf"
+            - "${{ matrix.module }}/test/**"
+
+    - name: Setup Go
+      if: steps.changes.outputs.module == "true"
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
+
+    - name: Setup Terraform
+      if: steps.changes.outputs.module == "true"
+      uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: ${{ env.TERRAFORM_VERSION }}
+        terraform_wrapper: false
+
+    - name: Terratest
+      if: steps.changes.outputs.module == "true"
+      run: |
+        cd ${{ matrix.module }}/test
+        go mod tidy
+        go test -v

--- a/.github/workflows/terratest.yml
+++ b/.github/workflows/terratest.yml
@@ -32,24 +32,24 @@ jobs:
       with:
         filters: |
           module:
-            - "${{ matrix.module }}/**/*.tf"
-            - "${{ matrix.module }}/test/**"
+            - '${{ matrix.module }}/**/*.tf'
+            - '${{ matrix.module }}/test/**'
 
     - name: Setup Go
-      if: steps.changes.outputs.module == "true"
+      if: steps.changes.outputs.module == 'true'
       uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}
 
     - name: Setup Terraform
-      if: steps.changes.outputs.module == "true"
+      if: steps.changes.outputs.module == 'true'
       uses: hashicorp/setup-terraform@v1
       with:
         terraform_version: ${{ env.TERRAFORM_VERSION }}
         terraform_wrapper: false
 
     - name: Terratest
-      if: steps.changes.outputs.module == "true"
+      if: steps.changes.outputs.module == 'true'
       run: |
         cd ${{ matrix.module }}/test
         go mod tidy

--- a/user_login_alarm/.checkov.yml
+++ b/user_login_alarm/.checkov.yml
@@ -1,0 +1,2 @@
+skip-check: 
+  - CKV_AWS_26

--- a/user_login_alarm/examples/alarm_actions/main.tf
+++ b/user_login_alarm/examples/alarm_actions/main.tf
@@ -1,0 +1,18 @@
+resource "aws_sns_topic" "samwise_success" {
+  name = "samwise_success_sns_terratest"
+}
+
+resource "aws_sns_topic" "samwise_failure" {
+  name = "samwise_failure_sns_terratest"
+}
+
+# Create an alarm for one account with a success and failure action
+module "alarm_actions" {
+  source                = "../../"
+  account_names         = ["samwise"]
+  namespace             = "terratest"
+  log_group_name        = "CloudTrail/Landing-Zone-Logs"
+  alarm_actions_success = [aws_sns_topic.samwise_success.arn]
+  alarm_actions_failure = [aws_sns_topic.samwise_failure.arn]
+  num_attempts          = 5
+}

--- a/user_login_alarm/examples/alarm_actions/outputs.tf
+++ b/user_login_alarm/examples/alarm_actions/outputs.tf
@@ -1,0 +1,7 @@
+output "sns_topic_success_arn" {
+  value = aws_sns_topic.samwise_success.arn
+}
+
+output "sns_topic_failure_arn" {
+  value = aws_sns_topic.samwise_failure.arn
+}

--- a/user_login_alarm/examples/alarm_actions/provider.tf
+++ b/user_login_alarm/examples/alarm_actions/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "ca-central-1"
+}

--- a/user_login_alarm/test/alarm_actions_test.go
+++ b/user_login_alarm/test/alarm_actions_test.go
@@ -1,0 +1,55 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActionsAlarmCreations(t *testing.T) {
+	t.Parallel()
+
+	accountName := "samwise"
+	alarmFailThreshold := 5.0
+	alarmSuccessThreshold := 1.0
+	metricNamespace := "terratest"
+	region := "ca-central-1"
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: "../examples/alarm_actions",
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": region,
+		},
+	}
+
+	// Destroy resource once tests are finished
+	defer terraform.Destroy(t, terraformOptions)
+
+	// Create the resources
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Get outputs from the `terraform apply`
+	snsSuccessArn := terraform.Output(t, terraformOptions, "sns_topic_success_arn")
+	snsFailureArn := terraform.Output(t, terraformOptions, "sns_topic_failure_arn")
+
+	client := NewCloudWatchClient(t, region)
+
+	// Validate Success alarm
+	metricName := accountName + "_ConsoleLogin_Success"
+	alarmSuccess := GetMetricAlarm(t, client, metricName, metricNamespace).MetricAlarms[0]
+
+	assert.Equal(t, metricName+"_alarm_success", *alarmSuccess.AlarmName)
+	assert.Equal(t, alarmSuccessThreshold, *alarmSuccess.Threshold)
+	assert.Equal(t, 1, len(alarmSuccess.AlarmActions))
+	assert.Equal(t, snsSuccessArn, *alarmSuccess.AlarmActions[0])
+
+	// Validate Failure alarm
+	metricName = accountName + "_ConsoleLogin_Failure"
+	alarmFail := GetMetricAlarm(t, client, metricName, metricNamespace).MetricAlarms[0]
+
+	assert.Equal(t, metricName+"_alarm_failure", *alarmFail.AlarmName)
+	assert.Equal(t, alarmFailThreshold, *alarmFail.Threshold)
+	assert.Equal(t, 1, len(alarmFail.AlarmActions))
+	assert.Equal(t, snsFailureArn, *alarmFail.AlarmActions[0])
+}

--- a/user_login_alarm/test/cloudwatch_test.go
+++ b/user_login_alarm/test/cloudwatch_test.go
@@ -1,0 +1,30 @@
+package test
+
+import (
+	"testing"
+
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/gruntwork-io/terratest/modules/aws"
+)
+
+// Retrieves the Alarms for a given metric and namespace
+func GetMetricAlarm(t *testing.T, client *cloudwatch.CloudWatch, metricName string, metricNamespace string) *cloudwatch.DescribeAlarmsForMetricOutput {
+	alarm, err := client.DescribeAlarmsForMetric(&cloudwatch.DescribeAlarmsForMetricInput{
+		MetricName: awssdk.String(metricName),
+		Namespace:  awssdk.String(metricNamespace),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return alarm
+}
+
+// Creates a new CloudWatch client
+func NewCloudWatchClient(t *testing.T, region string) *cloudwatch.CloudWatch {
+	sess, err := aws.NewAuthenticatedSession(region)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cloudwatch.New(sess)
+}


### PR DESCRIPTION
# Summary
* Adds a workflow that runs the modules that have Terratests against the `TerraformModules-Test` AWS account.
* Also includes a `user_alarm_action` example with SNS topics and the associated tests.

Closes #12