### PR TITLE
Measure lambda cold starts (plus min/max duration & memory usage)

### DIFF
--- a/lambda/README.md
+++ b/lambda/README.md
@@ -20,6 +20,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_query_definition.lambda_statistics](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_query_definition) | resource |
 | [aws_iam_policy.non_vpc_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.vpc_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |


### PR DESCRIPTION
# Summary | Résumé

This relates to the following [issue](https://github.com/orgs/cds-snc/projects/13/views/29?pane=issue&itemId=24251338) where we want to measure lambda cold starts. I also added additional statistics such as the count invocations, how many cold starts were invoked, the percentage of cold starts, maximum Cold Start time, Average/Min/Max duration, Average Memory used, memory allocated and percentage memory used. 

Not sure at all if this is the right approach - ie to create cloudwatch query in the log insights so if there are better approaches, I am all ears!