### PR TITLE
Revert "feat: add rds service linked name"

### DIFF
--- a/rds/README.md
+++ b/rds/README.md
@@ -27,7 +27,6 @@ No modules.
 | [aws_iam_policy.read_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.rds_proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.read_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_service_linked_role.rds_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) | resource |
 | [aws_rds_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
 | [aws_rds_cluster_instance.instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) | resource |
 | [aws_secretsmanager_secret.connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -12,11 +12,6 @@ resource "random_string" "random" {
 # RDS
 ###
 
-# Service role allowing AWS to manage resources required for RDS
-resource "aws_iam_service_linked_role" "rds_service" {
-  aws_service_name = "rds.amazonaws.com"
-}
-
 resource "aws_rds_cluster_instance" "instances" {
   count                = var.instances
   identifier           = "${var.name}-instance-${count.index}"


### PR DESCRIPTION
Reverts cds-snc/terraform-modules#86

Service role was auto created by AWS. Looks like I ran into a race condition between proxy creation and the service role being available. Re-running the TF apply did the trick