### PR TITLE
feat: merge default tags and fix devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@ ARG TERRAFORM_DOCS_VERSION_CHECKSUM
 
 # Install packages
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends awscli ca-certificates curl git gnupg2 jq make openssh-client python3-pip vim xz-utils zsh \
+    && apt-get -y install --no-install-recommends awscli build-essential ca-certificates curl git gnupg2 jq libssl-dev libffi-dev make openssh-client python3-dev python3-pip vim xz-utils zsh \
     && apt-get autoremove -y && apt-get clean -y 
 
 # Install Terraform

--- a/vpc/README.md
+++ b/vpc/README.md
@@ -70,6 +70,7 @@ No modules.
 | [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_default_tags.common_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
 | [aws_iam_policy_document.vpc_flow_logs_service_principal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vpc_metrics_flow_logs_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -30,9 +30,11 @@ resource "aws_vpc" "main" {
 
   tags = merge(local.common_tags, {
     Name = "${var.name}_vpc"
-  })
+  }, { for k, v in local.common_tags : k => v if lookup(data.aws_default_tags.common_tags.tags, k, "") != v })
 
 }
+
+data "aws_default_tags" "common_tags" {}
 
 resource "aws_eip" "nat" {
   count = var.enable_eip ? local.max_subnet_length : 0


### PR DESCRIPTION
using default tags + modules makes the plan always show +tag. This will test merging the tags so that existing tags don't get flagged in the diff.

Also added python compile libraries since the devcontainer was failing to build since it couldn't compile some dependencies.