### PR TITLE
chore: update default S3 scan object Docker image

### DIFF
--- a/S3_scan_object/README.md
+++ b/S3_scan_object/README.md
@@ -1,11 +1,15 @@
 # S3\_scan\_object
-Lambda function that triggers a [scan](https://scan-files.alpha.canada.ca) of newly created S3 objects and updates the object with the scan results via an SNS topic subscription.
+Lambda function that triggers a [ClamAV scan](https://scan-files.alpha.canada.ca) of newly created S3 objects and updates the object with the scan results via an SNS topic subscription.
 
 The function is invoked by `s3:ObjectCreated:*` events and messages published to its SNS `s3-object-scan-complete` topic.
 
 ## ⚠️ Notes
-- You will need a Scan Files API key to use this module.
-- Your AWS account must be part of our organization to use the default `lambda_ecr_arn` and `lambda_image_uri`.  To work around this, you can build your own Docker image using the code in [cds-snc/scan-files/module/s3-scan-object](https://github.com/cds-snc/scan-files/tree/main/module/s3-scan-object).
+- To use the default values for the following variables, your account must be part of our AWS organization:
+   - `lambda_ecr_arn`
+   - `lambda_image_uri`
+   - `scan_files_api_key_kms_arn`
+   - `scan_files_api_key_secret_arn`
+- You can build your own Lambda Docker image using the code in [cds-snc/scan-files/module/s3-scan-object](https://github.com/cds-snc/scan-files/tree/main/module/s3-scan-object).
 
 ## Requirements
 
@@ -21,7 +25,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_s3_scan_object"></a> [s3\_scan\_object](#module\_s3\_scan\_object) | github.com/cds-snc/terraform-modules | v3.0.2//lambda |
+| <a name="module_s3_scan_object"></a> [s3\_scan\_object](#module\_s3\_scan\_object) | github.com/cds-snc/terraform-modules | v3.0.4//lambda |
 | <a name="module_upload_bucket"></a> [upload\_bucket](#module\_upload\_bucket) | github.com/cds-snc/terraform-modules | v2.0.5//S3 |
 
 ## Resources
@@ -57,13 +61,13 @@ No requirements.
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_lambda_ecr_arn"></a> [lambda\_ecr\_arn](#input\_lambda\_ecr\_arn) | (Optional, default Scan Files ECR) ARN of the ECR used to pull the Lambda image | `string` | `"arn:aws:ecr:ca-central-1:806545929748:scan-files/module/s3-scan-object"` | no |
-| <a name="input_lambda_image_uri"></a> [lambda\_image\_uri](#input\_lambda\_image\_uri) | (Optional, default Scan Files ECR latest Docker image) The URI of the Lambda image | `string` | `"806545929748.dkr.ecr.ca-central-1.amazonaws.com/scan-files/module/s3-scan-object:6944b6fc5ab1127480cdb59e3ca1f94ca3395610"` | no |
+| <a name="input_lambda_image_uri"></a> [lambda\_image\_uri](#input\_lambda\_image\_uri) | (Optional, default Scan Files ECR latest Docker image) The URI of the Lambda image | `string` | `"806545929748.dkr.ecr.ca-central-1.amazonaws.com/scan-files/module/s3-scan-object:17644e2436b233e25b3b4630fc65e7e46c04a031"` | no |
 | <a name="input_product_name"></a> [product\_name](#input\_product\_name) | (Required) Name of the product using the module | `string` | n/a | yes |
 | <a name="input_s3_upload_bucket_create"></a> [s3\_upload\_bucket\_create](#input\_s3\_upload\_bucket\_create) | (Optional, default 'true') Create an S3 bucket to upload files to. | `bool` | `true` | no |
 | <a name="input_s3_upload_bucket_name"></a> [s3\_upload\_bucket\_name](#input\_s3\_upload\_bucket\_name) | (Optional, default null) Name of the S3 upload bucket to scan objects in.  If `s3_upload_bucket_create` is `false` this must be an existing bucket in the account. | `string` | `null` | no |
 | <a name="input_s3_upload_bucket_policy_create"></a> [s3\_upload\_bucket\_policy\_create](#input\_s3\_upload\_bucket\_policy\_create) | (Optional, defaut 'true') Create the S3 upload bucket policy to allow Scan Files access. | `bool` | `true` | no |
 | <a name="input_scan_files_api_key_kms_arn"></a> [scan\_files\_api\_key\_kms\_arn](#input\_scan\_files\_api\_key\_kms\_arn) | (Optional, default Scan Files KMS key arn) ARN of the KMS key used to encrypt the scan\_files\_api\_key\_secret\_arn | `string` | `"arn:aws:kms:ca-central-1:806545929748:key/*"` | no |
-| <a name="input_scan_files_api_key_secret_arn"></a> [scan\_files\_api\_key\_secret\_arn](#input\_scan\_files\_api\_key\_secret\_arn) | (Optional, default Scan Files secret arn) ARN of the SecretsManager secret that contains the Scan Files API key | `string` | `"arn:aws:secretsmanager:ca-central-1:806545929748:secret:/scan-files/*"` | no |
+| <a name="input_scan_files_api_key_secret_arn"></a> [scan\_files\_api\_key\_secret\_arn](#input\_scan\_files\_api\_key\_secret\_arn) | (Optional, default Scan Files secret arn) ARN of the SecretsManager secret that contains the Scan Files API key | `string` | `"arn:aws:secretsmanager:ca-central-1:806545929748:secret:/scan-files/api_auth_token-1tLf9T"` | no |
 | <a name="input_scan_files_assume_role_create"></a> [scan\_files\_assume\_role\_create](#input\_scan\_files\_assume\_role\_create) | (Optional, default 'true') Create the IAM role that Scan Files assumes.  Defaults to `true`.  If this is set to `false`, it is assumed that the role already exists in the account. | `bool` | `true` | no |
 | <a name="input_scan_files_role_arn"></a> [scan\_files\_role\_arn](#input\_scan\_files\_role\_arn) | (Optional, default Scan Files API role) Scan Files lambda execution role ARN | `string` | `"arn:aws:iam::806545929748:role/scan-files-api"` | no |
 | <a name="input_scan_files_url"></a> [scan\_files\_url](#input\_scan\_files\_url) | (Optional, default Scan Files production URL) Scan Files URL | `string` | `"https://scan-files.alpha.canada.ca"` | no |

--- a/S3_scan_object/input.tf
+++ b/S3_scan_object/input.tf
@@ -18,7 +18,7 @@ variable "lambda_ecr_arn" {
 
 variable "lambda_image_uri" {
   description = "(Optional, default Scan Files ECR latest Docker image) The URI of the Lambda image"
-  default     = "806545929748.dkr.ecr.ca-central-1.amazonaws.com/scan-files/module/s3-scan-object:6944b6fc5ab1127480cdb59e3ca1f94ca3395610"
+  default     = "806545929748.dkr.ecr.ca-central-1.amazonaws.com/scan-files/module/s3-scan-object:17644e2436b233e25b3b4630fc65e7e46c04a031"
   type        = string
 }
 

--- a/S3_scan_object/locals.tf
+++ b/S3_scan_object/locals.tf
@@ -1,8 +1,7 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  account_id      = data.aws_caller_identity.current.account_id
-  lambda_role_arn = "arn:aws:iam::${local.account_id}:role/${module.s3_scan_object.function_name}"
+  account_id = data.aws_caller_identity.current.account_id
 
   scan_files_assume_role_arn = var.scan_files_assume_role_create ? aws_iam_role.scan_files[0].arn : data.aws_iam_role.scan_files[0].arn
 

--- a/S3_scan_object/main.tf
+++ b/S3_scan_object/main.tf
@@ -1,16 +1,20 @@
 /* 
 * # S3_scan_object
-* Lambda function that triggers a [scan](https://scan-files.alpha.canada.ca) of newly created S3 objects and updates the object with the scan results via an SNS topic subscription.
+* Lambda function that triggers a [ClamAV scan](https://scan-files.alpha.canada.ca) of newly created S3 objects and updates the object with the scan results via an SNS topic subscription.
 * 
 * The function is invoked by `s3:ObjectCreated:*` events and messages published to its SNS `s3-object-scan-complete` topic.
 *
 * ## ⚠️ Notes
-* - You will need a Scan Files API key to use this module.
-* - Your AWS account must be part of our organization to use the default `lambda_ecr_arn` and `lambda_image_uri`.  To work around this, you can build your own Docker image using the code in [cds-snc/scan-files/module/s3-scan-object](https://github.com/cds-snc/scan-files/tree/main/module/s3-scan-object).
+* - To use the default values for the following variables, your account must be part of our AWS organization:
+*    - `lambda_ecr_arn`
+*    - `lambda_image_uri`
+*    - `scan_files_api_key_kms_arn`
+*    - `scan_files_api_key_secret_arn`
+* - You can build your own Lambda Docker image using the code in [cds-snc/scan-files/module/s3-scan-object](https://github.com/cds-snc/scan-files/tree/main/module/s3-scan-object).
 */
 
 module "s3_scan_object" {
-  source = "github.com/cds-snc/terraform-modules?ref=v3.0.2//lambda"
+  source = "github.com/cds-snc/terraform-modules?ref=v3.0.4//lambda"
 
   name      = "s3-scan-object-${var.product_name}"
   image_uri = var.lambda_image_uri

--- a/S3_scan_object/output.tf
+++ b/S3_scan_object/output.tf
@@ -1,6 +1,6 @@
 output "lambda_role_arn" {
   description = "ARN of the S3 scan object lambda role"
-  value       = local.lambda_role_arn
+  value       = module.s3_scan_object.function_role_arn
 }
 
 output "s3_upload_bucket_arn" {

--- a/S3_scan_object/s3.tf
+++ b/S3_scan_object/s3.tf
@@ -54,7 +54,7 @@ data "aws_iam_policy_document" "limit_tagging" {
     condition {
       test     = "StringNotLike"
       variable = "aws:PrincipalArn"
-      values   = [local.lambda_role_arn]
+      values   = [module.s3_scan_object.function_role_arn]
     }
   }
 
@@ -62,7 +62,7 @@ data "aws_iam_policy_document" "limit_tagging" {
     effect = "Allow"
     principals {
       type        = "AWS"
-      identifiers = [local.lambda_role_arn]
+      identifiers = [module.s3_scan_object.function_role_arn]
     }
     actions = [
       "s3:PutObjectTagging",


### PR DESCRIPTION
# Summary
1. Update to latest S3 scan object Docker image tag.
2. Use the Lambda module function role ARN output.

# Related
* cds-snc/forms-terraform#224