### PR TITLE
feat: add SNS topic inputs for Alarm and OK actions

### DIFF
--- a/S3_scan_object/README.md
+++ b/S3_scan_object/README.md
@@ -57,8 +57,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_alarm_on_lambda_error"></a> [alarm\_on\_lambda\_error](#input\_alarm\_on\_lambda\_error) | (Optional) Create CloudWatch alarm if the transport lambda fails.  If `true`, you must also provide `alarm_sns_topic_arn`. | `bool` | `false` | no |
-| <a name="input_alarm_sns_topic_arn"></a> [alarm\_sns\_topic\_arn](#input\_alarm\_sns\_topic\_arn) | (Optional) The SNS topic to send transport lambda alarm notifications to. | `string` | `""` | no |
+| <a name="input_alarm_error_sns_topic_arn"></a> [alarm\_error\_sns\_topic\_arn](#input\_alarm\_error\_sns\_topic\_arn) | (Optional) The SNS topic to send lambda alarm `Error` notifications to. | `string` | `""` | no |
+| <a name="input_alarm_ok_sns_topic_arn"></a> [alarm\_ok\_sns\_topic\_arn](#input\_alarm\_ok\_sns\_topic\_arn) | (Optional) The SNS topic to send lambda alarm `OK` notifications to. | `string` | `""` | no |
+| <a name="input_alarm_on_lambda_error"></a> [alarm\_on\_lambda\_error](#input\_alarm\_on\_lambda\_error) | (Optional) Create CloudWatch alarm if the transport lambda fails.  If `true`, you must also provide `alarm_ok_sns_topic_arn` and `alarm_error_sns_topic_arn` inputs. | `bool` | `false` | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_product_name"></a> [product\_name](#input\_product\_name) | (Required) Name of the product using the module | `string` | n/a | yes |

--- a/S3_scan_object/alarms.tf
+++ b/S3_scan_object/alarms.tf
@@ -31,6 +31,6 @@ resource "aws_cloudwatch_metric_alarm" "scan_files_api_error" {
   threshold          = "1"
   treat_missing_data = "notBreaching"
 
-  alarm_actions = [var.alarm_sns_topic_arn]
-  ok_actions    = [var.alarm_sns_topic_arn]
+  alarm_actions = [var.alarm_error_sns_topic_arn]
+  ok_actions    = [var.alarm_ok_sns_topic_arn]
 }

--- a/S3_scan_object/examples/simple/main.tf
+++ b/S3_scan_object/examples/simple/main.tf
@@ -4,14 +4,19 @@ module "simple" {
   product_name          = "simple"
   s3_upload_bucket_name = module.upload_bucket.s3_bucket_id
 
-  alarm_on_lambda_error = true
-  alarm_sns_topic_arn   = aws_sns_topic.cloudwatch_alarms.arn
+  alarm_on_lambda_error     = true
+  alarm_ok_sns_topic_arn    = aws_sns_topic.cloudwatch_alarms_ok.arn
+  alarm_error_sns_topic_arn = aws_sns_topic.cloudwatch_alarms_chaos_and_madness.arn
 
   billing_tag_value = "terratest"
 }
 
-resource "aws_sns_topic" "cloudwatch_alarms" {
-  name = "cloudwatch_alarms"
+resource "aws_sns_topic" "cloudwatch_alarms_ok" {
+  name = "cloudwatch_alarms_ok"
+}
+
+resource "aws_sns_topic" "cloudwatch_alarms_chaos_and_madness" {
+  name = "cloudwatch_alarms_chaos_and_madness"
 }
 
 resource "random_id" "upload_bucket" {

--- a/S3_scan_object/input.tf
+++ b/S3_scan_object/input.tf
@@ -1,11 +1,17 @@
 variable "alarm_on_lambda_error" {
-  description = "(Optional) Create CloudWatch alarm if the transport lambda fails.  If `true`, you must also provide `alarm_sns_topic_arn`."
+  description = "(Optional) Create CloudWatch alarm if the transport lambda fails.  If `true`, you must also provide `alarm_ok_sns_topic_arn` and `alarm_error_sns_topic_arn` inputs."
   type        = bool
   default     = false
 }
 
-variable "alarm_sns_topic_arn" {
-  description = "(Optional) The SNS topic to send transport lambda alarm notifications to."
+variable "alarm_ok_sns_topic_arn" {
+  description = "(Optional) The SNS topic to send lambda alarm `OK` notifications to."
+  type        = string
+  default     = ""
+}
+
+variable "alarm_error_sns_topic_arn" {
+  description = "(Optional) The SNS topic to send lambda alarm `Error` notifications to."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
# Summary
Update the S3 scan object module to allow users to specify
different SNS topics for Alarm and OK CloudWatch alarm actions.

# Related
* #144 