### PR TITLE
feat: S3 add public access block ID output

### DIFF
--- a/S3/README.md
+++ b/S3/README.md
@@ -52,5 +52,6 @@ No modules.
 | <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | The ARN of the bucket. Will be of format arn:aws:s3:::bucketname. |
 | <a name="output_s3_bucket_domain_name"></a> [s3\_bucket\_domain\_name](#output\_s3\_bucket\_domain\_name) | The bucket domain name. Will be of format bucketname.s3.amazonaws.com. |
 | <a name="output_s3_bucket_id"></a> [s3\_bucket\_id](#output\_s3\_bucket\_id) | The name of the bucket. |
+| <a name="output_s3_bucket_public_access_block_id"></a> [s3\_bucket\_public\_access\_block\_id](#output\_s3\_bucket\_public\_access\_block\_id) | n/a |
 | <a name="output_s3_bucket_region"></a> [s3\_bucket\_region](#output\_s3\_bucket\_region) | The AWS region this bucket resides in. |
 | <a name="output_s3_bucket_regional_domain_name"></a> [s3\_bucket\_regional\_domain\_name](#output\_s3\_bucket\_regional\_domain\_name) | The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL. |

--- a/S3/examples/basic_bucket/main.tf
+++ b/S3/examples/basic_bucket/main.tf
@@ -28,3 +28,7 @@ output "regional_domain" {
 output "region" {
   value = module.bucket.s3_bucket_region
 }
+
+output "public_access_block_id" {
+  value = module.bucket.s3_bucket_public_access_block_id
+}

--- a/S3/outputs.tf
+++ b/S3/outputs.tf
@@ -18,8 +18,11 @@ output "s3_bucket_regional_domain_name" {
   value       = aws_s3_bucket.this.bucket_regional_domain_name
 }
 
-
 output "s3_bucket_region" {
   description = "The AWS region this bucket resides in."
   value       = aws_s3_bucket.this.region
+}
+
+output "s3_bucket_public_access_block_id" {
+  value = aws_s3_bucket_public_access_block.this.id
 }

--- a/S3/test/basic_bucket_test.go
+++ b/S3/test/basic_bucket_test.go
@@ -37,6 +37,7 @@ func TestBasicBucketCreation(t *testing.T) {
 	bucket_arn := terraform.Output(t, terraformOptions, "arn")
 	bucket_id := terraform.Output(t, terraformOptions, "id")
 	bucket_region := terraform.Output(t, terraformOptions, "region")
+	public_access_block_id := terraform.Output(t, terraformOptions, "public_access_block_id")
 
 	assert.Equal(t, bucket_region, region)
 
@@ -45,6 +46,8 @@ func TestBasicBucketCreation(t *testing.T) {
 
 	assert.Equal(t, bucket_id, name)
 	assert.Equal(t, bucket_region, region)
+
+	assert.Equal(t, name, public_access_block_id)
 
 	// Test the public access block
 	s3Client := aws.NewS3Client(t, region)


### PR DESCRIPTION
# Summary 
This output allows other resources to depend on the public
access block being created which is required when creating
bucket resource access policies.

# Related
* #76 