### PR TITLE
feat: adds a SNS module that enforces the use of a CM KMS

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 		"context": "..",
 		"args": {
 			"GO_VERSION": "1.16.6",
-			"GO_CHECKSUM": "be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d",		
+			"GO_CHECKSUM": "be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d",
 			"SHELLCHECK_VERSION": "0.7.2",
 			"SHELLCHECK_CHECKSUM": "70423609f27b504d6c0c47e340f33652aea975e45f312324f2dbf91c95a3b188",
 			"TERRAFORM_VERSION": "1.0.3",
@@ -15,17 +15,14 @@
 			"CONFTEST_VERSION": "0.27.0"
 		}
 	},
-
 	"containerEnv": {
 		"SHELL": "/bin/zsh"
 	},
-
 	"remoteEnv": {
 		"CGO_ENABLED": "0",
 		"GO111MODULE": "on",
 		"PATH": "${containerEnv:PATH}:/usr/local/go/bin"
 	},
-
 	"settings": {
 		"[go]": {
 			"editor.formatOnSave": true
@@ -34,17 +31,15 @@
 			"editor.formatOnSave": true
 		}
 	},
-
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"golang.go",
 		"hashicorp.terraform",
 		"redhat.vscode-yaml",
-		"yzhang.markdown-all-in-one"
+		"yzhang.markdown-all-in-one",
+		"github.copilot"
 	],
-
 	"postCreateCommand": "go get -v golang.org/x/tools/gopls",
-
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/.modules
+++ b/.modules
@@ -1,1 +1,1 @@
-rds S3 S3_log_bucket user_login_alarm vpc lambda gh_oidc_role attach_tf_plan_policy sentinel_forwarder aws_goc_password_policy
+rds S3 S3_log_bucket user_login_alarm vpc lambda gh_oidc_role attach_tf_plan_policy sentinel_forwarder aws_goc_password_policy sns

