### PR TITLE
fix: add list log group tag policy statement

### DIFF
--- a/attach_tf_plan_policy/main.tf
+++ b/attach_tf_plan_policy/main.tf
@@ -53,6 +53,12 @@ data "aws_iam_policy_document" "this" {
     actions   = ["secretsmanager:ListSecrets"]
     resources = ["*"]
   }
+
+  statement {
+    sid       = "ListLogGroupTags"
+    actions   = ["logs:ListTagsForResource"]
+    resources = ["*"]
+  }
 }
 
 data "aws_iam_policy" "readonly" {


### PR DESCRIPTION
# Summary
Update the attach TF plan policy module to allow for the listing of log group tags.

This is to handle a change in the latest Terraform AWS provider that now requires this permission which is not provided by the AWS managed ReadOnly policy.