### PR TITLE
feat: output lambda invoke arn for api gateway integrations

### DIFF
--- a/lambda/README.md
+++ b/lambda/README.md
@@ -68,3 +68,4 @@ No modules.
 |------|-------------|
 | <a name="output_function_arn"></a> [function\_arn](#output\_function\_arn) | n/a |
 | <a name="output_function_name"></a> [function\_name](#output\_function\_name) | n/a |
+| <a name="output_invoke_arn"></a> [invoke\_arn](#output\_invoke\_arn) | n/a |

--- a/lambda/output.tf
+++ b/lambda/output.tf
@@ -5,3 +5,7 @@ output "function_arn" {
 output "function_name" {
   value = aws_lambda_function.this.function_name
 }
+
+output "invoke_arn" {
+  value = aws_lambda_function.this.invoke_arn
+}

--- a/vpc/README.md
+++ b/vpc/README.md
@@ -70,7 +70,6 @@ No modules.
 | [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
-| [aws_default_tags.common_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
 | [aws_iam_policy_document.vpc_flow_logs_service_principal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vpc_metrics_flow_logs_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -30,11 +30,9 @@ resource "aws_vpc" "main" {
 
   tags = merge(local.common_tags, {
     Name = "${var.name}_vpc"
-  }, { for k, v in local.common_tags : k => v if lookup(data.aws_default_tags.common_tags.tags, k, "") != v })
+  })
 
 }
-
-data "aws_default_tags" "common_tags" {}
 
 resource "aws_eip" "nat" {
   count = var.enable_eip ? local.max_subnet_length : 0


### PR DESCRIPTION
- Need to output invoke_arn so the lambda can be integrated with a api gateway
- Revert default tag merging since there are alot of resources that dont support tags which will cause plans to contain too many unchanged items since the tags will flap