### PR TITLE
chore: remove Terratest trigger on workflow file

### DIFF
--- a/.github/workflows/terratest.yml
+++ b/.github/workflows/terratest.yml
@@ -54,24 +54,22 @@ jobs:
         id: changes
         with:
           filters: |
-            common:
-              - '.github/workflows/terratest.yml'
             module:
               - '${{ matrix.module }}/**/*.tf'
               - '${{ matrix.module }}/test/**'
 
       - name: Setup Go
-        if: steps.changes.outputs.module == 'true' || steps.changes.outputs.common == 'true'
+        if: steps.changes.outputs.module == 'true'
         uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613 # v3.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Setup Terraform tools
-        if: steps.changes.outputs.module == 'true' || steps.changes.outputs.common == 'true'
+        if: steps.changes.outputs.module == 'true'
         uses: cds-snc/terraform-tools-setup@v1
 
       - name: Terratest
-        if: steps.changes.outputs.module == 'true' || steps.changes.outputs.common == 'true'
+        if: steps.changes.outputs.module == 'true'
         run: |
           cd ${{ matrix.module }}/test
           go mod tidy


### PR DESCRIPTION
# Summary
With Renovate updates triggering weekly, we're getting a lot of unneeded runs against all the TF modules.  Test workflows will now only trigger if the module code or test files change.
