### PR TITLE
feat: allow HTTPS ingress or egress from the VPC

### DIFF
--- a/vpc/README.md
+++ b/vpc/README.md
@@ -52,10 +52,14 @@ No modules.
 | [aws_network_acl.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
 | [aws_network_acl_rule.block_rdp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.block_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
-| [aws_network_acl_rule.ephemeral_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
-| [aws_network_acl_rule.ephemeral_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
-| [aws_network_acl_rule.https_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
-| [aws_network_acl_rule.https_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.https_request_egress_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.https_request_egress_ephemeral](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.https_request_ingress_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.https_request_ingress_ephemeral](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.https_response_egress_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.https_response_egress_ephemeral](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.https_response_ingress_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.https_response_ingress_ephemeral](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_route.private_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.public_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
@@ -73,10 +77,10 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allow_ephemeral_egress"></a> [allow\_ephemeral\_egress](#input\_allow\_ephemeral\_egress) | (Optional, default 'false') Allow connections on ports 1024 to 65535 out to the internet | `bool` | `false` | no |
-| <a name="input_allow_ephemeral_ingress"></a> [allow\_ephemeral\_ingress](#input\_allow\_ephemeral\_ingress) | (Optional, default 'false') Allow connections on ports 1024 to 65535 in from the internet | `bool` | `false` | no |
-| <a name="input_allow_https_egress"></a> [allow\_https\_egress](#input\_allow\_https\_egress) | (Optional, default 'false') Allow HTTPS connections on port 443 out to the internet | `bool` | `false` | no |
-| <a name="input_allow_https_ingress"></a> [allow\_https\_ingress](#input\_allow\_https\_ingress) | (Optional, default 'false') Allow HTTPS connections on port 443 in from the internet | `bool` | `false` | no |
+| <a name="input_allow_https_request_in"></a> [allow\_https\_request\_in](#input\_allow\_https\_request\_in) | (Optional, default 'false') Allow HTTPS connections on port 443 in from the internet | `bool` | `false` | no |
+| <a name="input_allow_https_request_in_response"></a> [allow\_https\_request\_in\_response](#input\_allow\_https\_request\_in\_response) | (Optional, default 'false') Allow a response back to the internet in reply to a request | `bool` | `false` | no |
+| <a name="input_allow_https_request_out"></a> [allow\_https\_request\_out](#input\_allow\_https\_request\_out) | (Optional, default 'false') Allow HTTPS connections on port 443 out to the internet | `bool` | `false` | no |
+| <a name="input_allow_https_request_out_response"></a> [allow\_https\_request\_out\_response](#input\_allow\_https\_request\_out\_response) | (Optional, default 'false') Allow a response back from the internet in reply to a request | `bool` | `false` | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_block_rdp"></a> [block\_rdp](#input\_block\_rdp) | (Optional, default 'true') Whether or not to block Port 3389 | `bool` | `true` | no |

--- a/vpc/README.md
+++ b/vpc/README.md
@@ -44,12 +44,18 @@ No modules.
 | [aws_default_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) | resource |
 | [aws_eip.nat](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_flow_log.flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) | resource |
+| [aws_iam_policy.vpc_metrics_flow_logs_write_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.vpc_metrics_flow_logs_write_policy_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_internet_gateway.gw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
 | [aws_nat_gateway.nat_gw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
 | [aws_network_acl.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl) | resource |
 | [aws_network_acl_rule.block_rdp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_network_acl_rule.block_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.ephemeral_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.ephemeral_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.https_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
+| [aws_network_acl_rule.https_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule) | resource |
 | [aws_route.private_nat_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.public_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
@@ -67,13 +73,14 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | The name of the billing tag | `string` | `"CostCentre"` | no |
-| <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (required) The value of the billing tag | `string` | n/a | yes |
-| <a name="input_block_rdp"></a> [block\_rdp](#input\_block\_rdp) | Whether or not to block Port 3389 | `bool` | `true` | no |
-| <a name="input_block_ssh"></a> [block\_ssh](#input\_block\_ssh) | Whether or not to block Port 22 | `bool` | `true` | no |
-| <a name="input_enable_flow_log"></a> [enable\_flow\_log](#input\_enable\_flow\_log) | Whether or not to enable VPC Flow Logs | `bool` | `false` | no |
-| <a name="input_high_availability"></a> [high\_availability](#input\_high\_availability) | Create either one set of subnets or as many as there are VPCs | `bool` | `false` | no |
-| <a name="input_name"></a> [name](#input\_name) | (required) the name of the vpc | `string` | n/a | yes |
+| <a name="input_allow_https_out"></a> [allow\_https\_out](#input\_allow\_https\_out) | (Optional, default 'true') Allow HTTPS connections out to the internet | `bool` | `true` | no |
+| <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
+| <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
+| <a name="input_block_rdp"></a> [block\_rdp](#input\_block\_rdp) | (Optional, default 'true') Whether or not to block Port 3389 | `bool` | `true` | no |
+| <a name="input_block_ssh"></a> [block\_ssh](#input\_block\_ssh) | (Optional, default 'true') Whether or not to block Port 22 | `bool` | `true` | no |
+| <a name="input_enable_flow_log"></a> [enable\_flow\_log](#input\_enable\_flow\_log) | (Optional, default 'false') Whether or not to enable VPC Flow Logs | `bool` | `false` | no |
+| <a name="input_high_availability"></a> [high\_availability](#input\_high\_availability) | (Optional, default 'false') Create 3 public and 3 private subnets across 3 availability zones in the region. | `bool` | `false` | no |
+| <a name="input_name"></a> [name](#input\_name) | (Required) The name of the vpc | `string` | n/a | yes |
 
 ## Outputs
 

--- a/vpc/README.md
+++ b/vpc/README.md
@@ -73,7 +73,10 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allow_https_out"></a> [allow\_https\_out](#input\_allow\_https\_out) | (Optional, default 'true') Allow HTTPS connections out to the internet | `bool` | `true` | no |
+| <a name="input_allow_ephemeral_egress"></a> [allow\_ephemeral\_egress](#input\_allow\_ephemeral\_egress) | (Optional, default 'false') Allow connections on ports 1024 to 65535 out to the internet | `bool` | `false` | no |
+| <a name="input_allow_ephemeral_ingress"></a> [allow\_ephemeral\_ingress](#input\_allow\_ephemeral\_ingress) | (Optional, default 'false') Allow connections on ports 1024 to 65535 in from the internet | `bool` | `false` | no |
+| <a name="input_allow_https_egress"></a> [allow\_https\_egress](#input\_allow\_https\_egress) | (Optional, default 'false') Allow HTTPS connections on port 443 out to the internet | `bool` | `false` | no |
+| <a name="input_allow_https_ingress"></a> [allow\_https\_ingress](#input\_allow\_https\_ingress) | (Optional, default 'false') Allow HTTPS connections on port 443 in from the internet | `bool` | `false` | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_block_rdp"></a> [block\_rdp](#input\_block\_rdp) | (Optional, default 'true') Whether or not to block Port 3389 | `bool` | `true` | no |

--- a/vpc/examples/high_availability/main.tf
+++ b/vpc/examples/high_availability/main.tf
@@ -12,7 +12,7 @@ module "high_availability_vpc" {
 
   # Allow users to send requests in from the internet and receive a response
   allow_https_request_in          = true
-  allow_https_request_in_response = true  
+  allow_https_request_in_response = true
 
   block_ssh = false
   block_rdp = false

--- a/vpc/examples/high_availability/main.tf
+++ b/vpc/examples/high_availability/main.tf
@@ -6,10 +6,13 @@ module "high_availability_vpc" {
   high_availability = true
   enable_flow_log   = true
 
-  # Allow services to connect out to the internet
-  allow_https_egress      = true
-  allow_ephemeral_egress  = true
-  allow_ephemeral_ingress = true
+  # Allow VPC resources to send requests out to the internet and recieve a response
+  allow_https_request_out          = true
+  allow_https_request_out_response = true
+
+  # Allow users to send requests in from the internet and receive a response
+  allow_https_request_in          = true
+  allow_https_request_in_response = true  
 
   block_ssh = false
   block_rdp = false

--- a/vpc/examples/high_availability/main.tf
+++ b/vpc/examples/high_availability/main.tf
@@ -5,9 +5,14 @@ module "high_availability_vpc" {
 
   high_availability = true
   enable_flow_log   = true
-  allow_https_out   = true
-  block_ssh         = false
-  block_rdp         = false
+
+  # Allow services to connect out to the internet
+  allow_https_egress      = true
+  allow_ephemeral_egress  = true
+  allow_ephemeral_ingress = true
+
+  block_ssh = false
+  block_rdp = false
 
   billing_tag_key   = "Business Unit"
   billing_tag_value = "Operations"

--- a/vpc/examples/high_availability/main.tf
+++ b/vpc/examples/high_availability/main.tf
@@ -5,6 +5,7 @@ module "high_availability_vpc" {
 
   high_availability = true
   enable_flow_log   = true
+  allow_https_out   = true
   block_ssh         = false
   block_rdp         = false
 

--- a/vpc/examples/single_zone/main.tf
+++ b/vpc/examples/single_zone/main.tf
@@ -6,7 +6,6 @@ module "single_zone_vpc" {
 
   high_availability = false
   enable_flow_log   = false
-  allow_https_out   = false
   block_ssh         = true
   block_rdp         = true
 

--- a/vpc/examples/single_zone/main.tf
+++ b/vpc/examples/single_zone/main.tf
@@ -6,6 +6,7 @@ module "single_zone_vpc" {
 
   high_availability = false
   enable_flow_log   = false
+  allow_https_out   = false
   block_ssh         = true
   block_rdp         = true
 

--- a/vpc/flowlogs.tf
+++ b/vpc/flowlogs.tf
@@ -54,7 +54,6 @@ data "aws_iam_policy_document" "vpc_metrics_flow_logs_write" {
     effect = "Allow"
 
     actions = [
-      "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:PutLogEvents",
       "logs:DescribeLogGroups",

--- a/vpc/inputs.tf
+++ b/vpc/inputs.tf
@@ -1,40 +1,45 @@
 variable "name" {
-  description = "(required) the name of the vpc"
+  description = "(Required) The name of the vpc"
   type        = string
 }
 
 variable "billing_tag_key" {
-  description = "The name of the billing tag"
+  description = "(Optional, default 'CostCentre') The name of the billing tag"
   type        = string
   default     = "CostCentre"
 }
 
 variable "billing_tag_value" {
-  description = "(required) The value of the billing tag"
+  description = "(Required) The value of the billing tag"
   type        = string
 }
 
 variable "high_availability" {
-  description = "Create either one set of subnets or as many as there are VPCs"
+  description = "(Optional, default 'false') Create 3 public and 3 private subnets across 3 availability zones in the region."
   type        = bool
   default     = false
 }
 
 variable "enable_flow_log" {
-  description = "Whether or not to enable VPC Flow Logs"
+  description = "(Optional, default 'false') Whether or not to enable VPC Flow Logs"
   type        = bool
   default     = false
 }
 
 variable "block_ssh" {
-  description = "Whether or not to block Port 22"
+  description = "(Optional, default 'true') Whether or not to block Port 22"
   type        = bool
   default     = true
-
 }
 
 variable "block_rdp" {
-  description = "Whether or not to block Port 3389"
+  description = "(Optional, default 'true') Whether or not to block Port 3389"
+  type        = bool
+  default     = true
+}
+
+variable "allow_https_out" {
+  description = "(Optional, default 'true') Allow HTTPS connections out to the internet"
   type        = bool
   default     = true
 }

--- a/vpc/inputs.tf
+++ b/vpc/inputs.tf
@@ -38,26 +38,26 @@ variable "block_rdp" {
   default     = true
 }
 
-variable "allow_https_egress" {
+variable "allow_https_request_out" {
   description = "(Optional, default 'false') Allow HTTPS connections on port 443 out to the internet"
   type        = bool
   default     = false
 }
 
-variable "allow_https_ingress" {
+variable "allow_https_request_out_response" {
+  description = "(Optional, default 'false') Allow a response back from the internet in reply to a request"
+  type        = bool
+  default     = false
+}
+
+variable "allow_https_request_in" {
   description = "(Optional, default 'false') Allow HTTPS connections on port 443 in from the internet"
   type        = bool
   default     = false
 }
 
-variable "allow_ephemeral_egress" {
-  description = "(Optional, default 'false') Allow connections on ports 1024 to 65535 out to the internet"
-  type        = bool
-  default     = false
-}
-
-variable "allow_ephemeral_ingress" {
-  description = "(Optional, default 'false') Allow connections on ports 1024 to 65535 in from the internet"
+variable "allow_https_request_in_response" {
+  description = "(Optional, default 'false') Allow a response back to the internet in reply to a request"
   type        = bool
   default     = false
 }

--- a/vpc/inputs.tf
+++ b/vpc/inputs.tf
@@ -38,8 +38,26 @@ variable "block_rdp" {
   default     = true
 }
 
-variable "allow_https_out" {
-  description = "(Optional, default 'true') Allow HTTPS connections out to the internet"
+variable "allow_https_egress" {
+  description = "(Optional, default 'false') Allow HTTPS connections on port 443 out to the internet"
   type        = bool
-  default     = true
+  default     = false
+}
+
+variable "allow_https_ingress" {
+  description = "(Optional, default 'false') Allow HTTPS connections on port 443 in from the internet"
+  type        = bool
+  default     = false
+}
+
+variable "allow_ephemeral_egress" {
+  description = "(Optional, default 'false') Allow connections on ports 1024 to 65535 out to the internet"
+  type        = bool
+  default     = false
+}
+
+variable "allow_ephemeral_ingress" {
+  description = "(Optional, default 'false') Allow connections on ports 1024 to 65535 in from the internet"
+  type        = bool
+  default     = false
 }

--- a/vpc/nacl.tf
+++ b/vpc/nacl.tf
@@ -32,19 +32,19 @@ resource "aws_network_acl_rule" "block_rdp" {
 }
 
 resource "aws_network_acl_rule" "https_ingress" {
-  count          = var.allow_https_out ? 1 : 0
+  count          = var.allow_https_ingress ? 1 : 0
   network_acl_id = aws_network_acl.main.id
   rule_number    = 60
   egress         = false
   protocol       = "tcp"
   rule_action    = "allow"
-  cidr_block     = aws_vpc.main.cidr_block
+  cidr_block     = "0.0.0.0/0"
   from_port      = 443
   to_port        = 443
 }
 
 resource "aws_network_acl_rule" "https_egress" {
-  count          = var.allow_https_out ? 1 : 0
+  count          = var.allow_https_egress ? 1 : 0
   network_acl_id = aws_network_acl.main.id
   rule_number    = 61
   egress         = true
@@ -58,7 +58,7 @@ resource "aws_network_acl_rule" "https_egress" {
 # NAT gateway uses ephemeral ports to translate the request and response
 # source/destination IP addresses (Port Address Translation)
 resource "aws_network_acl_rule" "ephemeral_ingress" {
-  count          = var.allow_https_out ? 1 : 0
+  count          = var.allow_ephemeral_ingress ? 1 : 0
   network_acl_id = aws_network_acl.main.id
   rule_number    = 62
   egress         = false
@@ -70,13 +70,13 @@ resource "aws_network_acl_rule" "ephemeral_ingress" {
 }
 
 resource "aws_network_acl_rule" "ephemeral_egress" {
-  count          = var.allow_https_out ? 1 : 0
+  count          = var.allow_ephemeral_egress ? 1 : 0
   network_acl_id = aws_network_acl.main.id
   rule_number    = 63
   egress         = true
   protocol       = "tcp"
   rule_action    = "allow"
-  cidr_block     = aws_vpc.main.cidr_block
+  cidr_block     = "0.0.0.0/0"
   from_port      = 1024
   to_port        = 65535
 }

--- a/vpc/nacl.tf
+++ b/vpc/nacl.tf
@@ -30,3 +30,53 @@ resource "aws_network_acl_rule" "block_rdp" {
   from_port      = 3389
   to_port        = 3389
 }
+
+resource "aws_network_acl_rule" "https_ingress" {
+  count          = var.allow_https_out ? 1 : 0
+  network_acl_id = aws_network_acl.main.id
+  rule_number    = 60
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = aws_vpc.main.cidr_block
+  from_port      = 443
+  to_port        = 443
+}
+
+resource "aws_network_acl_rule" "https_egress" {
+  count          = var.allow_https_out ? 1 : 0
+  network_acl_id = aws_network_acl.main.id
+  rule_number    = 61
+  egress         = true
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 443
+  to_port        = 443
+}
+
+# NAT gateway uses ephemeral ports to translate the request and response
+# source/destination IP addresses (Port Address Translation)
+resource "aws_network_acl_rule" "ephemeral_ingress" {
+  count          = var.allow_https_out ? 1 : 0
+  network_acl_id = aws_network_acl.main.id
+  rule_number    = 62
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 1024
+  to_port        = 65535
+}
+
+resource "aws_network_acl_rule" "ephemeral_egress" {
+  count          = var.allow_https_out ? 1 : 0
+  network_acl_id = aws_network_acl.main.id
+  rule_number    = 63
+  egress         = true
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = aws_vpc.main.cidr_block
+  from_port      = 1024
+  to_port        = 65535
+}

--- a/vpc/nacl.tf
+++ b/vpc/nacl.tf
@@ -31,22 +31,11 @@ resource "aws_network_acl_rule" "block_rdp" {
   to_port        = 3389
 }
 
-resource "aws_network_acl_rule" "https_ingress" {
-  count          = var.allow_https_ingress ? 1 : 0
+# Allow an HTTPS request out of the VPC
+resource "aws_network_acl_rule" "https_request_egress_443" {
+  count          = var.allow_https_request_out ? 1 : 0
   network_acl_id = aws_network_acl.main.id
   rule_number    = 60
-  egress         = false
-  protocol       = "tcp"
-  rule_action    = "allow"
-  cidr_block     = "0.0.0.0/0"
-  from_port      = 443
-  to_port        = 443
-}
-
-resource "aws_network_acl_rule" "https_egress" {
-  count          = var.allow_https_egress ? 1 : 0
-  network_acl_id = aws_network_acl.main.id
-  rule_number    = 61
   egress         = true
   protocol       = "tcp"
   rule_action    = "allow"
@@ -55,12 +44,35 @@ resource "aws_network_acl_rule" "https_egress" {
   to_port        = 443
 }
 
-# NAT gateway uses ephemeral ports to translate the request and response
-# source/destination IP addresses (Port Address Translation)
-resource "aws_network_acl_rule" "ephemeral_ingress" {
-  count          = var.allow_ephemeral_ingress ? 1 : 0
+resource "aws_network_acl_rule" "https_request_out_egress_ephemeral" {
+  count          = var.allow_https_request_out ? 1 : 0
+  network_acl_id = aws_network_acl.main.id
+  rule_number    = 61
+  egress         = true
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = aws_vpc.main.cidr_block
+  from_port      = 1024
+  to_port        = 65535
+}
+
+# Allow an HTTPS response to a request that leaves the VPC
+resource "aws_network_acl_rule" "https_request_out_response_ingress_443" {
+  count          = var.allow_https_request_out_response ? 1 : 0
   network_acl_id = aws_network_acl.main.id
   rule_number    = 62
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = aws_vpc.main.cidr_block
+  from_port      = 443
+  to_port        = 443
+}
+
+resource "aws_network_acl_rule" "https_request_out_response_ingress_ephemeral" {
+  count          = var.allow_https_request_out_response ? 1 : 0
+  network_acl_id = aws_network_acl.main.id
+  rule_number    = 63
   egress         = false
   protocol       = "tcp"
   rule_action    = "allow"
@@ -69,10 +81,48 @@ resource "aws_network_acl_rule" "ephemeral_ingress" {
   to_port        = 65535
 }
 
-resource "aws_network_acl_rule" "ephemeral_egress" {
-  count          = var.allow_ephemeral_egress ? 1 : 0
+# Allow an HTTPS request into the VPC
+resource "aws_network_acl_rule" "https_request_in_ingress_443" {
+  count          = var.allow_https_request_in ? 1 : 0
   network_acl_id = aws_network_acl.main.id
-  rule_number    = 63
+  rule_number    = 70
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 443
+  to_port        = 443
+}
+
+resource "aws_network_acl_rule" "https_request_in_ingress_ephemeral" {
+  count          = var.allow_https_request_in ? 1 : 0
+  network_acl_id = aws_network_acl.main.id
+  rule_number    = 71
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = aws_vpc.main.cidr_block
+  from_port      = 1024
+  to_port        = 65535
+}
+
+# Allow an HTTPS response to a request into the VPC
+resource "aws_network_acl_rule" "https_request_in_response_egress_443" {
+  count          = var.allow_https_request_in_response ? 1 : 0
+  network_acl_id = aws_network_acl.main.id
+  rule_number    = 72
+  egress         = true
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = aws_vpc.main.cidr_block
+  from_port      = 443
+  to_port        = 443
+}
+
+resource "aws_network_acl_rule" "https_request_in_response_egress_ephemeral" {
+  count          = var.allow_https_request_in_response ? 1 : 0
+  network_acl_id = aws_network_acl.main.id
+  rule_number    = 73
   egress         = true
   protocol       = "tcp"
   rule_action    = "allow"

--- a/vpc/test/high_availability_test.go
+++ b/vpc/test/high_availability_test.go
@@ -50,8 +50,37 @@ func TestHighAvailabilityVpc(t *testing.T) {
 	nats := GetVpcNatGateways(t, client, vpcId)
 	assert.Equal(t, 3, len(nats.NatGateways))
 
-	nacls := GetVpcDenyNetworkAcls(t, client, vpcId)
-	assert.Equal(t, 0, len(nacls.NetworkAcls))
+	// Expect NACL rules to not exist for blocking SSH, RDP
+	naclRulesDeny := []naclRule{
+		{
+			from:   "22",
+			to:     "22",
+			action: "deny",
+		},
+		{
+			from:   "3389",
+			to:     "3389",
+			action: "deny",
+		},
+	}
+	naclsDeny := GetVpcNetworkAcls(t, client, vpcId, &naclRulesDeny)
+	assert.Equal(t, 0, len(naclsDeny.NetworkAcls))
+
+	// Expect NACL rules to exist for allowing HTTPS traffic
+	naclRulesAllow := []naclRule{
+		{
+			from:   "443",
+			to:     "443",
+			action: "allow",
+		},
+		{
+			from:   "1024",
+			to:     "65535",
+			action: "allow",
+		},
+	}
+	naclsAllow := GetVpcNetworkAcls(t, client, vpcId, &naclRulesAllow)
+	assert.Equal(t, 1, len(naclsAllow.NetworkAcls))
 
 	flowLogs := GetVpcFlowLogs(t, client, "high_availability_flow_logs")
 	assert.Equal(t, 1, len(flowLogs.FlowLogs))


### PR DESCRIPTION
# Summary
This adds four new variables that control Network ACL rules to allow requests into and out of the VPC:

* `allow_https_request_out`: allow resources to send 443 requests out to the internet. 
* `allow_https_request_out_response`: allow resources to receive a response to their request out.
* `allow_https_request_in`: allow users to send 443 requests into the VPC from the internet.
* `allow_https_request_in_response`: allow a response to be sent back to the user from the VPC.

The allow for ephemeral ports is because NAT Gateways use them to track the network address translation.

It also includes a fix which prevents the flow log CloudWatch log group from being recreated after it has been deleted.