### PR TITLE
feat: add version output for lambda module

### DIFF
--- a/lambda/README.md
+++ b/lambda/README.md
@@ -69,4 +69,5 @@ No modules.
 | <a name="output_function_arn"></a> [function\_arn](#output\_function\_arn) | ARN of the Lambda function. |
 | <a name="output_function_name"></a> [function\_name](#output\_function\_name) | Name of the Lambda function. |
 | <a name="output_function_role_arn"></a> [function\_role\_arn](#output\_function\_role\_arn) | ARN of the Lambda function execution role. |
+| <a name="output_function_version"></a> [function\_version](#output\_function\_version) | Version of the Lambda function. |
 | <a name="output_invoke_arn"></a> [invoke\_arn](#output\_invoke\_arn) | ARN used to invoke the Lambda function. |

--- a/lambda/output.tf
+++ b/lambda/output.tf
@@ -15,7 +15,7 @@ output "function_role_arn" {
 
 output "function_version" {
   description = "Version of the Lambda function."
-  value       = aws_iam_role.this.version
+  value       = aws_lambda_function.this.version
 }
 
 output "invoke_arn" {

--- a/lambda/output.tf
+++ b/lambda/output.tf
@@ -15,7 +15,7 @@ output "function_role_arn" {
 
 output "function_version" {
   description = "Version of the Lambda function."
-  value       = aws_iam_role.this.arn
+  value       = aws_iam_role.this.version
 }
 
 output "invoke_arn" {

--- a/lambda/output.tf
+++ b/lambda/output.tf
@@ -13,6 +13,11 @@ output "function_role_arn" {
   value       = aws_iam_role.this.arn
 }
 
+output "function_version" {
+  description = "Version of the Lambda function."
+  value       = aws_iam_role.this.arn
+}
+
 output "invoke_arn" {
   description = "ARN used to invoke the Lambda function."
   value       = aws_lambda_function.this.invoke_arn


### PR DESCRIPTION
This PR adds the `version` of a lambda function as an available output.