### PR TITLE
Fix: doc check fails if .terraform or terraform.lock.hcl exists

### DIFF
--- a/S3/Makefile
+++ b/S3/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/S3_log_bucket/Makefile
+++ b/S3_log_bucket/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/S3_scan_object/Makefile
+++ b/S3_scan_object/Makefile
@@ -4,6 +4,8 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md
 
 lambda-install:

--- a/athena_access_logs/Makefile
+++ b/athena_access_logs/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/attach_tf_plan_policy/Makefile
+++ b/attach_tf_plan_policy/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/auto_revoke_sg_rules/Makefile
+++ b/auto_revoke_sg_rules/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/aws_goc_password_policy/Makefile
+++ b/aws_goc_password_policy/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/bin/scaffold.sh
+++ b/bin/scaffold.sh
@@ -17,6 +17,8 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md
 EOF
 

--- a/exposed_iam_credentials_disabler/Makefile
+++ b/exposed_iam_credentials_disabler/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/gh_oidc_role/Makefile
+++ b/gh_oidc_role/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/guardduty/Makefile
+++ b/guardduty/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/guardduty_member/Makefile
+++ b/guardduty_member/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/lambda/Makefile
+++ b/lambda/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/lambda_response/Makefile
+++ b/lambda_response/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/notify_slack/Makefile
+++ b/notify_slack/Makefile
@@ -4,6 +4,8 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md
 
 lambda-install:

--- a/rds/Makefile
+++ b/rds/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/resolver_dns/Makefile
+++ b/resolver_dns/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/sentinel_alert_rule/Makefile
+++ b/sentinel_alert_rule/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/sentinel_forwarder/Makefile
+++ b/sentinel_forwarder/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/sns/Makefile
+++ b/sns/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/user_login_alarm/Makefile
+++ b/user_login_alarm/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md

--- a/vpc/Makefile
+++ b/vpc/Makefile
@@ -4,4 +4,6 @@ fmt:
 	@terraform fmt -recursive
 
 docs:
+	@rm -rf .terraform
+	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md


### PR DESCRIPTION
# Summary | Résumé
- remove .terraform.lock.hcl and .terraform directory.
- add the rm command to scaffold.sh
- closes #212 