### PR TITLE
feat: nightly AWS nuke of Terraform modules account

### DIFF
--- a/.github/workflows/assets/aws-nuke-config.yml
+++ b/.github/workflows/assets/aws-nuke-config.yml
@@ -1,0 +1,116 @@
+# Regions to remove resources from
+regions:
+- "global"
+- "us-east-1"
+- "ca-central-1"
+
+# Only delete resources from this account that do not match the filters
+accounts:
+  "124044056575":
+    filters:
+      CloudFormationStack:
+        - propery: Name
+          type: regex
+          value: ".*Landing-?Zone.*"
+      CloudTrailTrail:
+        - propery: Name
+          type: regex
+          value: ".*Landing-?Zone.*"
+      CloudWatchAlarm:
+        - propery: TargetId
+          type: regex
+          value: "(CloudTrail.*|IAMPolicyChanges|RootLogin)"
+      CloudWatchEventsTarget:
+        - propery: Name
+          type: regex
+          value: ".*Landing-?Zone.*"
+      CloudWatchLogsLogGroup:
+        - propery: ARN
+          type: regex
+          value: ".*Landing-?Zone.*"
+      IAMRole:
+        - propery: Name
+          type: regex
+          value: "(Landing-?Zone|AWSReservedSSO|CloudFormation)"
+      IAMRolePolicy:
+        - propery: RoleName
+          type: regex
+          value: "(Landing-?Zone|AWSReservedSSO|CloudFormation)"
+      IAMRolePolicyAttachment:
+        - propery: RoleName
+          type: regex
+          value: "(Landing-?Zone|AWSReservedSSO)"
+      LambdaFunction:
+        - propery: Name
+          type: regex
+          value: ".*Landing-?Zone.*"
+      SNSSubscription:
+        - propery: ARN
+          type: regex
+          value: ".*Landing-?Zone.*"
+      SNSTopic:
+        - propery: TopicARN
+          type: regex
+          value: ".*Landing-?Zone.*"
+      SSMParameter:
+        - propery: Name
+          type: regex
+          value: ".*local_sns_arn.*"
+
+# Do not delete any of the following resource types
+resource-types:
+  excludes:
+    - CloudWatchEventsRule
+    - ConfigServiceConfigRule
+    - ConfigServiceDeliveryChannel
+    - ConfigServiceConfigurationRecorder
+    - EC2DHCPOption
+    - ElasticacheCacheParameterGroup
+    - FMSPolicy
+    - FMSNotificationChannel
+    - IAMUserAccessKey
+    - IAMUserPolicyAttachment
+    - IAMLoginProfile
+    - IAMSAMLProvider
+    - IAMUser
+    - KMSAlias
+    - OpsWorksUserProfile
+    - SecurityHub
+
+# Accounts that will not have resources removed
+account-blocklist:
+- "595701125956"
+- "239043911459"
+- "977382588899"
+- "722713121070"
+- "009883649233"
+- "703399696403"
+- "276192857112"
+- "637287734259"
+- "339850311124"
+- "507252742351"
+- "820252213580"
+- "563894450011"
+- "160411545784"
+- "136676205420"
+- "894242006032"
+- "028051698106"
+- "773858180673"
+- "370045664819"
+- "005133826942"
+- "578240607488"
+- "537819865265"
+- "527289287223"
+- "687401027353"
+- "797698708703"
+- "349837941862"
+- "406214159830"
+- "591111259917"
+- "296255494825"
+- "414662622316"
+- "957818836222"
+- "515018049985"
+- "925306372402"
+- "283582579564"
+- "400061975867"
+- "059208818674"

--- a/.github/workflows/aws-nuke.yml
+++ b/.github/workflows/aws-nuke.yml
@@ -1,0 +1,31 @@
+name: AWS nuke
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * *"
+
+env:
+  AWS_NUKE_VERSION: 2.15.0
+
+jobs:
+  aws-nuke:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install AWS nuke
+      run: |
+        curl -Lo aws-nuke.tar.gz https://github.com/rebuy-de/aws-nuke/releases/download/v${{ env.AWS_NUKE_VERSION }}/aws-nuke-v${{ env.AWS_NUKE_VERSION }}-linux-amd64.tar.gz
+        tar -xzf aws-nuke.tar.gz -C bin
+        chmod +x bin/*
+        echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+
+    - name: AWS nuke
+      run: |
+        aws-nuke-v${{ env.AWS_NUKE_VERSION }}-linux-amd64 \
+          --config .github/workflows/assets/aws-nuke-config.yml \
+          --access-key-id ${{ secrets.AWS_ACCESS_KEY_ID }} \
+          --secret-access-key ${{ secrets.AWS_SECRET_ACCESS_KEY }} \
+          --force --force-sleep 3 --no-dry-run --quiet


### PR DESCRIPTION
# Summary
This is to ensure Terratest resources are properly cleaned up each night.

The filter section of the AWS nuke config is setup to prevent deletion of all Landing Zone and SSO resources.

Closes #48 
Related cds-snc/platform-sre-security-support#5