### PR TITLE
fix: dynamodb arn wildcard table name

### DIFF
--- a/attach_tf_plan_policy/main.tf
+++ b/attach_tf_plan_policy/main.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "this" {
     effect  = "Allow"
     actions = ["dynamodb:*"]
     resources = [
-      "arn:aws:dynamodb:${var.region}:${var.account_id}:table/"
+      "arn:aws:dynamodb:${var.region}:${var.account_id}:table/*"
     ]
   }
 

--- a/attach_tf_plan_policy/main.tf
+++ b/attach_tf_plan_policy/main.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "this" {
     effect  = "Allow"
     actions = ["dynamodb:*"]
     resources = [
-      "arn:aws:dynamodb:${var.region}:${var.account_id}:table/*"
+      "arn:aws:dynamodb:${var.region}:${var.account_id}:table/${var.lock_table_name}"
     ]
   }
 


### PR DESCRIPTION
Access to write to Dynamodb state table's was not working due to the missing wildcard for the table in the ARN