### PR TITLE
feat: provide cidr and private/public subnets for vpc

### DIFF
--- a/vpc/README.md
+++ b/vpc/README.md
@@ -85,10 +85,13 @@ No modules.
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_block_rdp"></a> [block\_rdp](#input\_block\_rdp) | (Optional, default 'true') Whether or not to block Port 3389 | `bool` | `true` | no |
 | <a name="input_block_ssh"></a> [block\_ssh](#input\_block\_ssh) | (Optional, default 'true') Whether or not to block Port 22 | `bool` | `true` | no |
+| <a name="input_cidr"></a> [cidr](#input\_cidr) | (Optional, default '10.0.0.0/16') The CIDR block for the VPC | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_enable_eip"></a> [enable\_eip](#input\_enable\_eip) | (Optional, default 'true') Enables Elastic IPs, disabling is mainly used for testing purposes | `bool` | `true` | no |
 | <a name="input_enable_flow_log"></a> [enable\_flow\_log](#input\_enable\_flow\_log) | (Optional, default 'false') Whether or not to enable VPC Flow Logs | `bool` | `false` | no |
 | <a name="input_high_availability"></a> [high\_availability](#input\_high\_availability) | (Optional, default 'false') Create 3 public and 3 private subnets across 3 availability zones in the region. | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | (Required) The name of the vpc | `string` | n/a | yes |
+| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | (Optional, default []) A list of private subnets inside the VPC | `list(string)` | `[]` | no |
+| <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | (Optional, default []) A list of public subnets inside the VPC | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/vpc/examples/custom_cidr_and_subnets/main.tf
+++ b/vpc/examples/custom_cidr_and_subnets/main.tf
@@ -1,0 +1,22 @@
+# VPC for development work that creates one subnet 
+# in the region's first availability zone
+module "custom_cidr_and_subnets_vpc" {
+  source = "../../"
+  name   = "custom_cidr_and_subnets"
+
+  cidr              = "172.16.0.0/16"
+  public_subnets    = ["172.16.0.0/20", "172.16.16.0/20", "172.16.32.0/20"]
+  private_subnets   = ["172.16.128.0/20", "172.16.144.0/20", "172.16.160.0/20"]
+  high_availability = true
+  enable_flow_log   = true
+  block_ssh         = true
+  block_rdp         = true
+  enable_eip        = false
+
+  billing_tag_key   = "Business Unit"
+  billing_tag_value = "Operations"
+}
+
+output "vpc_id" {
+  value = module.custom_cidr_and_subnets_vpc.vpc_id
+}

--- a/vpc/examples/custom_cidr_and_subnets/main.tf
+++ b/vpc/examples/custom_cidr_and_subnets/main.tf
@@ -1,5 +1,4 @@
-# VPC for development work that creates one subnet 
-# in the region's first availability zone
+# VPC for work that requires custom cidr and private/subnet ranges
 module "custom_cidr_and_subnets_vpc" {
   source = "../../"
   name   = "custom_cidr_and_subnets"

--- a/vpc/examples/custom_cidr_and_subnets/provider.tf
+++ b/vpc/examples/custom_cidr_and_subnets/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "ca-central-1"
+}

--- a/vpc/inputs.tf
+++ b/vpc/inputs.tf
@@ -68,3 +68,21 @@ variable "allow_https_request_in_response" {
   type        = bool
   default     = false
 }
+
+variable "cidr" {
+  description = "(Optional, default '10.0.0.0/16') The CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnets" {
+  description = "(Optional, default []) A list of public subnets inside the VPC"
+  type        = list(string)
+  default     = []
+}
+
+variable "private_subnets" {
+  description = "(Optional, default []) A list of private subnets inside the VPC"
+  type        = list(string)
+  default     = []
+}

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -61,7 +61,7 @@ resource "aws_subnet" "private" {
   count             = local.max_subnet_length
   vpc_id            = aws_vpc.main.id
   availability_zone = element(local.zone_names, count.index)
-  cidr_block        = length(var.private_subnets) == 0 ? var.high_availability ? cidrsubnet(aws_vpc.main.cidr_block, 8, count.index) : cidrsubnet(aws_vpc.main.cidr_block, 10, 0) : var.private_subnets
+  cidr_block        = length(var.private_subnets) == 0 ? var.high_availability ? cidrsubnet(aws_vpc.main.cidr_block, 8, count.index) : cidrsubnet(aws_vpc.main.cidr_block, 10, 0) : element(var.private_subnets, count.index)
 
   tags = merge(local.common_tags, {
     Name = "${var.name}_private_subnet_${element(local.zone_names, count.index)}"
@@ -77,7 +77,7 @@ resource "aws_subnet" "public" {
   count             = local.max_subnet_length
   vpc_id            = aws_vpc.main.id
   availability_zone = element(local.zone_names, count.index)
-  cidr_block        = length(var.public_subnets) == 0 ? var.high_availability ? cidrsubnet(aws_vpc.main.cidr_block, 8, count.index + local.max_subnet_length) : cidrsubnet(aws_vpc.main.cidr_block, 10, 1) : var.public_subnets
+  cidr_block        = length(var.public_subnets) == 0 ? var.high_availability ? cidrsubnet(aws_vpc.main.cidr_block, 8, count.index + local.max_subnet_length) : cidrsubnet(aws_vpc.main.cidr_block, 10, 1) : element(var.public_subnets, count.index)
 
   tags = merge(local.common_tags, {
     Name = "${var.name}_public_subnet_${element(local.zone_names, count.index)}"

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -24,7 +24,7 @@
 */
 
 resource "aws_vpc" "main" {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = var.cidr
   enable_dns_support   = true
   enable_dns_hostnames = true
 
@@ -61,7 +61,7 @@ resource "aws_subnet" "private" {
   count             = local.max_subnet_length
   vpc_id            = aws_vpc.main.id
   availability_zone = element(local.zone_names, count.index)
-  cidr_block        = var.high_availability ? cidrsubnet(aws_vpc.main.cidr_block, 8, count.index) : cidrsubnet(aws_vpc.main.cidr_block, 10, 0)
+  cidr_block        = length(var.private_subnets) == 0 ? var.high_availability ? cidrsubnet(aws_vpc.main.cidr_block, 8, count.index) : cidrsubnet(aws_vpc.main.cidr_block, 10, 0) : var.private_subnets
 
   tags = merge(local.common_tags, {
     Name = "${var.name}_private_subnet_${element(local.zone_names, count.index)}"
@@ -77,7 +77,7 @@ resource "aws_subnet" "public" {
   count             = local.max_subnet_length
   vpc_id            = aws_vpc.main.id
   availability_zone = element(local.zone_names, count.index)
-  cidr_block        = var.high_availability ? cidrsubnet(aws_vpc.main.cidr_block, 8, count.index + local.max_subnet_length) : cidrsubnet(aws_vpc.main.cidr_block, 10, 1)
+  cidr_block        = length(var.public_subnets) == 0 ? var.high_availability ? cidrsubnet(aws_vpc.main.cidr_block, 8, count.index + local.max_subnet_length) : cidrsubnet(aws_vpc.main.cidr_block, 10, 1) : var.public_subnets
 
   tags = merge(local.common_tags, {
     Name = "${var.name}_public_subnet_${element(local.zone_names, count.index)}"

--- a/vpc/test/custom_cidr_and_subnets_test.go
+++ b/vpc/test/custom_cidr_and_subnets_test.go
@@ -31,5 +31,5 @@ func TestCustomCIDRandSubnetsVpc(t *testing.T) {
 	vpc := aws.GetVpcById(t, vpcId, region)
 
 	// 3 private + 3 public subnet
-	assert.Equal(t, 6, len(vpc.Subnets)
+	assert.Equal(t, 6, len(vpc.Subnets))
 }

--- a/vpc/test/custom_cidr_and_subnets_test.go
+++ b/vpc/test/custom_cidr_and_subnets_test.go
@@ -1,0 +1,35 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomCIDRandSubnetsVpc(t *testing.T) {
+	t.Parallel()
+
+	region := "ca-central-1"
+	availabilityZone := region + "a"
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: "../examples/custom_cidr_and_subnets",
+		EnvVars: map[string]string{
+			"AWS_DEFAULT_REGION": region,
+		},
+	}
+
+	// Destroy resource once tests are finished
+	defer terraform.Destroy(t, terraformOptions)
+
+	// Create the resources
+	terraform.InitAndApply(t, terraformOptions)
+
+	vpcId := terraform.Output(t, terraformOptions, "vpc_id")
+	vpc := aws.GetVpcById(t, vpcId, region)
+
+	// 3 private + 3 public subnet
+	assert.Equal(t, 6, len(vpc.Subnets)
+}

--- a/vpc/test/custom_cidr_and_subnets_test.go
+++ b/vpc/test/custom_cidr_and_subnets_test.go
@@ -12,7 +12,6 @@ func TestCustomCIDRandSubnetsVpc(t *testing.T) {
 	t.Parallel()
 
 	region := "ca-central-1"
-	availabilityZone := region + "a"
 
 	terraformOptions := &terraform.Options{
 		TerraformDir: "../examples/custom_cidr_and_subnets",


### PR DESCRIPTION
Ability to provide specific CIDR and public/private subnets when creating a VPC. Feature required since VPC peering does not allow overlapping CIDR ranges between the two VPC's being peered.