### PR TITLE
feat: add alarm for failed lambda invocations

### DIFF
--- a/S3_scan_object/.checkov.yml
+++ b/S3_scan_object/.checkov.yml
@@ -1,4 +1,6 @@
 skip-check:
+  - CKV_AWS_26  # SNS topic is an example and does not require encryption
   - CKV_AWS_116 # Lambda DLQ not required
   - CKV_AWS_117 # Lambda VPC not required
   - CKV_AWS_158 # CloudWatch service key encryption is acceptable
+  - CKV_AWS_173 # Lambda encryption settings for env vars are acceptable

--- a/S3_scan_object/README.md
+++ b/S3_scan_object/README.md
@@ -57,7 +57,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_alarm_sns_topic_arn"></a> [alarm\_sns\_topic\_arn](#input\_alarm\_sns\_topic\_arn) | (Optional) The SNS topic to send transport lambda alarm notifications to.  If not provided, no alarm is created. | `string` | `null` | no |
+| <a name="input_alarm_on_lambda_error"></a> [alarm\_on\_lambda\_error](#input\_alarm\_on\_lambda\_error) | (Optional) Create CloudWatch alarm if the transport lambda fails.  If `true`, you must also provide `alarm_sns_topic_arn`. | `bool` | `false` | no |
+| <a name="input_alarm_sns_topic_arn"></a> [alarm\_sns\_topic\_arn](#input\_alarm\_sns\_topic\_arn) | (Optional) The SNS topic to send transport lambda alarm notifications to. | `string` | `""` | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_product_name"></a> [product\_name](#input\_product\_name) | (Required) Name of the product using the module | `string` | n/a | yes |

--- a/S3_scan_object/README.md
+++ b/S3_scan_object/README.md
@@ -30,6 +30,8 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_cloudwatch_log_group.s3_scan_object](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_metric_filter.scan_files_lambda_error](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
+| [aws_cloudwatch_metric_alarm.scan_files_api_error](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_iam_policy.s3_scan_object](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.scan_files](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.s3_scan_object](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -55,6 +57,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_alarm_sns_topic_arn"></a> [alarm\_sns\_topic\_arn](#input\_alarm\_sns\_topic\_arn) | (Optional) The SNS topic to send transport lambda alarm notifications to.  If not provided, no alarm is created. | `string` | `null` | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_product_name"></a> [product\_name](#input\_product\_name) | (Required) Name of the product using the module | `string` | n/a | yes |

--- a/S3_scan_object/alarms.tf
+++ b/S3_scan_object/alarms.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "scan_files_lambda_error" {
-  count = var.alarm_sns_topic_arn != null ? 1 : 0
+  count = var.alarm_on_lambda_error ? 1 : 0
 
   name           = local.error_logged_lambda
   pattern        = "ERROR"
@@ -17,7 +17,7 @@ resource "aws_cloudwatch_log_metric_filter" "scan_files_lambda_error" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "scan_files_api_error" {
-  count = var.alarm_sns_topic_arn != null ? 1 : 0
+  count = var.alarm_on_lambda_error ? 1 : 0
 
   alarm_name          = local.error_logged_lambda
   alarm_description   = "Errors logged by the Scan Files transport lambda function"

--- a/S3_scan_object/alarms.tf
+++ b/S3_scan_object/alarms.tf
@@ -1,0 +1,36 @@
+locals {
+  error_logged_lambda = "S3ScanObjectLambdaError${title(var.product_name)}"
+}
+
+resource "aws_cloudwatch_log_metric_filter" "scan_files_lambda_error" {
+  count = var.alarm_sns_topic_arn != null ? 1 : 0
+
+  name           = local.error_logged_lambda
+  pattern        = "ERROR"
+  log_group_name = aws_cloudwatch_log_group.s3_scan_object.name
+
+  metric_transformation {
+    name      = local.error_logged_lambda
+    namespace = "ScanFiles"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "scan_files_api_error" {
+  count = var.alarm_sns_topic_arn != null ? 1 : 0
+
+  alarm_name          = local.error_logged_lambda
+  alarm_description   = "Errors logged by the Scan Files transport lambda function"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+
+  metric_name        = aws_cloudwatch_log_metric_filter.scan_files_lambda_error[0].metric_transformation[0].name
+  namespace          = aws_cloudwatch_log_metric_filter.scan_files_lambda_error[0].metric_transformation[0].namespace
+  period             = "60"
+  evaluation_periods = "1"
+  statistic          = "Sum"
+  threshold          = "1"
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = [var.alarm_sns_topic_arn]
+  ok_actions    = [var.alarm_sns_topic_arn]
+}

--- a/S3_scan_object/examples/simple/main.tf
+++ b/S3_scan_object/examples/simple/main.tf
@@ -3,6 +3,8 @@ module "simple" {
 
   product_name          = "simple"
   s3_upload_bucket_name = module.upload_bucket.s3_bucket_id
+
+  alarm_on_lambda_error = true
   alarm_sns_topic_arn   = aws_sns_topic.cloudwatch_alarms.arn
 
   billing_tag_value = "terratest"

--- a/S3_scan_object/examples/simple/main.tf
+++ b/S3_scan_object/examples/simple/main.tf
@@ -3,8 +3,13 @@ module "simple" {
 
   product_name          = "simple"
   s3_upload_bucket_name = module.upload_bucket.s3_bucket_id
+  alarm_sns_topic_arn   = aws_sns_topic.cloudwatch_alarms.arn
 
   billing_tag_value = "terratest"
+}
+
+resource "aws_sns_topic" "cloudwatch_alarms" {
+  name = "cloudwatch_alarms"
 }
 
 resource "random_id" "upload_bucket" {

--- a/S3_scan_object/input.tf
+++ b/S3_scan_object/input.tf
@@ -1,7 +1,13 @@
+variable "alarm_on_lambda_error" {
+  description = "(Optional) Create CloudWatch alarm if the transport lambda fails.  If `true`, you must also provide `alarm_sns_topic_arn`."
+  type        = bool
+  default     = false
+}
+
 variable "alarm_sns_topic_arn" {
-  description = "(Optional) The SNS topic to send transport lambda alarm notifications to.  If not provided, no alarm is created."
+  description = "(Optional) The SNS topic to send transport lambda alarm notifications to."
   type        = string
-  default     = null
+  default     = ""
 }
 
 variable "billing_tag_key" {

--- a/S3_scan_object/input.tf
+++ b/S3_scan_object/input.tf
@@ -1,3 +1,8 @@
+variable "alarm_sns_topic_arn" {
+  description = "(Optional) The SNS topic to send transport lambda alarm notifications to.  If not provided, no alarm is created."
+  type        = string
+  default     = null
+}
 
 variable "billing_tag_key" {
   description = "(Optional, default 'CostCentre') The name of the billing tag"


### PR DESCRIPTION
# Summary
Update the `S3_scan_object` module to add an optional
metric filter and CloudWatch alarm to alert on failed
invocations of the transport lambda.

The metric filter and alarm will only be created if an
optional SNS topic ARN is provided.

# Related
* Closes #144 