### PR TITLE
feat: add GOC Password Policy for AWS

### DIFF
--- a/.modules
+++ b/.modules
@@ -1,1 +1,1 @@
-rds S3 S3_log_bucket user_login_alarm vpc lambda gh_oidc_role attach_tf_plan_policy sentinel_forwarder
+rds S3 S3_log_bucket user_login_alarm vpc lambda gh_oidc_role attach_tf_plan_policy sentinel_forwarder aws_goc_password_policy

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 ## Module List
 
+- [AWS Government of Canada Password Policy](aws_goc_password_policy)
+- [Github Open ID Connect](gh_oidc_role)
 - [Notify Slack](notify_slack)
 - [RDS](rds)
 - [S3](S3)

--- a/S3/README.md
+++ b/S3/README.md
@@ -1,3 +1,4 @@
+# S3 Bucket
 
 This was adapted from the [terraform-aws-modules](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket)
 The License file for this module can be found in this directory

--- a/S3/main.tf
+++ b/S3/main.tf
@@ -1,4 +1,5 @@
-/* # S3 Bucket
+/* 
+* # S3 Bucket
 * 
 * This was adapted from the [terraform-aws-modules](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket)
 * The License file for this module can be found in this directory

--- a/S3_log_bucket/README.md
+++ b/S3_log_bucket/README.md
@@ -1,3 +1,4 @@
+# S3 Bucket
 
 This was adapted from the [terraform-aws-modules](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket)
 The License file for this module can be found in this directory.

--- a/S3_log_bucket/main.tf
+++ b/S3_log_bucket/main.tf
@@ -1,4 +1,5 @@
-/* # S3 Bucket
+/* 
+* # S3 Bucket
 * 
 * This was adapted from the [terraform-aws-modules](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket)
 * The License file for this module can be found in this directory.

--- a/aws_goc_password_policy/Makefile
+++ b/aws_goc_password_policy/Makefile
@@ -1,0 +1,7 @@
+.PHONY: fmt docs
+
+fmt:
+	@terraform fmt -recursive
+
+docs:
+	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/aws_goc_password_policy/README.md
+++ b/aws_goc_password_policy/README.md
@@ -1,0 +1,32 @@
+# aws\_goc\_password\_policy
+
+Implements the recommend [Government of Canada Password Guidance](https://www.canada.ca/en/government/system/digital-government/online-security-privacy/password-guidance.html) for AWS Accounts.
+This is required in order to meet the ["Management of Administrative Privilges"](https://github.com/canada-ca/cloud-guardrails/blob/master/EN/02_Management-Admin-Privileges.md) Guardrail that is part of the [GC Cloud Guardrails](https://github.com/canada-ca/cloud-guardrails) that need to be implemented in the first 30 days of acquiring an AWS Organization
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_account_password_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.

--- a/aws_goc_password_policy/main.tf
+++ b/aws_goc_password_policy/main.tf
@@ -1,0 +1,18 @@
+/* 
+* # aws_goc_password_policy
+* 
+* Implements the recommend [Government of Canada Password Guidance](https://www.canada.ca/en/government/system/digital-government/online-security-privacy/password-guidance.html) for AWS Accounts.
+* This is required in order to meet the ["Management of Administrative Privilges"](https://github.com/canada-ca/cloud-guardrails/blob/master/EN/02_Management-Admin-Privileges.md) Guardrail that is part of the [GC Cloud Guardrails](https://github.com/canada-ca/cloud-guardrails) that need to be implemented in the first 30 days of acquiring an AWS Organization
+* 
+*/
+
+resource "aws_iam_account_password_policy" "this" {
+  minimum_password_length        = 12
+  require_symbols                = true
+  require_numbers                = true
+  require_lowercase_characters   = true
+  require_uppercase_characters   = true
+  allow_users_to_change_password = true
+  hard_expiry                    = false
+  password_reuse_prevention      = 24
+}

--- a/gh_oidc_role/README.md
+++ b/gh_oidc_role/README.md
@@ -1,3 +1,4 @@
+# gh\_oicd\_role
 Creates an OpenID Connect Role that can be used for authenticating workflows in Github Actions
 This allows for a more secure way to connect to AWS as it doesn't rely on static credentials but uses temporary credentials created for each run.
 
