### PR TITLE
fix: remove arn from sns topic arn in stmt id

### DIFF
--- a/lambda/permissions.tf
+++ b/lambda/permissions.tf
@@ -32,7 +32,7 @@ resource "aws_s3_bucket_notification" "this" {
 resource "aws_lambda_permission" "sns" {
   count = length(var.sns_topic_arns)
 
-  statement_id  = "AllowExecutionFromSNS-${var.sns_topic_arns[count.index]}"
+  statement_id  = "AllowExecutionFromSNS${count.index}"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.this.function_name
   principal     = "sns.amazonaws.com"


### PR DESCRIPTION
# Summary | Résumé

The current statement ID is not valid when using an arn so just replace
with the index of the arn in the list of topics to trigger
