### PR TITLE
feat: lambda function ephemeral storage

### DIFF
--- a/lambda/README.md
+++ b/lambda/README.md
@@ -54,6 +54,7 @@ No modules.
 | <a name="input_ecr_arn"></a> [ecr\_arn](#input\_ecr\_arn) | (Optional) The arn of the ecr repository the image resides in the lambda will be given access to pull images and layers from this registry | `string` | n/a | yes |
 | <a name="input_enable_lambda_insights"></a> [enable\_lambda\_insights](#input\_enable\_lambda\_insights) | (Optional) Enable Lambda Insights | `bool` | `true` | no |
 | <a name="input_environment_variables"></a> [environment\_variables](#input\_environment\_variables) | (Optional) Environment variables to pass to the lambda | `map(string)` | `{}` | no |
+| <a name="input_ephemeral_storage"></a> [ephemeral\_storage](#input\_ephemeral\_storage) | (Optional) Set the Lambda function's ephemeral storage to a value between 512MB and 10240MB. | `number` | `512` | no |
 | <a name="input_image_uri"></a> [image\_uri](#input\_image\_uri) | (Required) Docker image URI | `string` | n/a | yes |
 | <a name="input_memory"></a> [memory](#input\_memory) | (Optional) Memory in MB | `number` | `128` | no |
 | <a name="input_name"></a> [name](#input\_name) | (Required) Name of the lambda | `string` | n/a | yes |

--- a/lambda/input.tf
+++ b/lambda/input.tf
@@ -70,6 +70,17 @@ variable "environment_variables" {
   description = "(Optional) Environment variables to pass to the lambda"
 }
 
+variable "ephemeral_storage" {
+  type        = number
+  default     = 512
+  description = "(Optional) Set the Lambda function's ephemeral storage to a value between 512MB and 10240MB."
+
+  validation {
+    condition     = var.ephemeral_storage >= 512 && var.ephemeral_storage <= 10240
+    error_message = "Ephemeral storage must be between 512MB and 10240MB."
+  }
+}
+
 variable "image_uri" {
   type        = string
   description = "(Required) Docker image URI"

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -43,6 +43,10 @@ resource "aws_lambda_function" "this" {
     }
   }
 
+  ephemeral_storage {
+    size = var.ephemeral_storage
+  }
+
   tags = local.common_tags
 }
 


### PR DESCRIPTION
# Summary
Update the lambda module to allow specifying ephemeral storage in the `/tmp` directory to a value above the default 512MB.

# Related
- cds-snc/scan-files#472