### PR TITLE
feat: Add Cloudwatch subscriptions as valid trigger

### DIFF
--- a/sentinel_forwarder/README.md
+++ b/sentinel_forwarder/README.md
@@ -4,7 +4,7 @@ This module sets up a lambda that will forward AWS logs to Azure Sentinel.
 It is a light wrapper on the code found here (https://github.com/cds-snc/aws-sentinel-connector-layer) and
 just stitches together the code with the triggers.
 
-Triggers can be EventHub rules or S3 ObjectCreated events. The following log types are supported:
+Triggers can be EventHub rules, S3 ObjectCreated events, or CloudWatch Log Subscriptions. The following log types are supported:
 - CloudTrail (.json.gz)
 - Load balancer (.log.gz)
 - VPC flow logs (.log.gz)
@@ -46,6 +46,7 @@ No modules.
 | [aws_iam_role_policy_attachment.sentinel_forwarder_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.sentinel_forwarder_lambda_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_function.sentinel_forwarder](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_pemissions.sentinel_forwarder_cloudwatch_log_subscription](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_pemissions) | resource |
 | [aws_lambda_permission.sentinel_forwarder_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.sentinel_forwarder_s3_triggers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_s3_bucket_notification.sentinel_forwarder_trigger_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
@@ -61,6 +62,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
+| <a name="input_cloudwatch_log_subscription_arns"></a> [cloudwatch\_log\_subscription\_arns](#input\_cloudwatch\_log\_subscription\_arns) | (Required) A list of CloudWatch log subscription ARNs to forward to Sentinel | `list(string)` | `[]` | no |
 | <a name="input_customer_id"></a> [customer\_id](#input\_customer\_id) | (Required) Azure log workspace customer ID | `string` | n/a | yes |
 | <a name="input_event_rule_names"></a> [event\_rule\_names](#input\_event\_rule\_names) | (Optional) List of names for event rules to trigger the lambda | `list(string)` | `[]` | no |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | (Required) Name of the Lambda function. | `string` | n/a | yes |

--- a/sentinel_forwarder/README.md
+++ b/sentinel_forwarder/README.md
@@ -73,4 +73,6 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_lambda_arn"></a> [lambda\_arn](#output\_lambda\_arn) | The ARN of the Lambda function. |

--- a/sentinel_forwarder/README.md
+++ b/sentinel_forwarder/README.md
@@ -62,7 +62,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
-| <a name="input_cloudwatch_log_subscription_arns"></a> [cloudwatch\_log\_subscription\_arns](#input\_cloudwatch\_log\_subscription\_arns) | (Required) A list of CloudWatch log subscription ARNs to forward to Sentinel | `list(string)` | `[]` | no |
+| <a name="input_cloudwatch_log_arns"></a> [cloudwatch\_log\_arns](#input\_cloudwatch\_log\_arns) | (Required) A list of CloudWatch log ARNs to forward to Sentinel | `list(string)` | `[]` | no |
 | <a name="input_customer_id"></a> [customer\_id](#input\_customer\_id) | (Required) Azure log workspace customer ID | `string` | n/a | yes |
 | <a name="input_event_rule_names"></a> [event\_rule\_names](#input\_event\_rule\_names) | (Optional) List of names for event rules to trigger the lambda | `list(string)` | `[]` | no |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | (Required) Name of the Lambda function. | `string` | n/a | yes |

--- a/sentinel_forwarder/input.tf
+++ b/sentinel_forwarder/input.tf
@@ -10,6 +10,12 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "cloudwatch_log_subscription_arns" {
+  description = "(Required) A list of CloudWatch log subscription ARNs to forward to Sentinel"
+  type        = list(string)
+  default     = []
+}
+
 variable "customer_id" {
   description = "(Required) Azure log workspace customer ID"
   sensitive   = true

--- a/sentinel_forwarder/input.tf
+++ b/sentinel_forwarder/input.tf
@@ -10,8 +10,8 @@ variable "billing_tag_value" {
   type        = string
 }
 
-variable "cloudwatch_log_subscription_arns" {
-  description = "(Required) A list of CloudWatch log subscription ARNs to forward to Sentinel"
+variable "cloudwatch_log_arns" {
+  description = "(Required) A list of CloudWatch log ARNs to forward to Sentinel"
   type        = list(string)
   default     = []
 }

--- a/sentinel_forwarder/input.tf
+++ b/sentinel_forwarder/input.tf
@@ -45,7 +45,7 @@ variable "function_name" {
 
 variable "layer_arn" {
   description = "(Optional) ARN of the lambda layer to use"
-  default     = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:9"
+  default     = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:20"
 }
 
 variable "log_type" {

--- a/sentinel_forwarder/main.tf
+++ b/sentinel_forwarder/main.tf
@@ -76,7 +76,7 @@ data "archive_file" "sentinel_forwarder" {
 #
 # CloudWatch Log Subscriptions
 #
-resource "aws_lambda_pemission" "sentinel_forwarder_cloudwatch_log_subscription" {
+resource "aws_lambda_permission" "sentinel_forwarder_cloudwatch_log_subscription" {
   count = length(var.cloudwatch_log_arns)
 
   statement_id  = "AllowExecutionFromCloudWatchLogs-${var.function_name}-${count.index}"

--- a/sentinel_forwarder/main.tf
+++ b/sentinel_forwarder/main.tf
@@ -29,6 +29,7 @@ terraform {
 }
 
 data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
 
 resource "aws_lambda_function" "sentinel_forwarder" {
   function_name = var.function_name

--- a/sentinel_forwarder/main.tf
+++ b/sentinel_forwarder/main.tf
@@ -76,7 +76,7 @@ data "archive_file" "sentinel_forwarder" {
 #
 # CloudWatch Log Subscriptions
 #
-resource "aws_lambda_pemissions" "sentinel_forwarder_cloudwatch_log_subscription" {
+resource "aws_lambda_pemission" "sentinel_forwarder_cloudwatch_log_subscription" {
   count = length(var.cloudwatch_log_arns)
 
   statement_id  = "AllowExecutionFromCloudWatchLogs-${var.function_name}-${count.index}"

--- a/sentinel_forwarder/main.tf
+++ b/sentinel_forwarder/main.tf
@@ -5,7 +5,7 @@
 * It is a light wrapper on the code found here (https://github.com/cds-snc/aws-sentinel-connector-layer) and
 * just stitches together the code with the triggers.
 *
-* Triggers can be EventHub rules or S3 ObjectCreated events. The following log types are supported:
+* Triggers can be EventHub rules, S3 ObjectCreated events, or CloudWatch Log Subscriptions. The following log types are supported:
 * - CloudTrail (.json.gz)
 * - Load balancer (.log.gz)
 * - VPC flow logs (.log.gz)
@@ -71,6 +71,19 @@ data "archive_file" "sentinel_forwarder" {
   type        = "zip"
   source_file = "${path.module}/wrapper/sentinel_forwarder.py"
   output_path = "/tmp/sentinel_forwarder.py.zip"
+}
+
+#
+# CloudWatch Log Subscriptions
+#
+resource "aws_lambda_pemissions" "sentinel_forwarder_cloudwatch_log_subscription" {
+  count = length(var.cloudwatch_log_subscription_arns)
+
+  statement_id  = "AllowExecutionFromCloudWatchLogs-${var.function_name}-${count.index}"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.sentinel_forwarder.function_name
+  principal     = "logs.${data.aws_region.current.name}.amazonaws.com"
+  source_arn    = format("%s:*", var.cloudwatch_log_subscription_arns[count.index])
 }
 
 #

--- a/sentinel_forwarder/main.tf
+++ b/sentinel_forwarder/main.tf
@@ -77,13 +77,13 @@ data "archive_file" "sentinel_forwarder" {
 # CloudWatch Log Subscriptions
 #
 resource "aws_lambda_pemissions" "sentinel_forwarder_cloudwatch_log_subscription" {
-  count = length(var.cloudwatch_log_subscription_arns)
+  count = length(var.cloudwatch_log_arns)
 
   statement_id  = "AllowExecutionFromCloudWatchLogs-${var.function_name}-${count.index}"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.sentinel_forwarder.function_name
   principal     = "logs.${data.aws_region.current.name}.amazonaws.com"
-  source_arn    = format("%s:*", var.cloudwatch_log_subscription_arns[count.index])
+  source_arn    = format("%s:*", var.cloudwatch_log_arns[count.index])
 }
 
 #

--- a/sentinel_forwarder/outputs.tf
+++ b/sentinel_forwarder/outputs.tf
@@ -1,0 +1,4 @@
+output "lambda_arn" {
+  description = "The ARN of the Lambda function."
+  value       = aws_lambda_function.sentinel_forwarder.arn
+}


### PR DESCRIPTION
This PR adds the ability for the sentinel forwarder lambda to be triggered from cloudwatch logs subscriptions. The pattern and the definition are outside of the scope of the module and therefore it only takes the arn of the cloudwatch log of the subscription.

For example, assume you have a cloudwatch log with arn `arn:aws:logs:ca-central-1:ACCOUNT:log-group:/aws/lambda/Foo`

Then you would configure the module the following way:
```
module "forwarder" {
  source            = "github.com/cds-snc/terraform-modules?ref=0305826b0ed74cf01dcfce2065bdffa7280179ec//sentinel_forwarder"
  function_name     = "sentinel-cloud-watch-forwarder"
  billing_tag_value = "billing_tag_value"

  customer_id = "customer_id"
  shared_key  = "shared_key"

  cloudwatch_log_arns = ["arn:aws:logs:ca-central-1:ACCOUNT:log-group:/aws/lambda/Foo"]
}


resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter" {
  name            = "test_lambdafunction_logfilter"
  log_group_name  = "/aws/lambda/Foo"
  filter_pattern  = "MY FILTER PATTERN"
  destination_arn = module.forwarder.lambda_arn
  distribution    = "Random"
}
```

Note the `aws_cloudwatch_log_subscription_filter` is out of scope of the module and needs to be set up outside.