### PR TITLE
fix: remove TF modules AWS account from blocklist

### DIFF
--- a/.github/workflows/assets/aws-nuke-config.yml
+++ b/.github/workflows/assets/aws-nuke-config.yml
@@ -95,7 +95,6 @@ resource-types:
 # Accounts that will not have resources removed
 account-blocklist:
 - "005133826942"
-- "124044056575"
 - "136676205420"
 - "239043911459"
 - "276192857112"


### PR DESCRIPTION
# Summary
Remove the Terraform modules AWS account from the `aws-nuke`
blocklist since this is preventing the workflow from running properly.