### PR TITLE
feat: custom conformance yaml

### DIFF
--- a/cds_conformance_pack/README.md
+++ b/cds_conformance_pack/README.md
@@ -8,7 +8,7 @@ For example to meet the config rule `internet-gateway-authorized-vpc-only` you c
 
 ```hcl
 module "conformance_pack" {
-  source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.7/cds_conformance_pack"
+  source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.8/cds_conformance_pack"
   internet_gateway_authorized_vpc_only_param_authorized_vpc_ids = "vpc-00534274da4ade29d"
   billing_tag_value = var.billing_code
 }
@@ -18,13 +18,24 @@ To exclude specific rules from the conformance pack, you can use the `excluded_r
 
 ```hcl
 module "conformance_pack" {
-  source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.7/cds_conformance_pack"
+  source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.8/cds_conformance_pack"
   excluded_rules                                                = ["InternetGatewayAuthorizedVpcOnly"]
   billing_tag_value = var.billing_code
 }
+```
 
 Note: The rules need to be in the CamelCase format as found in the YAML.
+
+If you would like to append or override the default conformance pack, you can use the `custom_conformance_pack_path` variable. For example, to append a rule to the conformance pack, you can set the variable as follows:
+
+```hcl
+module "conformance_pack" {
+  source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.8/cds_conformance_pack"
+  custom_conformance_pack_path                                   = "custom_conformance_pack.yaml"
+  billing_tag_value = var.billing_code
+}
 ```
+The custom conformance pack should be in the same format as the CCCS conformance pack YAML, in that you can use a `Parameters`, `Resources`, and `Conditions` section.
 
 ## Requirements
 
