### PR TITLE
fix: install Go language server automatically in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,6 +41,8 @@
 		"redhat.vscode-yaml"
 	],
 
+	"postCreateCommand": "go get -v golang.org/x/tools/gopls",
+
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }


### PR DESCRIPTION
# Summary
This makes sure `gopls` is installed as part of the devcontainer build.