### PR TITLE
feat: Lambda function role ARN output

### DIFF
--- a/lambda/README.md
+++ b/lambda/README.md
@@ -66,6 +66,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_function_arn"></a> [function\_arn](#output\_function\_arn) | n/a |
-| <a name="output_function_name"></a> [function\_name](#output\_function\_name) | n/a |
-| <a name="output_invoke_arn"></a> [invoke\_arn](#output\_invoke\_arn) | n/a |
+| <a name="output_function_arn"></a> [function\_arn](#output\_function\_arn) | ARN of the Lambda function. |
+| <a name="output_function_name"></a> [function\_name](#output\_function\_name) | Name of the Lambda function. |
+| <a name="output_function_role_arn"></a> [function\_role\_arn](#output\_function\_role\_arn) | ARN of the Lambda function execution role. |
+| <a name="output_invoke_arn"></a> [invoke\_arn](#output\_invoke\_arn) | ARN used to invoke the Lambda function. |

--- a/lambda/output.tf
+++ b/lambda/output.tf
@@ -1,11 +1,19 @@
 output "function_arn" {
-  value = aws_lambda_function.this.arn
+  description = "ARN of the Lambda function."
+  value       = aws_lambda_function.this.arn
 }
 
 output "function_name" {
-  value = aws_lambda_function.this.function_name
+  description = "Name of the Lambda function."
+  value       = aws_lambda_function.this.function_name
+}
+
+output "function_role_arn" {
+  description = "ARN of the Lambda function execution role."
+  value       = aws_iam_role.this.arn
 }
 
 output "invoke_arn" {
-  value = aws_lambda_function.this.invoke_arn
+  description = "ARN used to invoke the Lambda function."
+  value       = aws_lambda_function.this.invoke_arn
 }


### PR DESCRIPTION
# Summary 
Add the Lambda function role ARN to the module's outputs.
This ARN can then be used for IAM resource and permission
policies.