### PR TITLE
feat: s3 replication config

### DIFF
--- a/S3/README.md
+++ b/S3/README.md
@@ -41,6 +41,7 @@ No modules.
 | <a name="input_lifecycle_rule"></a> [lifecycle\_rule](#input\_lifecycle\_rule) | (Optional) List of maps containing configuration of object lifecycle management. | `any` | `[]` | no |
 | <a name="input_logging"></a> [logging](#input\_logging) | (Optional) Map containing access bucket logging configuration. </br> **target\_bucket**: name of the bucket to log to. </br> **target\_prefix**: prefix to use when logging | `map(string)` | `{}` | no |
 | <a name="input_object_lock_configuration"></a> [object\_lock\_configuration](#input\_object\_lock\_configuration) | (Optional, Forces new resource) Map containing S3 object locking configuration. | `any` | `{}` | no |
+| <a name="input_replication_configuration"></a> [replication\_configuration](#input\_replication\_configuration) | (Optional) Map containing cross-region replication configuration. | `any` | `{}` | no |
 | <a name="input_restrict_public_buckets"></a> [restrict\_public\_buckets](#input\_restrict\_public\_buckets) | (Optional, default 'true') Only the bucket owner and AWS Services can access this buckets if it has a public policy. | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
 | <a name="input_versioning"></a> [versioning](#input\_versioning) | (Optional) Map containing versioning configuration. | `map(string)` | `{}` | no |

--- a/S3/examples/basic_bucket/main.tf
+++ b/S3/examples/basic_bucket/main.tf
@@ -3,6 +3,10 @@ module "bucket" {
   source            = "../../"
   billing_tag_value = "terratest"
   bucket_name       = var.name
+
+  versioning = {
+    enabled = true
+  }
 }
 
 variable "name" {

--- a/S3/examples/basic_bucket/main.tf
+++ b/S3/examples/basic_bucket/main.tf
@@ -2,15 +2,15 @@
 module "bucket" {
   source            = "../../"
   billing_tag_value = "terratest"
-  bucket_name       = var.name
+  bucket_name       = "cds-terraform-modules-basic-bucket-${random_pet.this.id}"
 
   versioning = {
     enabled = true
   }
 }
 
-variable "name" {
-  type = string
+resource "random_pet" "this" {
+  length = 2
 }
 
 output "id" {

--- a/S3/examples/public_bucket/main.tf
+++ b/S3/examples/public_bucket/main.tf
@@ -2,7 +2,7 @@
 module "bucket" {
   source            = "../../"
   billing_tag_value = "terratest"
-  bucket_name       = var.name
+  bucket_name       = "cds-terraform-modules-public-bucket-${random_pet.this.id}"
 
   block_public_policy     = false
   restrict_public_buckets = false
@@ -12,8 +12,8 @@ module "bucket" {
   }
 }
 
-variable "name" {
-  type = string
+resource "random_pet" "this" {
+  length = 2
 }
 
 output "id" {

--- a/S3/examples/public_bucket/main.tf
+++ b/S3/examples/public_bucket/main.tf
@@ -6,6 +6,10 @@ module "bucket" {
 
   block_public_policy     = false
   restrict_public_buckets = false
+
+  versioning = {
+    enabled = true
+  }
 }
 
 variable "name" {

--- a/S3/examples/replication_bucket/iam.tf
+++ b/S3/examples/replication_bucket/iam.tf
@@ -1,0 +1,68 @@
+#
+# IAM role to allow replication
+#
+resource "aws_iam_role" "replication" {
+  name               = "s3-bucket-replication-${random_pet.this.id}"
+  assume_role_policy = data.aws_iam_policy_document.s3_assume.json
+}
+
+resource "aws_iam_policy" "replication" {
+  name   = "s3-bucket-replication-${random_pet.this.id}"
+  policy = data.aws_iam_policy_document.replication.json
+}
+
+resource "aws_iam_policy_attachment" "replication" {
+  name       = "s3-bucket-replication-${random_pet.this.id}"
+  roles      = [aws_iam_role.replication.name]
+  policy_arn = aws_iam_policy.replication.arn
+}
+
+data "aws_iam_policy_document" "s3_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "replication" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetReplicationConfiguration",
+      "s3:ListBucket"
+    ]
+    resources = [
+      module.source_bucket.s3_bucket_arn
+    ]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObjectVersion",
+      "s3:GetObjectVersionAcl"
+    ]
+    resources = [
+      "${module.source_bucket.s3_bucket_arn}/*"
+    ]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:ObjectOwnerOverrideToBucketOwner",
+      "s3:ReplicateObject",
+      "s3:ReplicateDelete"
+    ]
+    resources = [
+      "${module.destination_bucket.s3_bucket_arn}/*"
+    ]
+  }
+}
+
+
+
+

--- a/S3/examples/replication_bucket/main.tf
+++ b/S3/examples/replication_bucket/main.tf
@@ -1,0 +1,62 @@
+locals {
+  source_bucket_name      = "cds-terraform-modules-s3-repl-src-${random_pet.this.id}"
+  destination_bucket_name = "cds-terraform-modules-s3-repl-dest-${random_pet.this.id}"
+}
+
+# Source bucket that replicates objects
+module "source_bucket" {
+  source            = "../../"
+  billing_tag_value = "terratest"
+  bucket_name       = local.source_bucket_name
+
+  versioning = {
+    enabled = true
+  }
+
+  replication_configuration = {
+    role = aws_iam_role.replication.arn
+
+    rules = [
+      {
+        id       = "replicate-all-the-things"
+        status   = "Enabled"
+        priority = 20
+
+        filter = {
+          prefix = ""
+        }
+
+        destination = {
+          bucket = "arn:aws:s3:::${local.destination_bucket_name}"
+        }
+      }
+    ]
+  }
+}
+
+# Target bucket for the replication
+module "destination_bucket" {
+  source            = "../../"
+  billing_tag_value = "terratest"
+  bucket_name       = local.destination_bucket_name
+
+  versioning = {
+    enabled = true
+  }
+}
+
+resource "random_pet" "this" {
+  length = 2
+}
+
+output "source_bucket_id" {
+  value = module.source_bucket.s3_bucket_id
+}
+
+output "destination_bucket_arn" {
+  value = module.destination_bucket.s3_bucket_arn
+}
+
+output "replication_role_arn" {
+  value = aws_iam_role.replication.arn
+}

--- a/S3/examples/replication_bucket/main.tf
+++ b/S3/examples/replication_bucket/main.tf
@@ -19,15 +19,9 @@ module "source_bucket" {
     rules = [
       {
         id       = "replicate-all-the-things"
-        status   = "Enabled"
         priority = 20
-
-        filter = {
-          prefix = ""
-        }
-
         destination = {
-          bucket = "arn:aws:s3:::${local.destination_bucket_name}"
+          bucket = module.destination_bucket.s3_bucket_arn
         }
       }
     ]

--- a/S3/examples/replication_bucket/provider.tf
+++ b/S3/examples/replication_bucket/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "ca-central-1"
+}

--- a/S3/input.tf
+++ b/S3/input.tf
@@ -83,3 +83,9 @@ variable "object_lock_configuration" {
   type        = any
   default     = {}
 }
+
+variable "replication_configuration" {
+  description = "(Optional) Map containing cross-region replication configuration."
+  type        = any
+  default     = {}
+}

--- a/S3/main.tf
+++ b/S3/main.tf
@@ -69,6 +69,98 @@ resource "aws_s3_bucket" "this" {
     }
   }
 
+  # Max 1 block - replication_configuration
+  dynamic "replication_configuration" {
+    for_each = length(keys(var.replication_configuration)) == 0 ? [] : [var.replication_configuration]
+
+    content {
+      role = replication_configuration.value.role
+
+      dynamic "rules" {
+        for_each = replication_configuration.value.rules
+
+        content {
+          id                               = lookup(rules.value, "id", null)
+          priority                         = lookup(rules.value, "priority", null)
+          prefix                           = lookup(rules.value, "prefix", null)
+          delete_marker_replication_status = lookup(rules.value, "delete_marker_replication_status", null)
+          status                           = rules.value.status
+
+          dynamic "destination" {
+            for_each = length(keys(lookup(rules.value, "destination", {}))) == 0 ? [] : [lookup(rules.value, "destination", {})]
+
+            content {
+              bucket             = destination.value.bucket
+              storage_class      = lookup(destination.value, "storage_class", null)
+              replica_kms_key_id = lookup(destination.value, "replica_kms_key_id", null)
+              account_id         = lookup(destination.value, "account_id", null)
+
+              dynamic "access_control_translation" {
+                for_each = length(keys(lookup(destination.value, "access_control_translation", {}))) == 0 ? [] : [lookup(destination.value, "access_control_translation", {})]
+
+                content {
+                  owner = access_control_translation.value.owner
+                }
+              }
+
+              dynamic "replication_time" {
+                for_each = length(keys(lookup(destination.value, "replication_time", {}))) == 0 ? [] : [lookup(destination.value, "replication_time", {})]
+
+                content {
+                  status  = replication_time.value.status
+                  minutes = replication_time.value.minutes
+                }
+              }
+
+              dynamic "metrics" {
+                for_each = length(keys(lookup(destination.value, "metrics", {}))) == 0 ? [] : [lookup(destination.value, "metrics", {})]
+
+                content {
+                  status  = metrics.value.status
+                  minutes = metrics.value.minutes
+                }
+              }
+            }
+          }
+
+          dynamic "source_selection_criteria" {
+            for_each = length(keys(lookup(rules.value, "source_selection_criteria", {}))) == 0 ? [] : [lookup(rules.value, "source_selection_criteria", {})]
+
+            content {
+
+              dynamic "sse_kms_encrypted_objects" {
+                for_each = length(keys(lookup(source_selection_criteria.value, "sse_kms_encrypted_objects", {}))) == 0 ? [] : [lookup(source_selection_criteria.value, "sse_kms_encrypted_objects", {})]
+
+                content {
+
+                  enabled = sse_kms_encrypted_objects.value.enabled
+                }
+              }
+            }
+          }
+
+          # Send empty map if `filter` is an empty map or absent entirely
+          dynamic "filter" {
+            for_each = length(keys(lookup(rules.value, "filter", {}))) == 0 ? [{}] : []
+
+            content {}
+          }
+
+          # Send `filter` if it is present and has at least one field
+          dynamic "filter" {
+            for_each = length(keys(lookup(rules.value, "filter", {}))) != 0 ? [lookup(rules.value, "filter", {})] : []
+
+            content {
+              prefix = lookup(filter.value, "prefix", null)
+              tags   = lookup(filter.value, "tags", null)
+            }
+          }
+
+        }
+      }
+    }
+  }
+
   # Max 1 block - object_lock_configuration
   dynamic "object_lock_configuration" {
     for_each = length(keys(var.object_lock_configuration)) == 0 ? [] : [var.object_lock_configuration]

--- a/S3/main.tf
+++ b/S3/main.tf
@@ -119,9 +119,11 @@ resource "aws_s3_bucket" "this" {
             }
           }
 
-          # Replicate all objects in the source bucket
-          filter = {
-            prefix = ""
+          dynamic "filter" {
+            for_each = length(keys(var.replication_configuration)) == 0 ? [] : [1]
+            content {
+              prefix = ""
+            }
           }
 
         }

--- a/S3/test/basic_bucket_test.go
+++ b/S3/test/basic_bucket_test.go
@@ -15,15 +15,11 @@ func TestBasicBucketCreation(t *testing.T) {
 	t.Parallel()
 
 	region := "ca-central-1"
-	name := "totallyuniquecdstestbucket"
 
 	terraformOptions := &terraform.Options{
 		TerraformDir: "../examples/basic_bucket",
 		EnvVars: map[string]string{
 			"AWS_DEFAULT_REGION": region,
-		},
-		Vars: map[string]interface{}{
-			"name": name,
 		},
 	}
 
@@ -41,17 +37,14 @@ func TestBasicBucketCreation(t *testing.T) {
 
 	assert.Equal(t, bucket_region, region)
 
-	arn := fmt.Sprintf("arn:aws:s3:::%s", name)
+	arn := fmt.Sprintf("arn:aws:s3:::%s", bucket_id)
 	assert.Equal(t, bucket_arn, arn)
-
-	assert.Equal(t, bucket_id, name)
 	assert.Equal(t, bucket_region, region)
-
-	assert.Equal(t, name, public_access_block_id)
+	assert.Equal(t, bucket_id, public_access_block_id)
 
 	// Test the public access block
 	s3Client := aws.NewS3Client(t, region)
-	req, resp := s3Client.GetPublicAccessBlockRequest(&s3.GetPublicAccessBlockInput{Bucket: &name})
+	req, resp := s3Client.GetPublicAccessBlockRequest(&s3.GetPublicAccessBlockInput{Bucket: &bucket_id})
 	require.NoError(t, req.Send())
 
 	assert.Equal(t, true, *resp.PublicAccessBlockConfiguration.BlockPublicAcls)

--- a/S3/test/public_bucket_test.go
+++ b/S3/test/public_bucket_test.go
@@ -15,15 +15,11 @@ func TestPublicBucketCreation(t *testing.T) {
 	t.Parallel()
 
 	region := "ca-central-1"
-	name := "yetanothertotallyuniquecdstestbucket"
 
 	terraformOptions := &terraform.Options{
 		TerraformDir: "../examples/public_bucket",
 		EnvVars: map[string]string{
 			"AWS_DEFAULT_REGION": region,
-		},
-		Vars: map[string]interface{}{
-			"name": name,
 		},
 	}
 
@@ -40,15 +36,13 @@ func TestPublicBucketCreation(t *testing.T) {
 
 	assert.Equal(t, bucket_region, region)
 
-	arn := fmt.Sprintf("arn:aws:s3:::%s", name)
+	arn := fmt.Sprintf("arn:aws:s3:::%s", bucket_id)
 	assert.Equal(t, bucket_arn, arn)
-
-	assert.Equal(t, bucket_id, name)
 	assert.Equal(t, bucket_region, region)
 
 	// Test the public access block
 	s3Client := aws.NewS3Client(t, region)
-	req, resp := s3Client.GetPublicAccessBlockRequest(&s3.GetPublicAccessBlockInput{Bucket: &name})
+	req, resp := s3Client.GetPublicAccessBlockRequest(&s3.GetPublicAccessBlockInput{Bucket: &bucket_id})
 	require.NoError(t, req.Send())
 
 	assert.Equal(t, true, *resp.PublicAccessBlockConfiguration.BlockPublicAcls)

--- a/S3/test/replication_bucket_test.go
+++ b/S3/test/replication_bucket_test.go
@@ -1,0 +1,43 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplicationBucketCreation(t *testing.T) {
+	t.Parallel()
+
+	region := "ca-central-1"
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: "../examples/replication_bucket",
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": region,
+		},
+	}
+
+	// Destroy resource once tests are finished
+	defer terraform.Destroy(t, terraformOptions)
+
+	// Create the resources
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Get outputs from the `terraform apply`
+	source_bucket_id := terraform.Output(t, terraformOptions, "source_bucket_id")
+	destination_bucket_arn := terraform.Output(t, terraformOptions, "destination_bucket_arn")
+	replication_role_arn := terraform.Output(t, terraformOptions, "replication_role_arn")
+
+	// Test the public access block
+	s3Client := aws.NewS3Client(t, region)
+	req, resp := s3Client.GetBucketReplicationRequest(&s3.GetBucketReplicationInput{Bucket: &source_bucket_id})
+	require.NoError(t, req.Send())
+
+	assert.Equal(t, replication_role_arn, *resp.ReplicationConfiguration.Role)
+	assert.Equal(t, destination_bucket_arn, *resp.ReplicationConfiguration.Rules[0].Destination.Bucket)
+}

--- a/S3/test/replication_bucket_test.go
+++ b/S3/test/replication_bucket_test.go
@@ -33,7 +33,7 @@ func TestReplicationBucketCreation(t *testing.T) {
 	destination_bucket_arn := terraform.Output(t, terraformOptions, "destination_bucket_arn")
 	replication_role_arn := terraform.Output(t, terraformOptions, "replication_role_arn")
 
-	// Test the public access block
+	// Test the replication rules
 	s3Client := aws.NewS3Client(t, region)
 	req, resp := s3Client.GetBucketReplicationRequest(&s3.GetBucketReplicationInput{Bucket: &source_bucket_id})
 	require.NoError(t, req.Send())


### PR DESCRIPTION
# Summary
Add the ability to create s3 bucket replication rules.

Also removes the hardcoded bucket names from the s3 tests to prevent failures related to bucket names already being taken.