### PR TITLE
feat: RDS instance control performance insights

### DIFF
--- a/rds/README.md
+++ b/rds/README.md
@@ -25,7 +25,9 @@ No modules.
 | [aws_db_proxy_target.target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_proxy_target) | resource |
 | [aws_db_subnet_group.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
 | [aws_iam_policy.read_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.rds_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.rds_proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.rds_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.read_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_rds_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
 | [aws_rds_cluster_instance.instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) | resource |
@@ -36,6 +38,7 @@ No modules.
 | [aws_security_group.rds_proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [random_string.random](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.rds_monitoring_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.read_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
@@ -53,6 +56,7 @@ No modules.
 | <a name="input_instances"></a> [instances](#input\_instances) | (Optional, default '3') The number of RDS Cluster instances to create, defaults to HA mode. | `number` | `3` | no |
 | <a name="input_name"></a> [name](#input\_name) | (Required) The name of the db also used for other identifiers | `string` | n/a | yes |
 | <a name="input_password"></a> [password](#input\_password) | (Required) The password for the admin user for the db | `string` | n/a | yes |
+| <a name="input_performance_insights_enabled"></a> [performance\_insights\_enabled](#input\_performance\_insights\_enabled) | (Optional, default 'true') This flag enables performance insights for the RDS cluster instances. | `bool` | `true` | no |
 | <a name="input_preferred_backup_window"></a> [preferred\_backup\_window](#input\_preferred\_backup\_window) | (Required) The time you want your DB to be backedup. Takes the format `"07:00-09:00"` | `string` | n/a | yes |
 | <a name="input_prevent_cluster_deletion"></a> [prevent\_cluster\_deletion](#input\_prevent\_cluster\_deletion) | (Optional, default 'true') This flag prevents deletion of the RDS cluster. <br/> **Please Note:** We cannot prevent deletion of RDS instances in the module, we recommend you add `lifecycle { prevent_deletion = true }` to the module to prevent instance deletion | `bool` | `true` | no |
 | <a name="input_proxy_debug_logging"></a> [proxy\_debug\_logging](#input\_proxy\_debug\_logging) | (Optional, default 'false') Allows the proxy to log debug information. <br/> **Please Note:** This will include all sql commands and potential sensitive information | `bool` | `false` | no |

--- a/rds/README.md
+++ b/rds/README.md
@@ -25,9 +25,7 @@ No modules.
 | [aws_db_proxy_target.target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_proxy_target) | resource |
 | [aws_db_subnet_group.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
 | [aws_iam_policy.read_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_role.rds_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.rds_proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.rds_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.read_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_rds_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
 | [aws_rds_cluster_instance.instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) | resource |
@@ -38,7 +36,6 @@ No modules.
 | [aws_security_group.rds_proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [random_string.random](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.rds_monitoring_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.read_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs

--- a/rds/examples/mysql_cluster/main.tf
+++ b/rds/examples/mysql_cluster/main.tf
@@ -7,7 +7,7 @@ module "mysql_cluster" {
   engine         = "aurora-mysql"
   engine_version = "5.7.mysql_aurora.2.10.0"
   instances      = 2
-  instance_class = "db.r4.large"
+  instance_class = "db.t3.small"
   username       = "thebigcheese"
   password       = "pasword123"
 
@@ -15,6 +15,9 @@ module "mysql_cluster" {
   # Terratests so they can properly destroy resources once finished.
   prevent_cluster_deletion = false
   skip_final_snapshot      = true
+
+  # Required to use `db.t3.small` instances for MySQL
+  performance_insights_enabled = false
 
   backup_retention_period = 1
   preferred_backup_window = "01:00-03:00"

--- a/rds/input.tf
+++ b/rds/input.tf
@@ -46,6 +46,12 @@ variable "allow_major_version_upgrade" {
   default     = false
 }
 
+variable "performance_insights_enabled" {
+  type        = bool
+  description = "(Optional, default 'true') This flag enables performance insights for the RDS cluster instances."
+  default     = true
+}
+
 variable "prevent_cluster_deletion" {
   type        = bool
   description = "(Optional, default 'true') This flag prevents deletion of the RDS cluster. <br/> **Please Note:** We cannot prevent deletion of RDS instances in the module, we recommend you add `lifecycle { prevent_deletion = true }` to the module to prevent instance deletion"

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -21,7 +21,7 @@ resource "aws_rds_cluster_instance" "instances" {
   engine_version       = var.engine_version
   db_subnet_group_name = aws_db_subnet_group.rds.name
 
-  performance_insights_enabled = true
+  performance_insights_enabled = var.performance_insights_enabled
 
   tags = merge(local.common_tags, {
     Name = "${var.name}-instance-${count.index}"


### PR DESCRIPTION
# Summary
By allowing control over the RDS cluster instance performance insights
configuration, people will be able to use smaller MySQL DB instances.