### PR TITLE
feat: add guardduty and guardduty member modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ test.tf
 # Python
 .pytest_cache
 __pycache__
+
+.github/workflows/conftest/policy

--- a/.modules
+++ b/.modules
@@ -1,1 +1,1 @@
-rds S3 S3_log_bucket user_login_alarm vpc lambda gh_oidc_role attach_tf_plan_policy sentinel_forwarder aws_goc_password_policy sns
+rds S3 S3_log_bucket user_login_alarm vpc lambda gh_oidc_role attach_tf_plan_policy sentinel_forwarder aws_goc_password_policy sns guardduty guardduty_member

--- a/gh_oidc_role/main.tf
+++ b/gh_oidc_role/main.tf
@@ -2,6 +2,7 @@
 * # gh_oicd_role
 * Creates an OpenID Connect Role that can be used for authenticating workflows in Github Actions
 * This allows for a more secure way to connect to AWS as it doesn't rely on static credentials but uses temporary credentials created for each run.
+* 
 */
 
 

--- a/guardduty/Makefile
+++ b/guardduty/Makefile
@@ -1,0 +1,7 @@
+.PHONY: fmt docs
+
+fmt:
+	@terraform fmt -recursive
+
+docs:
+	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/guardduty/README.md
+++ b/guardduty/README.md
@@ -1,0 +1,45 @@
+Adapted from https://github.com/aws-samples/amazon-guardduty-for-aws-organizations-with-terraform
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws.guardduty_region"></a> [aws.guardduty\_region](#provider\_aws.guardduty\_region) | n/a |
+| <a name="provider_aws.guarduty_region"></a> [aws.guarduty\_region](#provider\_aws.guarduty\_region) | n/a |
+| <a name="provider_aws.management_region"></a> [aws.management\_region](#provider\_aws.management\_region) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_guardduty_detector.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector) | resource |
+| [aws_guardduty_organization_admin_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_admin_account) | resource |
+| [aws_guardduty_organization_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration) | resource |
+| [aws_guardduty_publishing_destination.pub_dest](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_publishing_destination) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
+| <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
+| <a name="input_delegated_admin_account_id"></a> [delegated\_admin\_account\_id](#input\_delegated\_admin\_account\_id) | The account id of the delegated admin. | `string` | n/a | yes |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | (Required) The KMS key to encrypt findings in the S3 bucket | `string` | n/a | yes |
+| <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | The AWS organization to enable GuardDuty in. | `string` | n/a | yes |
+| <a name="input_publishing_bucket_arn"></a> [publishing\_bucket\_arn](#input\_publishing\_bucket\_arn) | (Required) The ARN of the S3 bucket to publish findings to | `string` | n/a | yes |
+| <a name="input_publishing_frequency"></a> [publishing\_frequency](#input\_publishing\_frequency) | Specifies the frequency of notifications sent for subsequent finding occurrences. | `string` | `"FIFTEEN_MINUTES"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Key-value map of resource tags. If configured with a provider default\_tags configuration block present,<br>  tags with matching keys will overwrite those defined at the provider-level." | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_guardduty_detector"></a> [guardduty\_detector](#output\_guardduty\_detector) | The GuardDuty detector. |

--- a/guardduty/input.tf
+++ b/guardduty/input.tf
@@ -1,0 +1,52 @@
+
+variable "billing_tag_key" {
+  description = "(Optional, default 'CostCentre') The name of the billing tag"
+  type        = string
+  default     = "CostCentre"
+}
+
+variable "billing_tag_value" {
+  description = "(Required) The value of the billing tag"
+  type        = string
+}
+
+variable "delegated_admin_account_id" {
+  description = "The account id of the delegated admin."
+  type        = string
+}
+
+variable "publishing_frequency" {
+  description = "Specifies the frequency of notifications sent for subsequent finding occurrences."
+  type        = string
+  default     = "FIFTEEN_MINUTES"
+}
+
+variable "tags" {
+  description = "Specifies object tags key and value. This applies to all resources created by this module."
+  type        = map(string)
+  default     = {}
+}
+
+variable "organization_id" {
+  description = "The AWS organization to enable GuardDuty in."
+  type        = string
+}
+
+variable "publishing_bucket_arn" {
+  description = "(Required) The ARN of the S3 bucket to publish findings to"
+  type        = string
+}
+
+variable "kms_key_arn" {
+  description = "(Required) The KMS key to encrypt findings in the S3 bucket"
+  type        = string
+}
+
+variable "tags" {
+  description = <<EOF
+  (Optional) Key-value map of resource tags. If configured with a provider default_tags configuration block present,
+  tags with matching keys will overwrite those defined at the provider-level."
+  EOF
+  type        = map(string)
+  default     = {}
+}

--- a/guardduty/locals.tf
+++ b/guardduty/locals.tf
@@ -1,0 +1,10 @@
+
+locals {
+  common_tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = "true"
+  }
+
+  # tags = merge(var.tags, common_tags)
+}
+

--- a/guardduty/main.tf
+++ b/guardduty/main.tf
@@ -1,0 +1,56 @@
+/* # guardduty
+* Adapted from https://github.com/aws-samples/amazon-guardduty-for-aws-organizations-with-terraform
+*/
+
+# GuardDuty Detector in the Delegated admin account
+resource "aws_guardduty_detector" "this" {
+  provider   = aws.guardduty_region
+  depends_on = [var.organization_id]
+
+  enable                       = true
+  finding_publishing_frequency = var.publishing_frequency
+
+  # Additional setting to turn on S3 Protection
+  datasources {
+    s3_logs {
+      enable = true
+    }
+  }
+  tags = merge(var.tags, local.common_tags)
+}
+
+# Organization GuardDuty configuration in the Management account
+resource "aws_guardduty_organization_admin_account" "this" {
+  provider = aws.management_region
+
+  depends_on = [aws_guardduty_detector.this]
+
+  admin_account_id = var.delegated_admin_account_id
+}
+
+# Organization GuardDuty configuration in the Delegated admin account
+resource "aws_guardduty_organization_configuration" "this" {
+  provider = aws.guarduty_region
+
+  depends_on = [aws_guardduty_organization_admin_account.this]
+
+  auto_enable = true
+  detector_id = aws_guardduty_detector.this.id
+
+  # Additional setting to turn on S3 Protection
+  datasources {
+    s3_logs {
+      auto_enable = true
+    }
+  }
+}
+
+# GuardDuty Publishing destination in the Delegated admin account
+resource "aws_guardduty_publishing_destination" "pub_dest" {
+  provider   = aws.guardduty_region
+  depends_on = [aws_guardduty_organization_admin_account.this]
+
+  detector_id     = aws_guardduty_detector.this.id
+  destination_arn = var.publishing_bucket_arn
+  kms_key_arn     = var.kms_key_arn
+}

--- a/guardduty/output.tf
+++ b/guardduty/output.tf
@@ -1,0 +1,4 @@
+output "guardduty_detector" {
+  description = "The GuardDuty detector."
+  value       = aws_guardduty_detector.this.id
+}

--- a/guardduty/providers.tf
+++ b/guardduty/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  alias = "management_region"
+}
+
+provider "aws" {
+  alias = "guardduty_region"
+}

--- a/guardduty_member/Makefile
+++ b/guardduty_member/Makefile
@@ -1,0 +1,7 @@
+.PHONY: fmt docs
+
+fmt:
+	@terraform fmt -recursive
+
+docs:
+	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/guardduty_member/README.md
+++ b/guardduty_member/README.md
@@ -1,0 +1,38 @@
+This is only needed for enrolling accounts to Guardduty that were created before Guarduty was enabled.
+New accounts will be auto-enrolled by default if it was configured or if our Guardduty module was used.
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws.member_role"></a> [aws.member\_role](#provider\_aws.member\_role) | n/a |
+| <a name="provider_aws.primary_role"></a> [aws.primary\_role](#provider\_aws.primary\_role) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_guardduty_invite_accepter.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_invite_accepter) | resource |
+| [aws_guardduty_member.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_member) | resource |
+| [aws_caller_identity.member](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.primary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_guardduty_detector.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/guardduty_detector) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
+| <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.

--- a/guardduty_member/input.tf
+++ b/guardduty_member/input.tf
@@ -1,0 +1,12 @@
+
+variable "billing_tag_key" {
+  description = "(Optional, default 'CostCentre') The name of the billing tag"
+  type        = string
+  default     = "CostCentre"
+}
+
+variable "billing_tag_value" {
+  description = "(Required) The value of the billing tag"
+  type        = string
+}
+

--- a/guardduty_member/locals.tf
+++ b/guardduty_member/locals.tf
@@ -1,0 +1,8 @@
+
+locals {
+  common_tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = "true"
+  }
+}
+

--- a/guardduty_member/main.tf
+++ b/guardduty_member/main.tf
@@ -1,0 +1,43 @@
+/* # guardduty_member
+* This is only needed for enrolling accounts to Guardduty that were created before Guarduty was enabled.
+* New accounts will be auto-enrolled by default if it was configured or if our Guardduty module was used.
+*/
+
+data "aws_guardduty_detector" "this" {
+  provider = aws.primary_role
+}
+
+data "aws_caller_identity" "member" {
+  provider = aws.member_role
+}
+
+data "aws_caller_identity" "primary" {
+  provider = aws.primary_role
+}
+
+# The guardduty delegated admin account is where the member is registered and invited from.
+resource "aws_guardduty_member" "this" {
+  provider = aws.primary_role
+
+  detector_id = data.aws_guardduty_detector.this.id
+  account_id  = data.aws_caller_identity.member.account_id
+  invite      = true
+
+  email                      = data.aws_caller_identity.member.account_email
+  disable_email_notification = true
+
+  lifecycle {
+    ignore_changes = [
+      email
+    ]
+  }
+}
+
+# Accepting the invite needs to occur in the member account
+resource "aws_guardduty_invite_accepter" "this" {
+  depends_on = [aws_guardduty_member.this]
+  provider   = aws.member_role
+
+  detector_id       = data.aws_guardduty_detector.this.id
+  master_account_id = data.aws_caller_identity.primary.account_id
+}

--- a/guardduty_member/providers.tf
+++ b/guardduty_member/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  alias = "guardduty_role"
+}
+
+provider "aws" {
+  alias = "member_role"
+}


### PR DESCRIPTION
# Summary | Résumé

Adds a module that enables guardduty in a region and setups a
delegated admin account with a detector in it.

Adds a module that adds a member account, this is only needed for
accounts created before the guardduty module was created.

Ignore the downloaded conftest policies

*****Please note this may not work so expect potential follow up PRs**

