### PR TITLE
add a variable custom_details

### DIFF
--- a/sentinel_alert_rule/input.tf
+++ b/sentinel_alert_rule/input.tf
@@ -96,3 +96,8 @@ variable "entity_mapping" {
   default     = []
 }
 
+variable "custom_details" {
+  type        = map(string)
+  description = "(Optional) The custom details of the alert rule."
+  default     = {}
+}


### PR DESCRIPTION
# Summary | Résumé
This PR adds an optional variable `custom_details` to the `sentienl_alert_rule` module