### PR TITLE
feat: add 60 minute timeout to nuke job

### DIFF
--- a/.github/workflows/aws-nuke.yml
+++ b/.github/workflows/aws-nuke.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   aws-nuke:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
 
     - name: Checkout


### PR DESCRIPTION
# Summary
This will prevent eating up unnecessary GitHub Action minutes if AWS nuke is unable to delete a resource and begins looping.