### PR TITLE
feat: add rds service linked name

### DIFF
--- a/rds/README.md
+++ b/rds/README.md
@@ -27,6 +27,7 @@ No modules.
 | [aws_iam_policy.read_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.rds_proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.read_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_service_linked_role.rds_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) | resource |
 | [aws_rds_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
 | [aws_rds_cluster_instance.instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) | resource |
 | [aws_secretsmanager_secret.connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -12,6 +12,11 @@ resource "random_string" "random" {
 # RDS
 ###
 
+# Service role allowing AWS to manage resources required for RDS
+resource "aws_iam_service_linked_role" "rds_service" {
+  aws_service_name = "rds.amazonaws.com"
+}
+
 resource "aws_rds_cluster_instance" "instances" {
   count                = var.instances
   identifier           = "${var.name}-instance-${count.index}"


### PR DESCRIPTION
Latest version of the RDS module errors with the below. I suspect this is because the service linked name doesn't exist.

Closes #87 

![image](https://user-images.githubusercontent.com/85885638/141834921-d196f307-70f0-448f-b878-995346f8354e.png)
