### PR TITLE
Block all addresses access to port 22 and 3389

### DIFF
--- a/vpc/nacl.tf
+++ b/vpc/nacl.tf
@@ -14,7 +14,7 @@ resource "aws_network_acl_rule" "block_ssh" {
   egress         = false
   protocol       = "tcp"
   rule_action    = "deny"
-  cidr_block     = aws_vpc.main.cidr_block
+  cidr_block     = "0.0.0.0/0" 
   from_port      = 22
   to_port        = 22
 }
@@ -26,7 +26,7 @@ resource "aws_network_acl_rule" "block_rdp" {
   egress         = false
   protocol       = "tcp"
   rule_action    = "deny"
-  cidr_block     = aws_vpc.main.cidr_block
+  cidr_block     = "0.0.0.0/0"
   from_port      = 3389
   to_port        = 3389
 }

--- a/vpc/nacl.tf
+++ b/vpc/nacl.tf
@@ -14,7 +14,7 @@ resource "aws_network_acl_rule" "block_ssh" {
   egress         = false
   protocol       = "tcp"
   rule_action    = "deny"
-  cidr_block     = "0.0.0.0/0" 
+  cidr_block     = "0.0.0.0/0"
   from_port      = 22
   to_port        = 22
 }


### PR DESCRIPTION
# Summary | Résumé

Changed cidr rules to any address (0.0.0.0/0) to block ports 22 and 3389. This was needed in order to meet ATO compliance for the URL shortener (details are [here](https://github.com/cds-snc/url-shortener/issues/251)).