### PR TITLE
fix: attach VPC flow logs write policy to role

### DIFF
--- a/vpc/flowlogs.tf
+++ b/vpc/flowlogs.tf
@@ -44,7 +44,7 @@ resource "aws_iam_policy" "vpc_metrics_flow_logs_write_policy" {
   name        = "VpcMetricsFlowLogsWrite"
   description = "IAM policy for writing flow logs in CloudWatch"
   path        = "/"
-  policy      = data.aws_iam_policy_document.vpc_metrics_flow_logs_write.json
+  policy      = data.aws_iam_policy_document.vpc_metrics_flow_logs_write[0].json
 }
 
 data "aws_iam_policy_document" "vpc_metrics_flow_logs_write" {


### PR DESCRIPTION
# Summary
Attaches the IAM policy that allows for the write of VPC flow logs to the role.