### PR TITLE
feat: use for_each instead of count

### DIFF
--- a/gh_oidc_role/main.tf
+++ b/gh_oidc_role/main.tf
@@ -5,8 +5,8 @@
 * 
 */
 
-locals { 
-  roles_kv ={for r in var.roles: r.name => r}
+locals {
+  roles_kv = { for r in var.roles : r.name => r }
 }
 
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
# Summary | Résumé

Switches internally from creating resources using count to for_each. 

This change will more than likely be breaking and will cause the apply to fail partway through, especially if you haven't migrated to the globally managed OIDC Roles here at CDS. 

Since at the time of me creating this PR there are only two accounts using those roles I'll assume this will break stuff for everyone so I will go up a major vversion when releasing this.
