### PR TITLE
fix: s3_log_bucket required providers

### DIFF
--- a/S3_log_bucket/versions.tf
+++ b/S3_log_bucket/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.26"
 
   required_providers {
-    aws = ">= 3.36, < 4"
+    aws = ">= 4.9.0, < 5"
   }
 }


### PR DESCRIPTION
# Summary | Résumé

We missed upgrading the required providers for the s3 log bucket module.

This brings it in line with all the other modules in the repo.


