### PR TITLE
fix: remove KMS master key ID from example

### DIFF
--- a/notify_slack/examples/full/main.tf
+++ b/notify_slack/examples/full/main.tf
@@ -18,8 +18,8 @@ module "notify_slack" {
 # SNS: topic & subscription
 #
 resource "aws_sns_topic" "warning" {
-  name              = "warning"
-  kms_master_key_id = "alias/aws/sns"
+  # checkov:skip=CKV_AWS_26: encryption not required for example
+  name = "warning"
 }
 
 resource "aws_sns_topic_subscription" "alert_warning" {


### PR DESCRIPTION
# Summary
The default `alias/aws/sns` KMS key managed by the SNS service
cannot be used by CloudWatch because its key policy does not
allow it.  Since it's an AWS managed key, the policy cannot be 
updated either.

In a production scenario, a Customer Managed Key (CMK) should
be used for encryption.