@@ -9,8 +10,8 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.70.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 3.1.0 |
 
 ## Modules
 
@@ -34,7 +35,7 @@ No modules.
 | <a name="input_assume_policy"></a> [assume\_policy](#input\_assume\_policy) | (Optional) Assume role JSON policy to attach to the oidc role | `string` | `"{}"` | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
-| <a name="input_oidc_exists"></a> [oidc\_exists](#input\_oidc\_exists) | (Optional, default false) If false, the OIDC provider will be created | `boolean` | `false` | no |
+| <a name="input_oidc_exists"></a> [oidc\_exists](#input\_oidc\_exists) | (Optional, default false) If false, the OIDC provider will be created | `bool` | `false` | no |
 | <a name="input_org_name"></a> [org\_name](#input\_org\_name) | (Optional)  The name of the org the workflow will be called from.<br>    In the format of http://github.com/`org_name` | `string` | `"cds-snc"` | no |
 | <a name="input_roles"></a> [roles](#input\_roles) | (Required) The list of roles to create for GH OIDC<br><br>  name: The name of the role to create<br><br>  repo\_name: The name of the repo to authenticate<br>  If you use `*` this will allow this role to be used in any repo in the org identified in `org_name`<br><br>  claim: The claim that the token is allowed to be authorized from. <br>  This allows you to further restrict where this role is allowed to be used.<br>  If you wanted to restrict to the main branch you could use a value like `ref:refs/heads/main`, if you don't want to restrict you can use `*`<br><br>  **Please Note:** You need to provide at least one role for this module to work. | <pre>set(object({<br>    name : string,<br>    repo_name : string,<br>    claim : string<br>  }))</pre> | n/a | yes |
 

--- a/gh_oidc_role/main.tf
+++ b/gh_oidc_role/main.tf
@@ -1,4 +1,5 @@
-/* # gh_oicd_role
+/* 
+* # gh_oicd_role
 * Creates an OpenID Connect Role that can be used for authenticating workflows in Github Actions
 * This allows for a more secure way to connect to AWS as it doesn't rely on static credentials but uses temporary credentials created for each run.
 */

--- a/sentinel_forwarder/README.md
+++ b/sentinel_forwarder/README.md
@@ -50,6 +50,7 @@ No modules.
 | [aws_lambda_permission.sentinel_forwarder_s3_triggers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_s3_bucket_notification.sentinel_forwarder_trigger_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [archive_file.sentinel_forwarder](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.lambda_assume_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sentinel_forwarder_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sentinel_forwarder_lambda_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -63,7 +64,7 @@ No modules.
 | <a name="input_customer_id"></a> [customer\_id](#input\_customer\_id) | (Required) Azure log workspace customer ID | `string` | n/a | yes |
 | <a name="input_event_rule_names"></a> [event\_rule\_names](#input\_event\_rule\_names) | (Optional) List of names for event rules to trigger the lambda | `list(string)` | `[]` | no |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | (Required) Name of the Lambda function. | `string` | n/a | yes |
-| <a name="input_layer_arn"></a> [layer\_arn](#input\_layer\_arn) | (Optional) ARN of the lambda layer to use | `string` | `"arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:5"` | no |
+| <a name="input_layer_arn"></a> [layer\_arn](#input\_layer\_arn) | (Optional) ARN of the lambda layer to use | `string` | `"arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:6"` | no |
 | <a name="input_log_type"></a> [log\_type](#input\_log\_type) | (Optional) The namespace for logs. This only applies if you are sending application logs | `string` | `"ApplicationLog"` | no |
 | <a name="input_s3_sources"></a> [s3\_sources](#input\_s3\_sources) | (Optional) List of s3 buckets to trigger the lambda | <pre>list(object({<br>    bucket_arn    = string<br>    bucket_id     = string<br>    filter_prefix = string<br>    kms_key_arn   = string<br>  }))</pre> | `[]` | no |
 | <a name="input_shared_key"></a> [shared\_key](#input\_shared\_key) | (Required) Azure log workspace shared secret | `string` | n/a | yes |


### PR DESCRIPTION
# Summary | Résumé

Adds a password policy that aligns with the published Guidance
from the Government of Canada

https://www.canada.ca/en/government/system/digital-government/online-security-privacy/password-guidance.html

Also fixes some issues with docs.
