### PR TITLE
feat: add `RequestId` to forwarded event payload

### DIFF
--- a/S3_scan_object/lambda/main.py
+++ b/S3_scan_object/lambda/main.py
@@ -7,9 +7,10 @@ import boto3
 import logging
 import json
 import os
+import uuid
 
 ACCOUNT_ID=os.environ.get("ACCOUNT_ID")
-LOG_LEVEL=os.environ.get("LOG_LEVEL", logging.ERROR)
+LOG_LEVEL=os.environ.get("LOG_LEVEL", logging.INFO)
 S3_SCAN_OBJECT_FUNCTION_ARN=os.environ.get("S3_SCAN_OBJECT_FUNCTION_ARN")
 
 client = boto3.client("lambda")
@@ -18,14 +19,16 @@ logger.setLevel(LOG_LEVEL)
 
 def handler(event, context):
   event["AccountId"] = ACCOUNT_ID
-  logger.info(event)
+  event["RequestId"] = str(uuid.uuid4())
+  logger.debug(event)
 
+  logger.info(f"[{event['RequestId']}] Invoking {S3_SCAN_OBJECT_FUNCTION_ARN}")
   client_response = client.invoke(
     FunctionName=S3_SCAN_OBJECT_FUNCTION_ARN,
     Payload=json.dumps(event),
   )
   
   response = json.loads(client_response["Payload"].read().decode("utf-8"))
-  logger.info(response)
+  logger.debug(response)
 
   return response

--- a/S3_scan_object/lambda/main_test.py
+++ b/S3_scan_object/lambda/main_test.py
@@ -4,11 +4,12 @@ from unittest.mock import patch
 
 @patch("main.client")
 @patch("main.json.loads")
+@patch("main.uuid.uuid4", return_value="1234asdf-5678-ghjk-9012-qwer12324poiy5678")
 @patch("main.ACCOUNT_ID", "GeneralKenobi")
 @patch("main.S3_SCAN_OBJECT_FUNCTION_ARN", "arn:aws:lambda:ca-central-1:123456789012:function:anakin")
-def test_handler(mock_json_loads, mock_client):
+def test_handler(mock_uuid, mock_json_loads, mock_client):
   main.handler({"Hello": "There"}, None)
   mock_client.invoke.assert_called_with(
     FunctionName='arn:aws:lambda:ca-central-1:123456789012:function:anakin', 
-    Payload='{"Hello": "There", "AccountId": "GeneralKenobi"}'
+    Payload='{"Hello": "There", "AccountId": "GeneralKenobi", "RequestId": "1234asdf-5678-ghjk-9012-qwer12324poiy5678"}'
   )


### PR DESCRIPTION
# Summary
Add a `RequestId` UUID to the event used to invoke the `s3-scan-object`
lambda.  This will be used to track requests as they flow through the
different components of the system.

# Related
* cds-snc/forms-terraform#224