### PR TITLE
feat!: Upgrade required AWS Version

### DIFF
--- a/.github/workflows/conftest/test_plan.tf
+++ b/.github/workflows/conftest/test_plan.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.14"
+      version = ">= 4.9.0, < 5"
     }
 
   }

--- a/S3/versions.tf
+++ b/S3/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.26"
 
   required_providers {
-    aws = ">= 3.36, < 4"
+    aws = ">= 4.9.0, < 5"
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Upgrading s3 aws provider as AFT Module requires > 4.9.0

BREAKING CHANGE: Upgrading major version of AWS Provider


