### PR TITLE
feat: Github Open ID Connect Role in AWS

### DIFF
--- a/.github/workflows/conftest/test_plan.tf
+++ b/.github/workflows/conftest/test_plan.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0.0"
+  required_version = "~> 1.1.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/.github/workflows/conftest/test_plan.tf
+++ b/.github/workflows/conftest/test_plan.tf
@@ -66,7 +66,7 @@ module "lambda" {
   image_uri         = "${aws_ecr_repository.test.repository_url}:latest"
   ecr_arn           = aws_ecr_repository.test.arn
   billing_tag_value = "cal"
-  policies =  [data.aws_iam_policy_document.test.json]
+  policies          = [data.aws_iam_policy_document.test.json]
 
 }
 
@@ -76,10 +76,10 @@ resource "aws_security_group" "this" {
   vpc_id      = module.vpc.vpc_id
 
   tags = {
-    Terraform = "true"
+    Terraform  = "true"
     CostCentre = "cal"
   }
-  
+
 }
 
 module "lambda_vpc" {
@@ -89,8 +89,15 @@ module "lambda_vpc" {
   ecr_arn           = aws_ecr_repository.test.arn
   billing_tag_value = "cal"
   vpc = {
-    subnet_ids = module.vpc.public_subnet_ids
+    subnet_ids         = module.vpc.public_subnet_ids
     security_group_ids = [aws_security_group.this.id]
   }
 
+}
+
+module "oicd_role" {
+  source            = "../../../gh_oicd_role"
+  role_name         = "test"
+  repo              = "foo"
+  billing_tag_value = "cal"
 }

--- a/.modules
+++ b/.modules
@@ -1,1 +1,1 @@
-rds S3 S3_log_bucket user_login_alarm vpc lambda
+rds S3 S3_log_bucket user_login_alarm vpc lambda gh_oicd_role

--- a/gh_oicd_role/Makefile
+++ b/gh_oicd_role/Makefile
@@ -1,0 +1,7 @@
+.PHONY: fmt docs
+
+fmt:
+	@terraform fmt -recursive
+
+docs:
+	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/gh_oicd_role/README.md
+++ b/gh_oicd_role/README.md
@@ -20,7 +20,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_iam_openid_connect_provider.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
+| [aws_iam_openid_connect_provider.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.asume_role_saml](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -32,11 +32,14 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
+| <a name="input_claim"></a> [claim](#input\_claim) | (Optional) The claim that the token is allowed to be authorized from.<br>    This allows you to restrict to specific branches in your repo. <br><br>    Defaults to `*` which allows you to use this token anywhere in your repo. <br><br>    If you wanted to restrict to the main branch you could use a value like `ref:refs/heads/main` | `string` | `"*"` | no |
 | <a name="input_org_name"></a> [org\_name](#input\_org\_name) | (Optional)  The name of the org the workflow will be called from.<br>    In the format of http://github.com/`org_name` | `string` | `"cds-snc"` | no |
-| <a name="input_repo"></a> [repo](#input\_repo) | (Required) The name of the repo that will be the workflow will be called from.<br>    In the format of http://github.com/cds-snc/`repo` | `string` | n/a | yes |
+| <a name="input_repo"></a> [repo](#input\_repo) | (Required) The name of the repo that will be the workflow will be called from.<br>    In the format of http://github.com/cds-snc/`repo`<br><br>    If you use `*` this will allow this role to be used in any repo in the org identified in `org_name` | `string` | n/a | yes |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | (Required) The name of the role to create | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_arn"></a> [arn](#output\_arn) | This is the arn of the IAM Role that will be authenticated using OICD.<br>This is needed for assigning roles to that authenticated IAM Role |
+| <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | This is the arn of the IAM Role that will be authenticated using OICD.<br>This is needed for assigning roles to that authenticated IAM Role |
+| <a name="output_role_name"></a> [role\_name](#output\_role\_name) | (Optional) The name of the role that will be impersonated using OICD |

--- a/gh_oicd_role/README.md
+++ b/gh_oicd_role/README.md
@@ -1,0 +1,36 @@
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_openid_connect_provider.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [tls_certificate.thumprint](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
+| <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
+| <a name="input_org_name"></a> [org\_name](#input\_org\_name) | (Optional)  The name of the org the workflow will be called from.<br>    In the format of http://github.com/`org_name` | `string` | `"cds-snc"` | no |
+| <a name="input_repo"></a> [repo](#input\_repo) | (Required) The name of the repo that will be the workflow will be called from.<br>    In the format of http://github.com/cds-snc/`repo` | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.

--- a/gh_oicd_role/input.tf
+++ b/gh_oicd_role/input.tf
@@ -14,6 +14,8 @@ variable "repo" {
   description = <<EOF
     (Required) The name of the repo that will be the workflow will be called from.
     In the format of http://github.com/cds-snc/`repo`
+
+    If you use `*` this will allow this role to be used in any repo in the org identified in `org_name`
   EOF
   type        = string
 }
@@ -25,4 +27,22 @@ variable "org_name" {
   EOF
   type        = string
   default     = "cds-snc"
+}
+
+variable "claim" {
+  description = <<EOF
+    (Optional) The claim that the token is allowed to be authorized from.
+    This allows you to restrict to specific branches in your repo. 
+
+    Defaults to `*` which allows you to use this token anywhere in your repo. 
+
+    If you wanted to restrict to the main branch you could use a value like `ref:refs/heads/main`
+  EOF
+  type        = string
+  default     = "*"
+}
+
+variable "role_name" {
+  description = "(Required) The name of the role to create"
+  type        = string
 }

--- a/gh_oicd_role/input.tf
+++ b/gh_oicd_role/input.tf
@@ -1,0 +1,28 @@
+
+variable "billing_tag_key" {
+  description = "(Optional, default 'CostCentre') The name of the billing tag"
+  type        = string
+  default     = "CostCentre"
+}
+
+variable "billing_tag_value" {
+  description = "(Required) The value of the billing tag"
+  type        = string
+}
+
+variable "repo" {
+  description = <<EOF
+    (Required) The name of the repo that will be the workflow will be called from.
+    In the format of http://github.com/cds-snc/`repo`
+  EOF
+  type        = string
+}
+
+variable "org_name" {
+  description = <<EOF
+    (Optional)  The name of the org the workflow will be called from.
+    In the format of http://github.com/`org_name`
+  EOF
+  type        = string
+  default     = "cds-snc"
+}

--- a/gh_oicd_role/locals.tf
+++ b/gh_oicd_role/locals.tf
@@ -7,6 +7,5 @@ locals {
   gh_url  = "https://${local.gh_path}"
   gh_path = "token.actions.githubusercontent.com"
 
-  audiences = ["https://github.com/cds-snc/${var.repo_name}"]
 }
 

--- a/gh_oicd_role/locals.tf
+++ b/gh_oicd_role/locals.tf
@@ -1,0 +1,12 @@
+
+locals {
+  common_tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = "true"
+  }
+  gh_url  = "https://${local.gh_path}"
+  gh_path = "token.actions.githubusercontent.com"
+
+  audiences = ["https://github.com/cds-snc/${var.repo_name}"]
+}
+

--- a/gh_oicd_role/main.tf
+++ b/gh_oicd_role/main.tf
@@ -1,0 +1,38 @@
+/* # gh_oicd_role
+* Creates an OpenID Connect Role that can be used for authenticating workflows in Github Actions
+* This allows for a more secure way to connect to AWS as it doesn't rely on static credentials but uses temporary credentials created for each run.
+*/
+
+
+data "aws_caller_identity" "current" {}
+
+data "tls_certificate" "thumprint" {
+  url = local.gh_url
+}
+
+resource "aws_iam_role" "this" {
+  name               = "gh-oicd-aws"
+  assume_role_policy = data.aws_iam_policy_document.asume_role_saml.json
+}
+
+data "aws_iam_policy_document" "asume_role_saml" {
+  statement {
+    principal {
+      type        = "Federated"
+      identifiers = ["arn:aws_iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.gh_path}"]
+    }
+  }
+  actions = ["sts:AssumeRoleWithWebIdentity"]
+  condition {
+    test     = "ForAnyValue:StringLike"
+    variable = "vstoken.actions.githubusercontent.com:sub"
+    values   = "repo:<owner>/<repo>:*"
+  }
+
+}
+
+resource "aws_iam_openid_connect_provider" "default" {
+  url             = local.gh_url
+  client_id_list  = local.audiences
+  thumbprint_list = [data.tls_certificate.thumprint.certificates.0.sha1_fingerprint]
+}

--- a/gh_oicd_role/output.tf
+++ b/gh_oicd_role/output.tf
@@ -1,0 +1,7 @@
+output "arn" {
+  description = <<-EOF
+  This is the arn of the IAM Role that will be authenticated using OICD.
+  This is needed for assigning roles to that authenticated IAM Role
+  EOF
+  value       = aws_iam_role.this.arn
+}

--- a/gh_oicd_role/output.tf
+++ b/gh_oicd_role/output.tf
@@ -1,7 +1,12 @@
-output "arn" {
+output "role_arn" {
   description = <<-EOF
   This is the arn of the IAM Role that will be authenticated using OICD.
   This is needed for assigning roles to that authenticated IAM Role
   EOF
   value       = aws_iam_role.this.arn
+}
+
+output "role_name" {
+  description = "(Optional) The name of the role that will be impersonated using OICD"
+  value       = aws_iam_role.this.name
 }


### PR DESCRIPTION
# Summary | Résumé

Allows authentication in github workflows using Open ID Connect, this
allows us to authenticate with an AWS Account using Open ID Connect.

This allows for more secure authentication as keys are rotated every
time an authentication occurs.

I was able to authenticate using this module to my scratch account:
![image](https://user-images.githubusercontent.com/87738/148613120-7e52b6ff-f786-4b18-b307-ffdfac5397f9.png)


Closes https://github.com/cds-snc/site-reliability-engineering/issues/359
