### PR TITLE
feat: output vpc subnet cidr blocks

### DIFF
--- a/gh_oidc_role/README.md
+++ b/gh_oidc_role/README.md
@@ -10,7 +10,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.70.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.72.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 3.1.0 |
 
 ## Modules

--- a/vpc/README.md
+++ b/vpc/README.md
@@ -28,7 +28,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.65.0 |
 
 ## Modules
 
@@ -98,7 +98,9 @@ No modules.
 | <a name="output_main_nacl_id"></a> [main\_nacl\_id](#output\_main\_nacl\_id) | n/a |
 | <a name="output_main_route_table_id"></a> [main\_route\_table\_id](#output\_main\_route\_table\_id) | n/a |
 | <a name="output_private_route_table_ids"></a> [private\_route\_table\_ids](#output\_private\_route\_table\_ids) | n/a |
+| <a name="output_private_subnet_cidr_blocks"></a> [private\_subnet\_cidr\_blocks](#output\_private\_subnet\_cidr\_blocks) | n/a |
 | <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | n/a |
 | <a name="output_public_ips"></a> [public\_ips](#output\_public\_ips) | n/a |
+| <a name="output_public_subnet_cidr_blocks"></a> [public\_subnet\_cidr\_blocks](#output\_public\_subnet\_cidr\_blocks) | n/a |
 | <a name="output_public_subnet_ids"></a> [public\_subnet\_ids](#output\_public\_subnet\_ids) | n/a |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | n/a |

--- a/vpc/outputs.tf
+++ b/vpc/outputs.tf
@@ -14,8 +14,16 @@ output "public_subnet_ids" {
   value = aws_subnet.public.*.id
 }
 
+output "public_subnet_cidr_blocks" {
+  value = aws_subnet.public.*.cidr_block
+}
+
 output "private_subnet_ids" {
   value = aws_subnet.private.*.id
+}
+
+output "private_subnet_cidr_blocks" {
+  value = aws_subnet.private.*.cidr_block
 }
 
 output "private_route_table_ids" {


### PR DESCRIPTION
Access to cidr blocks to be used in security groups that are behind a network load balancing. cidr blocks needed since network load balancers don't support security groups.