### PR TITLE
feat: add architectures input variable for module

### DIFF
--- a/lambda/input.tf
+++ b/lambda/input.tf
@@ -17,6 +17,12 @@ variable "api_gateway_source_arn" {
   description = "(Optional) The api gateway rest point that can call the lambda"
 }
 
+variable "architectures" {
+  type        = list(any)
+  default     = ["x86_64"]
+  description = "(Optional) The architectures that the lambda can run on"
+}
+
 variable "billing_tag_key" {
   description = "(Optional, default 'CostCentre') The name of the billing tag"
   type        = string

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -7,6 +7,7 @@ resource "aws_lambda_function" "this" {
   function_name                  = var.name
   package_type                   = "Image"
   image_uri                      = var.image_uri
+  architectures                  = var.architectures
   role                           = aws_iam_role.this.arn
   timeout                        = var.timeout
   memory_size                    = var.memory


### PR DESCRIPTION
This PR allows the lambda module to take an optional architectures argument:

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#architectures