### PR TITLE
feat: makes the creation of the OIDC provider optional

### DIFF
--- a/gh_oidc_role/README.md
+++ b/gh_oidc_role/README.md
@@ -9,8 +9,8 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.70.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 3.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
 
 ## Modules
 
@@ -34,6 +34,7 @@ No modules.
 | <a name="input_assume_policy"></a> [assume\_policy](#input\_assume\_policy) | (Optional) Assume role JSON policy to attach to the oidc role | `string` | `"{}"` | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
+| <a name="input_oidc_exists"></a> [oidc\_exists](#input\_oidc\_exists) | (Optional, default false) If false, the OIDC provider will be created | `boolean` | `false` | no |
 | <a name="input_org_name"></a> [org\_name](#input\_org\_name) | (Optional)  The name of the org the workflow will be called from.<br>    In the format of http://github.com/`org_name` | `string` | `"cds-snc"` | no |
 | <a name="input_roles"></a> [roles](#input\_roles) | (Required) The list of roles to create for GH OIDC<br><br>  name: The name of the role to create<br><br>  repo\_name: The name of the repo to authenticate<br>  If you use `*` this will allow this role to be used in any repo in the org identified in `org_name`<br><br>  claim: The claim that the token is allowed to be authorized from. <br>  This allows you to further restrict where this role is allowed to be used.<br>  If you wanted to restrict to the main branch you could use a value like `ref:refs/heads/main`, if you don't want to restrict you can use `*`<br><br>  **Please Note:** You need to provide at least one role for this module to work. | <pre>set(object({<br>    name : string,<br>    repo_name : string,<br>    claim : string<br>  }))</pre> | n/a | yes |
 

--- a/gh_oidc_role/input.tf
+++ b/gh_oidc_role/input.tf
@@ -10,6 +10,12 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "oidc_exists" {
+  description = "(Optional, default false) If false, the OIDC provider will be created"
+  type        = boolean
+  default     = false
+}
+
 variable "org_name" {
   description = <<EOF
     (Optional)  The name of the org the workflow will be called from.

--- a/gh_oidc_role/main.tf
+++ b/gh_oidc_role/main.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "oidc_assume_role_policy" {
 
     principals {
       type        = "Federated"
-      identifiers = [aws_iam_openid_connect_provider.github.arn]
+      identifiers = [var.oidc_exists ? aws_iam_openid_connect_provider.github.arn : "arn:aws:iam::${data.aws_caller_identity.account_id}:oidc-provider/token.actions.githubusercontent.com"]
     }
 
     condition {
@@ -52,6 +52,7 @@ data "aws_iam_policy_document" "oidc_assume_role_policy" {
 }
 
 resource "aws_iam_openid_connect_provider" "github" {
+  count           = var.oidc_exists ? 0 : 1
   url             = local.gh_url
   client_id_list  = ["sts.amazonaws.com"]
   thumbprint_list = [data.tls_certificate.thumprint.certificates.0.sha1_fingerprint]


### PR DESCRIPTION
This PR adds a flag to the OIDC provider module which makes the creation of the identity provider optional. This would be the case if two different projects are using the provider in one account. The ARN of the identity provider is predictable, 

```
arn:aws:iam::XXXXXXXXXXXX:oidc-provider/token.actions.githubusercontent.com
```

so if the flag is set to true, it will just assign the existing ARN to the new roles. 