@@ -62,6 +73,7 @@ No requirements.
 | <a name="input_cloudwatch_alarm_action_check_param_insufficient_data_action_required"></a> [cloudwatch\_alarm\_action\_check\_param\_insufficient\_data\_action\_required](#input\_cloudwatch\_alarm\_action\_check\_param\_insufficient\_data\_action\_required) | (Optional) Indicates whether an action is required when the alarm changes to the INSUFFICIENT\_DATA state. | `string` | `"true"` | no |
 | <a name="input_cloudwatch_alarm_action_check_param_ok_action_required"></a> [cloudwatch\_alarm\_action\_check\_param\_ok\_action\_required](#input\_cloudwatch\_alarm\_action\_check\_param\_ok\_action\_required) | (Optional) Indicates whether an action is required when the alarm changes to the OK state. | `string` | `"false"` | no |
 | <a name="input_conformance_pack_name"></a> [conformance\_pack\_name](#input\_conformance\_pack\_name) | (Optional) The name of the conformance pack. | `string` | `"CDS-Conformance-Pack"` | no |
+| <a name="input_custom_conformance_pack_path"></a> [custom\_conformance\_pack\_path](#input\_custom\_conformance\_pack\_path) | (Optional) The path to the custom conformance pack YAML file. | `string` | `""` | no |
 | <a name="input_elb_predefined_security_policy_ssl_check_param_predefined_policy_name"></a> [elb\_predefined\_security\_policy\_ssl\_check\_param\_predefined\_policy\_name](#input\_elb\_predefined\_security\_policy\_ssl\_check\_param\_predefined\_policy\_name) | (Optional) The name of the predefined security policy for the ELB SSL negotiation configuration. | `string` | `"TLS-1-2-2017-01"` | no |
 | <a name="input_excluded_rules"></a> [excluded\_rules](#input\_excluded\_rules) | (Optional) The list of rules to exclude from the conformance pack. These need to be in the CamelCase format as found in the YAML. | `list(string)` | `[]` | no |
 | <a name="input_iam_customer_policy_blocked_kms_actions_param_blocked_actions_patterns"></a> [iam\_customer\_policy\_blocked\_kms\_actions\_param\_blocked\_actions\_patterns](#input\_iam\_customer\_policy\_blocked\_kms\_actions\_param\_blocked\_actions\_patterns) | (Optional) The patterns of KMS actions to be blocked in the customer-managed IAM policy. | `string` | `"kms:*, kms:Decrypt, kms:ReEncrypt*"` | no |

--- a/cds_conformance_pack/README.md
+++ b/cds_conformance_pack/README.md
@@ -10,7 +10,7 @@ For example to meet the config rule `internet-gateway-authorized-vpc-only` you c
 module "conformance_pack" {
   source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.8/cds_conformance_pack"
   internet_gateway_authorized_vpc_only_param_authorized_vpc_ids = "vpc-00534274da4ade29d"
-  billing_tag_value = var.billing_code
+  billing_tag_value                                             = var.billing_code
 }
 ```
 
@@ -20,7 +20,7 @@ To exclude specific rules from the conformance pack, you can use the `excluded_r
 module "conformance_pack" {
   source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.8/cds_conformance_pack"
   excluded_rules                                                = ["InternetGatewayAuthorizedVpcOnly"]
-  billing_tag_value = var.billing_code
+  billing_tag_value                                             = var.billing_code
 }
 ```
 
@@ -31,8 +31,8 @@ If you would like to append or override the default conformance pack, you can us
 ```hcl
 module "conformance_pack" {
   source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.8/cds_conformance_pack"
-  custom_conformance_pack_path                                   = "custom_conformance_pack.yaml"
-  billing_tag_value = var.billing_code
+  custom_conformance_pack_path                                  = "./custom_conformance_pack.yaml"
+  billing_tag_value                                             = var.billing_code
 }
 ```
 The custom conformance pack should be in the same format as the CCCS conformance pack YAML, in that you can use a `Parameters`, `Resources`, and `Conditions` section.

--- a/cds_conformance_pack/input.tf
+++ b/cds_conformance_pack/input.tf
@@ -39,6 +39,12 @@ variable "conformance_pack_name" {
   default     = "CDS-Conformance-Pack"
 }
 
+variable "custom_conformance_pack_path" {
+  description = "(Optional) The path to the custom conformance pack YAML file."
+  type        = string
+  default     = ""
+}
+
 variable "elb_predefined_security_policy_ssl_check_param_predefined_policy_name" {
   description = "(Optional) The name of the predefined security policy for the ELB SSL negotiation configuration."
   type        = string

--- a/cds_conformance_pack/locals.tf
+++ b/cds_conformance_pack/locals.tf
@@ -1,4 +1,3 @@
-
 locals {
   common_tags = {
     (var.billing_tag_key) = var.billing_tag_value
@@ -10,64 +9,11 @@ locals {
     for k, v in local.conformance_yaml.Resources : k => v if !contains(var.excluded_rules, k)
   }
 
-  custom_conformance_pack_custom_conformance_pack_yaml_file_exists = can(file(var.custom_conformance_pack_path))
-  parsed_custom_conformance_pack_yaml                              = yamldecode(file(var.custom_conformance_pack_path))
-
-  required_keys = [
-    "Resources"
-  ]
-
-  optional_keys = [
-    "Conditions",
-    "Parameters"
-  ]
+  custom_conformance_pack = try(yamldecode(file(var.custom_conformance_pack_path)), {})
 
   modified_conformance_pack = {
-    Parameters = local.conformance_yaml.Parameters
-    Resources  = local.conformance_yaml_without_excluded_rules
-    Conditions = local.conformance_yaml.Conditions
+    Parameters = merge(local.conformance_yaml.Parameters, try(local.custom_conformance_pack.Parameters, {}))
+    Resources  = merge(local.conformance_yaml_without_excluded_rules, try(local.custom_conformance_pack.Resources, {}))
+    Conditions = merge(local.conformance_yaml.Conditions, try(local.custom_conformance_pack.Conditions, {}))
   }
 }
-
-resource "null_resource" "validate_yaml" {
-  count = local.custom_conformance_pack_yaml_file_exists ? 1 : 0
-
-  triggers = {
-    validate_yaml = jsonencode(local.parsed_custom_conformance_pack_yaml)
-  }
-
-  provisioner "local-exec" {
-    command = "echo 'YAML file is valid'"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      triggers
-    ]
-  }
-
-  depends_on = [
-    local.parsed_custom_conformance_pack_yaml
-  ]
-
-  dynamic "required_key" {
-    for_each = local.required_keys
-    content {
-      validate {
-        condition     = contains(keys(local.parsed_custom_conformance_pack_yaml), required_key.value)
-        error_message = "Missing required key '${required_key.value}' in YAML file"
-      }
-    }
-  }
-
-  dynamic "optional_key" {
-    for_each = local.optional_keys
-    content {
-      validate {
-        condition     = contains(keys(local.parsed_custom_conformance_pack_yaml), optional_key.value)
-        error_message = "Unknown key '${optional_key.value}' in YAML file"
-      }
-    }
-  }
-}
-

--- a/cds_conformance_pack/locals.tf
+++ b/cds_conformance_pack/locals.tf
@@ -4,5 +4,70 @@ locals {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = "true"
   }
+
+  conformance_yaml = yamldecode(file("${path.module}/Operational-Best-Practices-for-CCCS-Medium.yaml"))
+  conformance_yaml_without_excluded_rules = {
+    for k, v in local.conformance_yaml.Resources : k => v if !contains(var.excluded_rules, k)
+  }
+
+  custom_conformance_pack_custom_conformance_pack_yaml_file_exists = can(file(var.custom_conformance_pack_path))
+  parsed_custom_conformance_pack_yaml                              = yamldecode(file(var.custom_conformance_pack_path))
+
+  required_keys = [
+    "Resources"
+  ]
+
+  optional_keys = [
+    "Conditions",
+    "Parameters"
+  ]
+
+  modified_conformance_pack = {
+    Parameters = local.conformance_yaml.Parameters
+    Resources  = local.conformance_yaml_without_excluded_rules
+    Conditions = local.conformance_yaml.Conditions
+  }
+}
+
+resource "null_resource" "validate_yaml" {
+  count = local.custom_conformance_pack_yaml_file_exists ? 1 : 0
+
+  triggers = {
+    validate_yaml = jsonencode(local.parsed_custom_conformance_pack_yaml)
+  }
+
+  provisioner "local-exec" {
+    command = "echo 'YAML file is valid'"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      triggers
+    ]
+  }
+
+  depends_on = [
+    local.parsed_custom_conformance_pack_yaml
+  ]
+
+  dynamic "required_key" {
+    for_each = local.required_keys
+    content {
+      validate {
+        condition     = contains(keys(local.parsed_custom_conformance_pack_yaml), required_key.value)
+        error_message = "Missing required key '${required_key.value}' in YAML file"
+      }
+    }
+  }
+
+  dynamic "optional_key" {
+    for_each = local.optional_keys
+    content {
+      validate {
+        condition     = contains(keys(local.parsed_custom_conformance_pack_yaml), optional_key.value)
+        error_message = "Unknown key '${optional_key.value}' in YAML file"
+      }
+    }
+  }
 }
 

--- a/cds_conformance_pack/main.tf
+++ b/cds_conformance_pack/main.tf
@@ -27,18 +27,6 @@
 * Note: The rules need to be in the CamelCase format as found in the YAML.
 */
 
-locals {
-  conformance_yaml = yamldecode(file("${path.module}/Operational-Best-Practices-for-CCCS-Medium.yaml"))
-  conformance_yaml_without_excluded_rules = {
-    for k, v in local.conformance_yaml.Resources : k => v if !contains(var.excluded_rules, k)
-  }
-  modified_conformance_pack = {
-    Parameters = local.conformance_yaml.Parameters
-    Resources  = local.conformance_yaml_without_excluded_rules
-    Conditions = local.conformance_yaml.Conditions
-  }
-}
-
 resource "random_uuid" "bucket_suffix" {}
 
 module "s3" {

--- a/cds_conformance_pack/main.tf
+++ b/cds_conformance_pack/main.tf
@@ -9,7 +9,7 @@
 * 
 * ```hcl
 * module "conformance_pack" {
-*   source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.7/cds_conformance_pack"
+*   source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.8/cds_conformance_pack"
 *   internet_gateway_authorized_vpc_only_param_authorized_vpc_ids = "vpc-00534274da4ade29d"
 *   billing_tag_value = var.billing_code
 * }
@@ -19,12 +19,25 @@
 *
 * ```hcl
 * module "conformance_pack" {
-*   source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.7/cds_conformance_pack"
+*   source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.8/cds_conformance_pack"
 *   excluded_rules                                                = ["InternetGatewayAuthorizedVpcOnly"]
 *   billing_tag_value = var.billing_code
 * }
-*
+* ```
+* 
 * Note: The rules need to be in the CamelCase format as found in the YAML.
+*
+* If you would like to append or override the default conformance pack, you can use the `custom_conformance_pack_path` variable. For example, to append a rule to the conformance pack, you can set the variable as follows:
+*
+* ```hcl
+* module "conformance_pack" {
+*   source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.8/cds_conformance_pack"
+*   custom_conformance_pack_path                                   = "custom_conformance_pack.yaml"
+*   billing_tag_value = var.billing_code
+* }
+* ```
+* The custom conformance pack should be in the same format as the CCCS conformance pack YAML, in that you can use a `Parameters`, `Resources`, and `Conditions` section. 
+*
 */
 
 resource "random_uuid" "bucket_suffix" {}

--- a/cds_conformance_pack/main.tf
+++ b/cds_conformance_pack/main.tf
@@ -11,7 +11,7 @@
 * module "conformance_pack" {
 *   source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.8/cds_conformance_pack"
 *   internet_gateway_authorized_vpc_only_param_authorized_vpc_ids = "vpc-00534274da4ade29d"
-*   billing_tag_value = var.billing_code
+*   billing_tag_value                                             = var.billing_code
 * }
 * ```
 *
@@ -21,7 +21,7 @@
 * module "conformance_pack" {
 *   source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.8/cds_conformance_pack"
 *   excluded_rules                                                = ["InternetGatewayAuthorizedVpcOnly"]
-*   billing_tag_value = var.billing_code
+*   billing_tag_value                                             = var.billing_code
 * }
 * ```
 * 
@@ -32,8 +32,8 @@
 * ```hcl
 * module "conformance_pack" {
 *   source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.8/cds_conformance_pack"
-*   custom_conformance_pack_path                                   = "custom_conformance_pack.yaml"
-*   billing_tag_value = var.billing_code
+*   custom_conformance_pack_path                                  = "./custom_conformance_pack.yaml"
+*   billing_tag_value                                             = var.billing_code
 * }
 * ```
 * The custom conformance pack should be in the same format as the CCCS conformance pack YAML, in that you can use a `Parameters`, `Resources`, and `Conditions` section. 


### PR DESCRIPTION
Adds the ability to inject custom conformance rules alongside the conformance pack using a custom yaml file. This allows the ability to replace existing rules and add new ones.

ex - defining this override

```
Resources:
  AccessKeysRotated:
    Properties:
      ConfigRuleName: access-keys-rotated-YOLO
      InputParameters:
        maxAccessKeyAge:
          Fn::If:
            - accessKeysRotatedParamMaxAccessKeyAge
            - Ref: AccessKeysRotatedParamMaxAccessKeyAge
            - Ref: AWS::NoValue
      Source:
        Owner: AWS
        SourceIdentifier: ACCESS_KEYS_ROTATED
    Type: AWS::Config::ConfigRule
```

yields this result:

<img width="781" alt="Screenshot 2023-04-23 at 1 15 12 PM" src="https://user-images.githubusercontent.com/867334/233854523-b54717b2-c462-497c-98c2-6ba95fdd2c4f.png">



