### PR TITLE
fix: add the readonly role into this module

### DIFF
--- a/attach_tf_plan_policy/README.md
+++ b/attach_tf_plan_policy/README.md
@@ -22,7 +22,9 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role_policy_attachment.readonly](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_policy.readonly](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs

--- a/attach_tf_plan_policy/main.tf
+++ b/attach_tf_plan_policy/main.tf
@@ -54,3 +54,12 @@ data "aws_iam_policy_document" "this" {
     resources = ["*"]
   }
 }
+
+data "aws_iam_policy" "readonly" {
+  name = "ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "readonly" {
+  role       = var.role_name
+  policy_arn = data.aws_iam_policy.readonly.arn
+}


### PR DESCRIPTION
# Summary | Résumé

I had the readonly role attachement outside of the module, figured it
would be better to bring it in.


