### PR TITLE
feat: use `aws_request_id` as common UUID

### DIFF
--- a/S3_scan_object/lambda/main.py
+++ b/S3_scan_object/lambda/main.py
@@ -7,7 +7,6 @@ import boto3
 import logging
 import json
 import os
-import uuid
 
 ACCOUNT_ID=os.environ.get("ACCOUNT_ID")
 LOG_LEVEL=os.environ.get("LOG_LEVEL", logging.INFO)
@@ -19,7 +18,7 @@ logger.setLevel(LOG_LEVEL)
 
 def handler(event, context):
   event["AccountId"] = ACCOUNT_ID
-  event["RequestId"] = str(uuid.uuid4())
+  event["RequestId"] = context.aws_request_id
   logger.debug(event)
 
   logger.info(f"[{event['RequestId']}] Invoking {S3_SCAN_OBJECT_FUNCTION_ARN}")

--- a/S3_scan_object/lambda/main_test.py
+++ b/S3_scan_object/lambda/main_test.py
@@ -2,13 +2,16 @@ import main
 
 from unittest.mock import patch
 
+class LambdaContext:
+  def __init__(self, aws_request_id):
+    self.aws_request_id = aws_request_id
+
 @patch("main.client")
 @patch("main.json.loads")
-@patch("main.uuid.uuid4", return_value="1234asdf-5678-ghjk-9012-qwer12324poiy5678")
 @patch("main.ACCOUNT_ID", "GeneralKenobi")
 @patch("main.S3_SCAN_OBJECT_FUNCTION_ARN", "arn:aws:lambda:ca-central-1:123456789012:function:anakin")
-def test_handler(mock_uuid, mock_json_loads, mock_client):
-  main.handler({"Hello": "There"}, None)
+def test_handler(mock_json_loads, mock_client):
+  main.handler({"Hello": "There"}, LambdaContext("1234asdf-5678-ghjk-9012-qwer12324poiy5678"))
   mock_client.invoke.assert_called_with(
     FunctionName='arn:aws:lambda:ca-central-1:123456789012:function:anakin', 
     Payload='{"Hello": "There", "AccountId": "GeneralKenobi", "RequestId": "1234asdf-5678-ghjk-9012-qwer12324poiy5678"}'


### PR DESCRIPTION
# Summary
Update the transport lambda to use its `context.aws_request_id` as the
request ID that's passed into Scan Files to correlate log messages.

# Related
* Closes cds-snc/scan-files#199