### PR TITLE
feat: allow DB engine upgrades to apply immediately

### DIFF
--- a/rds/README.md
+++ b/rds/README.md
@@ -62,6 +62,7 @@ No modules.
 | <a name="input_serverless_min_capacity"></a> [serverless\_min\_capacity](#input\_serverless\_min\_capacity) | (Optional) The minimum capacity of the Aurora serverless cluster (0.5 to 128 in increments of 0.5) | `number` | `0` | no |
 | <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | (Optional, default 'false') This flag determines if a final database snapshot it taken before the cluster is deleted. | `bool` | `false` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | (Required) The name of the subnet the DB has to stay in | `set(string)` | n/a | yes |
+| <a name="input_upgrade_immediately"></a> [upgrade\_immediately](#input\_upgrade\_immediately) | (Optional, default false) Apply database engine upgrades immediately. | `bool` | `false` | no |
 | <a name="input_username"></a> [username](#input\_username) | (Required) The username for the admin user for the db | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | (Required) The vpc to run the cluster and related infrastructure in | `string` | n/a | yes |
 

--- a/rds/input.tf
+++ b/rds/input.tf
@@ -127,6 +127,12 @@ variable "password" {
   sensitive   = true
 }
 
+variable "upgrade_immediately" {
+  description = "(Optional, default false) Apply database engine upgrades immediately."
+  type        = bool
+  default     = false
+}
+
 ###
 # Proxy Configuration
 ###

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -42,6 +42,7 @@ resource "aws_rds_cluster" "cluster" {
   db_subnet_group_name        = aws_db_subnet_group.rds.name
   deletion_protection         = var.prevent_cluster_deletion
   allow_major_version_upgrade = var.allow_major_version_upgrade
+  apply_immediately           = var.upgrade_immediately
 
   storage_encrypted   = true
   skip_final_snapshot = var.skip_final_snapshot


### PR DESCRIPTION
# Summary
Update the cluster to provide an option that allows for immediate
DB engine upgrades, rather than during the maintenance
window.