### PR TITLE
fix: force destroy Athena DB and workgroup

### DIFF
--- a/athena_access_logs/main.tf
+++ b/athena_access_logs/main.tf
@@ -4,8 +4,9 @@
 */
 
 resource "aws_athena_database" "logs" {
-  name   = var.athena_database_name
-  bucket = var.athena_bucket_name
+  name          = var.athena_database_name
+  bucket        = var.athena_bucket_name
+  force_destroy = true
 
   encryption_configuration {
     encryption_option = "SSE_S3"
@@ -13,7 +14,8 @@ resource "aws_athena_database" "logs" {
 }
 
 resource "aws_athena_workgroup" "logs" {
-  name = var.athena_workgroup_name
+  name          = var.athena_workgroup_name
+  force_destroy = true
 
   configuration {
     enforce_workgroup_configuration    = true


### PR DESCRIPTION
# Summary
Update the Athena access log module to set `force_destroy` on
the database and workgroup.  This will make it easier for
projects using the module to remove these resources by 
allowing them to be deleted even if they contain data.

Force destroy is safe in this case because the database is
only a copy of the data which exists in the S3
access log bucket.