### PR TITLE
fix: remove unnecessary named import

### DIFF
--- a/vpc/test/vpc_test.go
+++ b/vpc/test/vpc_test.go
@@ -3,14 +3,14 @@ package test
 import (
 	"testing"
 
-	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/require"
 )
 
 // Gets a VPCs internet gateway
 func GetVpcInternetGateways(t *testing.T, client *ec2.EC2, vpcId string) *ec2.DescribeInternetGatewaysOutput {
-	igwFilter := ec2.Filter{Name: awssdk.String("attachment.vpc-id"), Values: []*string{&vpcId}}
+	igwFilter := ec2.Filter{Name: aws.String("attachment.vpc-id"), Values: []*string{&vpcId}}
 
 	igws, err := client.DescribeInternetGateways(&ec2.DescribeInternetGatewaysInput{Filters: []*ec2.Filter{&igwFilter}})
 	require.NoError(t, err)
@@ -20,7 +20,7 @@ func GetVpcInternetGateways(t *testing.T, client *ec2.EC2, vpcId string) *ec2.De
 
 // Gets a VPCs NAT gateways
 func GetVpcNatGateways(t *testing.T, client *ec2.EC2, vpcId string) *ec2.DescribeNatGatewaysOutput {
-	vpcFilter := ec2.Filter{Name: awssdk.String("vpc-id"), Values: []*string{&vpcId}}
+	vpcFilter := ec2.Filter{Name: aws.String("vpc-id"), Values: []*string{&vpcId}}
 
 	natGateways, err := client.DescribeNatGateways(&ec2.DescribeNatGatewaysInput{Filter: []*ec2.Filter{&vpcFilter}})
 	require.NoError(t, err)
@@ -30,10 +30,10 @@ func GetVpcNatGateways(t *testing.T, client *ec2.EC2, vpcId string) *ec2.Describ
 
 // Gets the NACLs for a VPC that deny access to port 22 and 3389
 func GetVpcDenyNetworkAcls(t *testing.T, client *ec2.EC2, vpcId string) *ec2.DescribeNetworkAclsOutput {
-	vpcFilter := ec2.Filter{Name: awssdk.String("vpc-id"), Values: []*string{&vpcId}}
-	naclPortSshFilter := ec2.Filter{Name: awssdk.String("entry.port-range.from"), Values: []*string{awssdk.String("22")}}
-	naclPortRdpFilter := ec2.Filter{Name: awssdk.String("entry.port-range.from"), Values: []*string{awssdk.String("3389")}}
-	denyActionFilter := ec2.Filter{Name: awssdk.String("entry.rule-action"), Values: []*string{awssdk.String("deny")}}
+	vpcFilter := ec2.Filter{Name: aws.String("vpc-id"), Values: []*string{&vpcId}}
+	naclPortSshFilter := ec2.Filter{Name: aws.String("entry.port-range.from"), Values: []*string{aws.String("22")}}
+	naclPortRdpFilter := ec2.Filter{Name: aws.String("entry.port-range.from"), Values: []*string{aws.String("3389")}}
+	denyActionFilter := ec2.Filter{Name: aws.String("entry.rule-action"), Values: []*string{aws.String("deny")}}
 
 	networkAcls, err := client.DescribeNetworkAcls(&ec2.DescribeNetworkAclsInput{Filters: []*ec2.Filter{&vpcFilter, &naclPortSshFilter, &naclPortRdpFilter, &denyActionFilter}})
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func GetVpcDenyNetworkAcls(t *testing.T, client *ec2.EC2, vpcId string) *ec2.Des
 
 // Gets a VPCs flow log
 func GetVpcFlowLogs(t *testing.T, client *ec2.EC2, logGroupName string) *ec2.DescribeFlowLogsOutput {
-	flowLogsFilter := ec2.Filter{Name: awssdk.String("log-group-name"), Values: []*string{&logGroupName}}
+	flowLogsFilter := ec2.Filter{Name: aws.String("log-group-name"), Values: []*string{&logGroupName}}
 
 	flowLogs, err := client.DescribeFlowLogs(&ec2.DescribeFlowLogsInput{Filter: []*ec2.Filter{&flowLogsFilter}})
 	require.NoError(t, err)


### PR DESCRIPTION
# Summary
The AWS import no longer requires an alias.

This commit is being pulled out of #47 since the tests will not be able to run successfully for both the VPC and RDS modules.  They both create high availability VPCs, which exhausts the account's pool of Elastic IPs.