### PR TITLE
feat: S3 delete marker replication status

### DIFF
--- a/S3/main.tf
+++ b/S3/main.tf
@@ -84,7 +84,7 @@ resource "aws_s3_bucket" "this" {
         content {
           id                               = lookup(rules.value, "id", null)
           priority                         = lookup(rules.value, "priority", null)
-          delete_marker_replication_status = "Enabled"
+          delete_marker_replication_status = lookup(rules.value, "delete_marker_replication_status", null)
           status                           = "Enabled"
 
           dynamic "destination" {


### PR DESCRIPTION
# Summary
Update to allow the S3 bucket's replication rule to specify if delete
markers are replicated to the destination bucket.

This is being done to support the Cloud Based Sensor so that
satellite buckets can have a shorter expiration time and save
storage costs.