--- a/sns/Makefile
+++ b/sns/Makefile
@@ -1,0 +1,7 @@
+.PHONY: fmt docs
+
+fmt:
+	@terraform fmt -recursive
+
+docs:
+	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/sns/README.md
+++ b/sns/README.md
@@ -1,0 +1,66 @@
+
+ A wrapper on the SNS module that enfores a customer managed KMS key
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_kms_key.sns_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_sns_topic.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.kms_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_application_failure_feedback_role_arn"></a> [application\_failure\_feedback\_role\_arn](#input\_application\_failure\_feedback\_role\_arn) | (Optional) IAM role for failure feedback | `string` | `null` | no |
+| <a name="input_application_success_feedback_role_arn"></a> [application\_success\_feedback\_role\_arn](#input\_application\_success\_feedback\_role\_arn) | (Optional) The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
+| <a name="input_application_success_feedback_sample_rate"></a> [application\_success\_feedback\_sample\_rate](#input\_application\_success\_feedback\_sample\_rate) | (Optional) Percentage of success to sample | `number` | `null` | no |
+| <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
+| <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | `null` | no |
+| <a name="input_content_based_deduplication"></a> [content\_based\_deduplication](#input\_content\_based\_deduplication) | (Optional) Enables content-based deduplication for FIFO topics. For more information, see the related documentation | `bool` | `false` | no |
+| <a name="input_delivery_policy"></a> [delivery\_policy](#input\_delivery\_policy) | (Optional) The SNS delivery policy. More on AWS documentation | `string` | `null` | no |
+| <a name="input_display_name"></a> [display\_name](#input\_display\_name) | (Optional) The display name for the topic | `string` | `null` | no |
+| <a name="input_fifo_topic"></a> [fifo\_topic](#input\_fifo\_topic) | (Optional) Boolean indicating whether or not to create a FIFO (first-in-first-out) topic (default is false). | `bool` | `false` | no |
+| <a name="input_firehose_failure_feedback_role_arn"></a> [firehose\_failure\_feedback\_role\_arn](#input\_firehose\_failure\_feedback\_role\_arn) | (Optional) IAM role for failure feedback | `string` | `null` | no |
+| <a name="input_firehose_success_feedback_role_arn"></a> [firehose\_success\_feedback\_role\_arn](#input\_firehose\_success\_feedback\_role\_arn) | (Optional) The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
+| <a name="input_firehose_success_feedback_sample_rate"></a> [firehose\_success\_feedback\_sample\_rate](#input\_firehose\_success\_feedback\_sample\_rate) | (Optional) Percentage of success to sample | `number` | `null` | no |
+| <a name="input_http_failure_feedback_role_arn"></a> [http\_failure\_feedback\_role\_arn](#input\_http\_failure\_feedback\_role\_arn) | (Optional) IAM role for failure feedback | `string` | `null` | no |
+| <a name="input_http_success_feedback_role_arn"></a> [http\_success\_feedback\_role\_arn](#input\_http\_success\_feedback\_role\_arn) | (Optional) The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
+| <a name="input_http_success_feedback_sample_rate"></a> [http\_success\_feedback\_sample\_rate](#input\_http\_success\_feedback\_sample\_rate) | (Optional) Percentage of success to sample | `number` | `null` | no |
+| <a name="input_kms_event_sources"></a> [kms\_event\_sources](#input\_kms\_event\_sources) | (Optional) List of AWS services that can access the topic. | `list(string)` | `[]` | no |
+| <a name="input_kms_iam_sources"></a> [kms\_iam\_sources](#input\_kms\_iam\_sources) | (Optional) List of AWS IAM role sources that can access the topic. | `list(string)` | `[]` | no |
+| <a name="input_kms_master_key_id"></a> [kms\_master\_key\_id](#input\_kms\_master\_key\_id) | (Optional) The ID of an AWS-managed customer master key (CMK) for Amazon SNS or a custom CMK. For more information, see Key Terms | `string` | `null` | no |
+| <a name="input_lambda_failure_feedback_role_arn"></a> [lambda\_failure\_feedback\_role\_arn](#input\_lambda\_failure\_feedback\_role\_arn) | (Optional) IAM role for failure feedback | `string` | `null` | no |
+| <a name="input_lambda_success_feedback_role_arn"></a> [lambda\_success\_feedback\_role\_arn](#input\_lambda\_success\_feedback\_role\_arn) | (Optional) The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
+| <a name="input_lambda_success_feedback_sample_rate"></a> [lambda\_success\_feedback\_sample\_rate](#input\_lambda\_success\_feedback\_sample\_rate) | (Optional) Percentage of success to sample | `number` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the topic. Topic names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 256 characters long. For a FIFO (first-in-first-out) topic, the name must end with the .fifo suffix. If omitted, Terraform will assign a random, unique name. Conflicts with name\_prefix | `string` | n/a | yes |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | (Optional) Creates a unique name beginning with the specified prefix. Conflicts with name | `string` | `null` | no |
+| <a name="input_policy"></a> [policy](#input\_policy) | (Optional) The fully-formed AWS policy as JSON. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide. | `string` | `null` | no |
+| <a name="input_sqs_failure_feedback_role_arn"></a> [sqs\_failure\_feedback\_role\_arn](#input\_sqs\_failure\_feedback\_role\_arn) | (Optional) IAM role for failure feedback | `string` | `null` | no |
+| <a name="input_sqs_success_feedback_role_arn"></a> [sqs\_success\_feedback\_role\_arn](#input\_sqs\_success\_feedback\_role\_arn) | (Optional) The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
+| <a name="input_sqs_success_feedback_sample_rate"></a> [sqs\_success\_feedback\_sample\_rate](#input\_sqs\_success\_feedback\_sample\_rate) | (Optional) Percentage of success to sample | `number` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Key-value map of resource tags. If configured with a provider default\_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_kms_key_id"></a> [kms\_key\_id](#output\_kms\_key\_id) | KMS Key ID used for SNS |
+| <a name="output_sns_arn"></a> [sns\_arn](#output\_sns\_arn) | The ARN of the SNS topic. |
+| <a name="output_sns_id"></a> [sns\_id](#output\_sns\_id) | The name of the SNS topic. |

--- a/sns/README.md
+++ b/sns/README.md
@@ -45,7 +45,7 @@ No modules.
 | <a name="input_http_success_feedback_sample_rate"></a> [http\_success\_feedback\_sample\_rate](#input\_http\_success\_feedback\_sample\_rate) | (Optional) Percentage of success to sample | `number` | `null` | no |
 | <a name="input_kms_event_sources"></a> [kms\_event\_sources](#input\_kms\_event\_sources) | (Optional) List of AWS services that can access the topic. | `list(string)` | `[]` | no |
 | <a name="input_kms_iam_sources"></a> [kms\_iam\_sources](#input\_kms\_iam\_sources) | (Optional) List of AWS IAM role sources that can access the topic. | `list(string)` | `[]` | no |
-| <a name="input_kms_master_key_id"></a> [kms\_master\_key\_id](#input\_kms\_master\_key\_id) | (Optional) The ID of an AWS-managed customer master key (CMK) for Amazon SNS or a custom CMK. For more information, see Key Terms | `string` | `null` | no |
+| <a name="input_kms_master_key_id"></a> [kms\_master\_key\_id](#input\_kms\_master\_key\_id) | (Optional) The ARN of an AWS-managed customer master key (CMK) for Amazon SNS or a custom CMK. For more information, see Key Terms | `string` | `null` | no |
 | <a name="input_lambda_failure_feedback_role_arn"></a> [lambda\_failure\_feedback\_role\_arn](#input\_lambda\_failure\_feedback\_role\_arn) | (Optional) IAM role for failure feedback | `string` | `null` | no |
 | <a name="input_lambda_success_feedback_role_arn"></a> [lambda\_success\_feedback\_role\_arn](#input\_lambda\_success\_feedback\_role\_arn) | (Optional) The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
 | <a name="input_lambda_success_feedback_sample_rate"></a> [lambda\_success\_feedback\_sample\_rate](#input\_lambda\_success\_feedback\_sample\_rate) | (Optional) Percentage of success to sample | `number` | `null` | no |
@@ -61,6 +61,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_kms_key_id"></a> [kms\_key\_id](#output\_kms\_key\_id) | KMS Key ID used for SNS |
+| <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | KMS Key ARN used for SNS |
 | <a name="output_sns_arn"></a> [sns\_arn](#output\_sns\_arn) | The ARN of the SNS topic. |
 | <a name="output_sns_id"></a> [sns\_id](#output\_sns\_id) | The name of the SNS topic. |

--- a/sns/README.md
+++ b/sns/README.md
@@ -1,5 +1,10 @@
 
- A wrapper on the SNS module that enfores a customer managed KMS key
+A wrapper on the SNS module that enfores a customer managed KMS key. You can either supply
+your own KMS ARN as `kms_master_key_id` or let the module create their own key. If you choose
+to let the module create a KMS key it will also include an IAM policy that allows access from the
+root user of the account. You can also supply service like `s3.amazonaws.com` or `sns.amazonaws.com`
+in the `kms_event_sources` list, as well as IAM roles in the `kms_iam_sources` list who will then have
+`kms:Decrypt*` and `kms:GenerateDataKey*` permissions on the key.
 
 ## Requirements
 

--- a/sns/input.tf
+++ b/sns/input.tf
@@ -77,7 +77,7 @@ variable "http_failure_feedback_role_arn" {
 }
 
 variable "kms_master_key_id" {
-  description = "(Optional) The ID of an AWS-managed customer master key (CMK) for Amazon SNS or a custom CMK. For more information, see Key Terms"
+  description = "(Optional) The ARN of an AWS-managed customer master key (CMK) for Amazon SNS or a custom CMK. For more information, see Key Terms"
   type        = string
   default     = null
 }

--- a/sns/input.tf
+++ b/sns/input.tf
@@ -1,0 +1,167 @@
+
+variable "billing_tag_key" {
+  description = "(Optional, default 'CostCentre') The name of the billing tag"
+  type        = string
+  default     = "CostCentre"
+}
+
+variable "billing_tag_value" {
+  description = "(Required) The value of the billing tag"
+  type        = string
+  default     = null
+}
+
+variable "name" {
+  description = "The name of the topic. Topic names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 256 characters long. For a FIFO (first-in-first-out) topic, the name must end with the .fifo suffix. If omitted, Terraform will assign a random, unique name. Conflicts with name_prefix"
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "(Optional) Creates a unique name beginning with the specified prefix. Conflicts with name"
+  type        = string
+  default     = null
+}
+
+variable "display_name" {
+  description = "(Optional) The display name for the topic"
+  type        = string
+  default     = null
+}
+
+variable "policy" {
+  description = "(Optional) The fully-formed AWS policy as JSON. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide."
+  type        = string
+  default     = null
+}
+
+variable "delivery_policy" {
+  description = "(Optional) The SNS delivery policy. More on AWS documentation"
+  type        = string
+  default     = null
+}
+
+variable "application_success_feedback_role_arn" {
+  description = "(Optional) The IAM role permitted to receive success feedback for this topic"
+  type        = string
+  default     = null
+}
+
+variable "application_success_feedback_sample_rate" {
+  description = "(Optional) Percentage of success to sample"
+  type        = number
+  default     = null
+}
+
+variable "application_failure_feedback_role_arn" {
+  description = "(Optional) IAM role for failure feedback"
+  type        = string
+  default     = null
+}
+
+variable "http_success_feedback_role_arn" {
+  description = "(Optional) The IAM role permitted to receive success feedback for this topic"
+  type        = string
+  default     = null
+}
+
+variable "http_success_feedback_sample_rate" {
+  description = "(Optional) Percentage of success to sample"
+  type        = number
+  default     = null
+}
+
+variable "http_failure_feedback_role_arn" {
+  description = "(Optional) IAM role for failure feedback"
+  type        = string
+  default     = null
+}
+
+variable "kms_master_key_id" {
+  description = "(Optional) The ID of an AWS-managed customer master key (CMK) for Amazon SNS or a custom CMK. For more information, see Key Terms"
+  type        = string
+  default     = null
+}
+
+variable "kms_event_sources" {
+  description = "(Optional) List of AWS services that can access the topic."
+  type        = list(string)
+  default     = []
+}
+
+variable "kms_iam_sources" {
+  description = "(Optional) List of AWS IAM role sources that can access the topic."
+  type        = list(string)
+  default     = []
+}
+
+variable "fifo_topic" {
+  description = "(Optional) Boolean indicating whether or not to create a FIFO (first-in-first-out) topic (default is false)."
+  type        = bool
+  default     = false
+}
+
+variable "content_based_deduplication" {
+  description = "(Optional) Enables content-based deduplication for FIFO topics. For more information, see the related documentation"
+  type        = bool
+  default     = false
+}
+
+variable "lambda_success_feedback_role_arn" {
+  description = "(Optional) The IAM role permitted to receive success feedback for this topic"
+  type        = string
+  default     = null
+}
+
+variable "lambda_success_feedback_sample_rate" {
+  description = "(Optional) Percentage of success to sample"
+  type        = number
+  default     = null
+}
+
+variable "lambda_failure_feedback_role_arn" {
+  description = "(Optional) IAM role for failure feedback"
+  type        = string
+  default     = null
+}
+
+variable "sqs_success_feedback_role_arn" {
+  description = "(Optional) The IAM role permitted to receive success feedback for this topic"
+  type        = string
+  default     = null
+}
+
+variable "sqs_success_feedback_sample_rate" {
+  description = "(Optional) Percentage of success to sample"
+  type        = number
+  default     = null
+}
+
+variable "sqs_failure_feedback_role_arn" {
+  description = "(Optional) IAM role for failure feedback"
+  type        = string
+  default     = null
+}
+
+variable "firehose_success_feedback_role_arn" {
+  description = "(Optional) The IAM role permitted to receive success feedback for this topic"
+  type        = string
+  default     = null
+}
+
+variable "firehose_success_feedback_sample_rate" {
+  description = "(Optional) Percentage of success to sample"
+  type        = number
+  default     = null
+}
+
+variable "firehose_failure_feedback_role_arn" {
+  description = "(Optional) IAM role for failure feedback"
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "(Optional) Key-value map of resource tags. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level."
+  type        = map(string)
+  default     = {}
+}

--- a/sns/locals.tf
+++ b/sns/locals.tf
@@ -1,0 +1,8 @@
+
+locals {
+  common_tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = "true"
+  }
+}
+

--- a/sns/main.tf
+++ b/sns/main.tf
@@ -47,7 +47,7 @@ data "aws_iam_policy_document" "kms_policies" {
 
     principals {
       type        = "AWS"
-      identifiers = [var.kms_iam_sources]
+      identifiers = var.kms_iam_sources
     }
 
     actions = [
@@ -59,7 +59,7 @@ data "aws_iam_policy_document" "kms_policies" {
       "*"
     ]
 
-    conditions {
+    condition {
       StringEquals = {
         "AWS:SourceAccount" = data.aws_caller_identity.current.account_id
       }

--- a/sns/main.tf
+++ b/sns/main.tf
@@ -63,7 +63,7 @@ data "aws_iam_policy_document" "kms_policies" {
 
       principals {
         type        = "Service"
-        identifiers = statement.value
+        identifiers = [statement.value]
       }
 
       actions = [
@@ -91,7 +91,7 @@ data "aws_iam_policy_document" "kms_policies" {
 
       principals {
         type        = "AWS"
-        identifiers = statement.value
+        identifiers = [statement.value]
       }
 
       actions = [

--- a/sns/main.tf
+++ b/sns/main.tf
@@ -97,5 +97,5 @@ data "aws_iam_policy_document" "kms_policies" {
 resource "aws_kms_key" "sns_key" {
   count       = var.kms_master_key_id == null ? 1 : 0
   description = "SNS Key for ${var.name}"
-  policy      = length(data.aws_iam_policy_document.kms_policies.statement) == 0 ? null : data.aws_iam_policy_document.kms_policies.statement.json
+  policy      = length(data.aws_iam_policy_document.kms_policies.statement) == 0 ? null : data.aws_iam_policy_document.kms_policies.json
 }

--- a/sns/main.tf
+++ b/sns/main.tf
@@ -60,14 +60,14 @@ data "aws_iam_policy_document" "kms_policies" {
   }
 
   dynamic "statement" {
-    for_each = [var.kms_event_sources]
+    for_each = length(var.kms_event_sources) > 0 ? [true] : []
 
     content {
       effect = "Allow"
 
       principals {
         type        = "Service"
-        identifiers = statement.value
+        identifiers = var.kms_event_sources
       }
 
       actions = [
@@ -88,14 +88,14 @@ data "aws_iam_policy_document" "kms_policies" {
   }
 
   dynamic "statement" {
-    for_each = [var.kms_iam_sources]
+    for_each = length(var.kms_iam_sources) > 0 ? [true] : []
 
     content {
       effect = "Allow"
 
       principals {
         type        = "AWS"
-        identifiers = statement.value
+        identifiers = var.kms_iam_sources
       }
 
       actions = [

--- a/sns/main.tf
+++ b/sns/main.tf
@@ -18,7 +18,7 @@ resource "aws_sns_topic" "this" {
   http_success_feedback_role_arn           = var.http_success_feedback_role_arn
   http_success_feedback_sample_rate        = var.http_success_feedback_sample_rate
   http_failure_feedback_role_arn           = var.http_failure_feedback_role_arn
-  kms_master_key_id                        = var.kms_master_key_id == null ? null : var.kms_master_key_id
+  kms_master_key_id                        = var.kms_master_key_id == null ? aws_kms_key.sns_key.arn : var.kms_master_key_id
   fifo_topic                               = var.fifo_topic
   content_based_deduplication              = var.content_based_deduplication
   lambda_success_feedback_role_arn         = var.lambda_success_feedback_role_arn
@@ -60,9 +60,9 @@ data "aws_iam_policy_document" "kms_policies" {
     ]
 
     condition {
-      StringEquals = {
-        "AWS:SourceAccount" = data.aws_caller_identity.current.account_id
-      }
+      test = "StringLike"
+      variable = "AWS:SourceArn"
+      values = [data.aws_caller_identity.current.account_id]
     }
   }
 }

--- a/sns/main.tf
+++ b/sns/main.tf
@@ -1,0 +1,74 @@
+/* # SNS
+*
+*  A wrapper on the SNS module that enfores a customer managed KMS key
+*
+*/
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_sns_topic" "this" {
+  name                                     = var.name
+  name_prefix                              = var.name_prefix
+  display_name                             = var.display_name
+  policy                                   = var.policy
+  delivery_policy                          = var.delivery_policy
+  application_success_feedback_role_arn    = var.application_success_feedback_role_arn
+  application_success_feedback_sample_rate = var.application_success_feedback_sample_rate
+  application_failure_feedback_role_arn    = var.application_failure_feedback_role_arn
+  http_success_feedback_role_arn           = var.http_success_feedback_role_arn
+  http_success_feedback_sample_rate        = var.http_success_feedback_sample_rate
+  http_failure_feedback_role_arn           = var.http_failure_feedback_role_arn
+  kms_master_key_id                        = var.kms_master_key_id == null ? null : var.kms_master_key_id
+  fifo_topic                               = var.fifo_topic
+  content_based_deduplication              = var.content_based_deduplication
+  lambda_success_feedback_role_arn         = var.lambda_success_feedback_role_arn
+  lambda_success_feedback_sample_rate      = var.lambda_success_feedback_sample_rate
+  lambda_failure_feedback_role_arn         = var.lambda_failure_feedback_role_arn
+  sqs_success_feedback_role_arn            = var.sqs_success_feedback_role_arn
+  sqs_success_feedback_sample_rate         = var.sqs_success_feedback_sample_rate
+  sqs_failure_feedback_role_arn            = var.sqs_failure_feedback_role_arn
+  firehose_success_feedback_role_arn       = var.firehose_success_feedback_role_arn
+  firehose_success_feedback_sample_rate    = var.firehose_success_feedback_sample_rate
+  firehose_failure_feedback_role_arn       = var.firehose_failure_feedback_role_arn
+  tags                                     = merge(local.common_tags, var.tags)
+}
+
+
+
+data "aws_iam_policy_document" "kms_policies" {
+  statement {
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = var.kms_event_sources
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.kms_iam_sources]
+    }
+
+    actions = [
+      "kms:Decrypt*",
+      "kms:GenerateDataKey*",
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    conditions {
+      StringEquals = {
+        "AWS:SourceAccount" = data.aws_caller_identity.current.account_id
+      }
+    }
+  }
+}
+
+resource "aws_kms_key" "sns_key" {
+  count       = var.kms_master_key_id == null ? 0 : 1
+  description = "SNS Key for ${var.name}"
+  policy      = data.aws_iam_policy_document.kms_policies.json
+}

--- a/sns/main.tf
+++ b/sns/main.tf
@@ -97,5 +97,5 @@ data "aws_iam_policy_document" "kms_policies" {
 resource "aws_kms_key" "sns_key" {
   count       = var.kms_master_key_id == null ? 1 : 0
   description = "SNS Key for ${var.name}"
-  policy      = data.aws_iam_policy_document.kms_policies.json
+  policy      = data.aws_iam_policy_document.kms_policies.statement == null ? null : data.aws_iam_policy_document.kms_policies.statement.json
 }

--- a/sns/main.tf
+++ b/sns/main.tf
@@ -55,19 +55,19 @@ data "aws_iam_policy_document" "kms_policies" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+      identifiers = [data.aws_caller_identity.current.account_id]
     }
   }
 
   dynamic "statement" {
-    for_each = var.kms_event_sources
+    for_each = [var.kms_event_sources]
 
     content {
       effect = "Allow"
 
       principals {
         type        = "Service"
-        identifiers = [statement.value]
+        identifiers = statement.value
       }
 
       actions = [
@@ -88,14 +88,14 @@ data "aws_iam_policy_document" "kms_policies" {
   }
 
   dynamic "statement" {
-    for_each = var.kms_iam_sources
+    for_each = [var.kms_iam_sources]
 
     content {
       effect = "Allow"
 
       principals {
         type        = "AWS"
-        identifiers = [statement.value]
+        identifiers = statement.value
       }
 
       actions = [

--- a/sns/main.tf
+++ b/sns/main.tf
@@ -97,5 +97,5 @@ data "aws_iam_policy_document" "kms_policies" {
 resource "aws_kms_key" "sns_key" {
   count       = var.kms_master_key_id == null ? 1 : 0
   description = "SNS Key for ${var.name}"
-  policy      = length(data.aws_iam_policy_document.kms_policies.statement) == 0 ? null : data.aws_iam_policy_document.kms_policies.json
+  policy      = data.aws_iam_policy_document.kms_policies.statement == null ? null : data.aws_iam_policy_document.kms_policies.json
 }

--- a/sns/main.tf
+++ b/sns/main.tf
@@ -97,5 +97,5 @@ data "aws_iam_policy_document" "kms_policies" {
 resource "aws_kms_key" "sns_key" {
   count       = var.kms_master_key_id == null ? 1 : 0
   description = "SNS Key for ${var.name}"
-  policy      = data.aws_iam_policy_document.kms_policies.statement == null ? null : data.aws_iam_policy_document.kms_policies.statement.json
+  policy      = length(data.aws_iam_policy_document.kms_policies.statement) == 0 ? null : data.aws_iam_policy_document.kms_policies.statement.json
 }

--- a/sns/main.tf
+++ b/sns/main.tf
@@ -36,6 +36,25 @@ resource "aws_sns_topic" "this" {
 
 
 data "aws_iam_policy_document" "kms_policies" {
+
+  statement {
+
+    effect = "Allow"
+
+    actions = [
+      "kms:*"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+
   dynamic "statement" {
     for_each = var.kms_event_sources
 
@@ -97,5 +116,5 @@ data "aws_iam_policy_document" "kms_policies" {
 resource "aws_kms_key" "sns_key" {
   count       = var.kms_master_key_id == null ? 1 : 0
   description = "SNS Key for ${var.name}"
-  policy      = data.aws_iam_policy_document.kms_policies.statement == null ? null : data.aws_iam_policy_document.kms_policies.json
+  policy      = data.aws_iam_policy_document.kms_policies.json
 }

--- a/sns/main.tf
+++ b/sns/main.tf
@@ -60,9 +60,9 @@ data "aws_iam_policy_document" "kms_policies" {
     ]
 
     condition {
-      test = "StringLike"
+      test     = "StringLike"
       variable = "AWS:SourceArn"
-      values = [data.aws_caller_identity.current.account_id]
+      values   = [data.aws_caller_identity.current.account_id]
     }
   }
 }

--- a/sns/main.tf
+++ b/sns/main.tf
@@ -18,7 +18,7 @@ resource "aws_sns_topic" "this" {
   http_success_feedback_role_arn           = var.http_success_feedback_role_arn
   http_success_feedback_sample_rate        = var.http_success_feedback_sample_rate
   http_failure_feedback_role_arn           = var.http_failure_feedback_role_arn
-  kms_master_key_id                        = var.kms_master_key_id == null ? aws_kms_key.sns_key.arn : var.kms_master_key_id
+  kms_master_key_id                        = var.kms_master_key_id == null ? aws_kms_key.sns_key[0].arn : var.kms_master_key_id
   fifo_topic                               = var.fifo_topic
   content_based_deduplication              = var.content_based_deduplication
   lambda_success_feedback_role_arn         = var.lambda_success_feedback_role_arn

--- a/sns/main.tf
+++ b/sns/main.tf
@@ -1,7 +1,11 @@
 /* # SNS
 *
-*  A wrapper on the SNS module that enfores a customer managed KMS key
-*
+* A wrapper on the SNS module that enfores a customer managed KMS key. You can either supply
+* your own KMS ARN as `kms_master_key_id` or let the module create their own key. If you choose
+* to let the module create a KMS key it will also include an IAM policy that allows access from the
+* root user of the account. You can also supply service like `s3.amazonaws.com` or `sns.amazonaws.com`
+* in the `kms_event_sources` list, as well as IAM roles in the `kms_iam_sources` list who will then have 
+* `kms:Decrypt*` and `kms:GenerateDataKey*` permissions on the key.
 */
 
 data "aws_caller_identity" "current" {}

--- a/sns/main.tf
+++ b/sns/main.tf
@@ -68,7 +68,7 @@ data "aws_iam_policy_document" "kms_policies" {
 }
 
 resource "aws_kms_key" "sns_key" {
-  count       = var.kms_master_key_id == null ? 0 : 1
+  count       = var.kms_master_key_id == null ? 1 : 0
   description = "SNS Key for ${var.name}"
   policy      = data.aws_iam_policy_document.kms_policies.json
 }

--- a/sns/output.tf
+++ b/sns/output.tf
@@ -8,7 +8,7 @@ output "sns_arn" {
   value       = aws_sns_topic.this.arn
 }
 
-output "kms_key_id" {
-  description = "KMS Key ID used for SNS"
+output "kms_key_arn" {
+  description = "KMS Key ARN used for SNS"
   value       = aws_sns_topic.kms_master_key_id
 }

--- a/sns/output.tf
+++ b/sns/output.tf
@@ -10,5 +10,5 @@ output "sns_arn" {
 
 output "kms_key_arn" {
   description = "KMS Key ARN used for SNS"
-  value       = aws_sns_topic.kms_master_key_id
+  value       = aws_sns_topic.this.kms_master_key_id
 }

--- a/sns/output.tf
+++ b/sns/output.tf
@@ -10,5 +10,5 @@ output "sns_arn" {
 
 output "kms_key_id" {
   description = "KMS Key ID used for SNS"
-  value       = aws_sns_topic.kms_master_key_id.id
+  value       = aws_sns_topic.kms_master_key_id
 }

--- a/sns/output.tf
+++ b/sns/output.tf
@@ -1,0 +1,14 @@
+output "sns_id" {
+  description = "The name of the SNS topic."
+  value       = aws_sns_topic.this.id
+}
+
+output "sns_arn" {
+  description = "The ARN of the SNS topic."
+  value       = aws_sns_topic.this.arn
+}
+
+output "kms_key_id" {
+  description = "KMS Key ID used for SNS"
+  value       = aws_sns_topic.kms_master_key_id.id
+}


### PR DESCRIPTION
Closes #40. This PR adds a SNS module that enforces the use of a customer managed KMS key with the correct settings for service and IAM users.

Description: A wrapper on the SNS module that enfores a customer managed KMS key. You can either supply your own KMS ARN as `kms_master_key_id` or let the module create their own key. If you choose to let the module create a KMS key it will also include an IAM policy that allows access from the root user of the account. You can also supply service like `s3.amazonaws.com` or `sns.amazonaws.com` in the `kms_event_sources` list, as well as IAM roles in the `kms_iam_sources` list who will then have  `kms:Decrypt*` and `kms:GenerateDataKey*` permissions on the key.