### PR TITLE
feat: Pin s3 buckets to < 4

### DIFF
--- a/S3/versions.tf
+++ b/S3/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.26"
 
   required_providers {
-    aws = ">= 3.36"
+    aws = ">= 3.36, < 4"
   }
 }

--- a/S3_log_bucket/versions.tf
+++ b/S3_log_bucket/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.26"
 
   required_providers {
-    aws = ">= 3.36"
+    aws = ">= 3.36, < 4"
   }
 }


### PR DESCRIPTION
# Summary | Résumé

This module does not work with the new AWS v4 Provider, tests are
failing because it gets the latest verion of the provider.

