### PR TITLE
Fixing acl association to S3 log bucket

### DIFF
--- a/S3_log_bucket/README.md
+++ b/S3_log_bucket/README.md
@@ -25,10 +25,10 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_acl.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_ownership_controls.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_ownership_controls.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
-| [s3_bucket_acl.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_elb_service_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_service_account) | data source |
 | [aws_iam_policy_document.combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.deny_insecure_transport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -49,9 +49,8 @@ No modules.
 | <a name="input_critical_tag_value"></a> [critical\_tag\_value](#input\_critical\_tag\_value) | (Required: default=true) The value of the critical tag. If set to true, protection SCP rules will be applied to the resource. | `bool` | `true` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |
 | <a name="input_lifecycle_rule"></a> [lifecycle\_rule](#input\_lifecycle\_rule) | (Optional) List of maps containing configuration of object lifecycle management. | `any` | `[]` | no |
+| <a name="input_object_ownership"></a> [object\_ownership](#input\_object\_ownership) | (Optional), overrides object ownership value in aws\_s3\_bucket\_ownership\_controls. Defaults to BucketOwnerPreferred | `string` | `"BucketOwnerPreferred"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
-| <a name="object_ownership"></a> [object\_ownership](#input\_object\_ownership) | (Optional), overrides object ownership value in aws_s3_bucket_ownership_controls | `string` | `BucketOwnerPreferred` | no |
-
 
 ## Outputs
 

--- a/S3_log_bucket/README.md
+++ b/S3_log_bucket/README.md
@@ -50,7 +50,7 @@ No modules.
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |
 | <a name="input_lifecycle_rule"></a> [lifecycle\_rule](#input\_lifecycle\_rule) | (Optional) List of maps containing configuration of object lifecycle management. | `any` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
-| <a name="object_ownership"></a> [object\_ownership](#input\_object\_ownership) | (Optional), overrides object ownership value in aws_s3_bucket_ownership_controls | `map(string)` | `{}` | no |
+| <a name="object_ownership"></a> [object\_ownership](#input\_object\_ownership) | (Optional), overrides object ownership value in aws_s3_bucket_ownership_controls | `string` | `BucketOwnerPreferred` | no |
 
 
 ## Outputs

--- a/S3_log_bucket/README.md
+++ b/S3_log_bucket/README.md
@@ -27,6 +27,8 @@ No modules.
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_ownership_controls.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [s3_bucket_acl.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_elb_service_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_service_account) | data source |
 | [aws_iam_policy_document.combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.deny_insecure_transport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -48,6 +50,8 @@ No modules.
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |
 | <a name="input_lifecycle_rule"></a> [lifecycle\_rule](#input\_lifecycle\_rule) | (Optional) List of maps containing configuration of object lifecycle management. | `any` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
+| <a name="object_ownership"></a> [object\_ownership](#input\_object\_ownership) | (Optional), overrides object ownership value in aws_s3_bucket_ownership_controls | `map(string)` | `{}` | no |
+
 
 ## Outputs
 

--- a/S3_log_bucket/input.tf
+++ b/S3_log_bucket/input.tf
@@ -65,3 +65,9 @@ variable "lifecycle_rule" {
   type        = any
   default     = []
 }
+
+variable "object_ownership" {
+  description = "(Optional, overrides object ownership value in aws_s3_bucket_ownership_controls. Defaults to BucketOwnerPreferred"
+  type        = string
+  default     = "BucketOwnerPreferred"
+}

--- a/S3_log_bucket/input.tf
+++ b/S3_log_bucket/input.tf
@@ -67,7 +67,7 @@ variable "lifecycle_rule" {
 }
 
 variable "object_ownership" {
-  description = "(Optional, overrides object ownership value in aws_s3_bucket_ownership_controls. Defaults to BucketOwnerPreferred"
+  description = "(Optional), overrides object ownership value in aws_s3_bucket_ownership_controls. Defaults to BucketOwnerPreferred"
   type        = string
   default     = "BucketOwnerPreferred"
 }

--- a/S3_log_bucket/main.tf
+++ b/S3_log_bucket/main.tf
@@ -60,7 +60,7 @@ resource "aws_s3_bucket_policy" "this" {
 resource "aws_s3_bucket_ownership_controls" "this" {
   bucket = aws_s3_bucket.this.id
   rule {
-    object_ownership = "BucketOwnerPreferred"
+    object_ownership = var.object_ownership
   }
 }
 


### PR DESCRIPTION
# Summary | Résumé

[In April, AWS made it so that you could not add non-private ACLs inline with the S3 bucket. ](https://github.com/hashicorp/terraform-provider-aws/issues/28353)

Additionally, adding inline ACLs has been deprecated as of V4 of AWS provider.

This PR moves the ACL configuration outside of the S3 bucket and into a dedicated aws_s3_bucket_acl as well as setting the default ownership controls.

# Test instructions | Instructions pour tester la modification

* Create new s3 resource using this module


