### PR TITLE
fix: RDS database_name input validation

### DIFF
--- a/rds/examples/mysql_cluster/main.tf
+++ b/rds/examples/mysql_cluster/main.tf
@@ -3,7 +3,7 @@ module "mysql_cluster" {
   source = "../../"
   name   = "mysql"
 
-  database_name  = "terratest"
+  database_name  = "terratest_mysql"
   engine         = "aurora-mysql"
   engine_version = "5.7.mysql_aurora.2.10.0"
   instances      = 2

--- a/rds/examples/postgresql_cluster/main.tf
+++ b/rds/examples/postgresql_cluster/main.tf
@@ -3,7 +3,7 @@ module "postgresql_cluster" {
   source = "../../"
   name   = "postgresql"
 
-  database_name  = "terratest"
+  database_name  = "terratest_postgresql"
   engine         = "aurora-postgresql"
   engine_version = "11.9"
   instances      = 2

--- a/rds/input.tf
+++ b/rds/input.tf
@@ -20,8 +20,8 @@ variable "database_name" {
   description = "(Required) The name of the database to be created inside the cluster."
 
   validation {
-    condition     = can(regex("^[[:alpha:]][[:alnum:]]+$", var.database_name))
-    error_message = "Database name must begin with a letter and contain only alphanumeric characters."
+    condition     = can(regex("^[A-Za-z][0-9A-Za-z_-]*$", var.database_name))
+    error_message = "Database name must begin with a letter and contain only alphanumeric, hyphen and underscore characters."
   }
 }
 

--- a/rds/test/mysql_test.go
+++ b/rds/test/mysql_test.go
@@ -64,7 +64,7 @@ func TestMysqlCluster(t *testing.T) {
 	assert.Equal(t, 2, len(cluster.DBClusterMembers))
 	assert.Equal(t, 3, len(cluster.AvailabilityZones))
 	assert.Equal(t, int64(1), *cluster.BackupRetentionPeriod)
-	assert.Equal(t, "terratest", *cluster.DatabaseName)
+	assert.Equal(t, "terratest_mysql", *cluster.DatabaseName)
 	assert.Equal(t, "thebigcheese", *cluster.MasterUsername)
 	assert.Equal(t, "aurora-mysql", *cluster.Engine)
 	assert.Equal(t, "default.aurora-mysql5.7", *cluster.DBClusterParameterGroup)

--- a/rds/test/postgresql_test.go
+++ b/rds/test/postgresql_test.go
@@ -64,7 +64,7 @@ func TestPostgresqlCluster(t *testing.T) {
 	assert.Equal(t, 2, len(cluster.DBClusterMembers))
 	assert.Equal(t, 3, len(cluster.AvailabilityZones))
 	assert.Equal(t, int64(1), *cluster.BackupRetentionPeriod)
-	assert.Equal(t, "terratest", *cluster.DatabaseName)
+	assert.Equal(t, "terratest_postgresql", *cluster.DatabaseName)
 	assert.Equal(t, "thebigcheese", *cluster.MasterUsername)
 	assert.Equal(t, "aurora-postgresql", *cluster.Engine)
 	assert.Equal(t, "default.aurora-postgresql11", *cluster.DBClusterParameterGroup)


### PR DESCRIPTION
# Summary
Allow hyphens and underscores in the RDS `database_name` input.