### PR TITLE
fix: pin checkov install in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -41,7 +41,7 @@ RUN curl -Lo shellcheck.tar.xz "https://github.com/koalaman/shellcheck/releases/
 
 # Install Checkov
 RUN pip3 install --upgrade requests setuptools \
-    && pip3 install --upgrade botocore checkov
+    && pip3 install --upgrade botocore checkov==2.1.242
 
 # Install Go
 RUN curl -Lo go.tar.gz "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" \


### PR DESCRIPTION
# Summary
Update the devcontainer to pin the version of checkov installed as the latest version currently does not install because of a dependency conflict.

# Related
- bridgecrewio/checkov#3649