### PR TITLE
Feat/critical s3 default versioning

### DIFF
--- a/S3_log_bucket/README.md
+++ b/S3_log_bucket/README.md
@@ -29,6 +29,7 @@ No modules.
 | [aws_s3_bucket_ownership_controls.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_elb_service_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_service_account) | data source |
 | [aws_iam_policy_document.combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.deny_insecure_transport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/S3_log_bucket/main.tf
+++ b/S3_log_bucket/main.tf
@@ -203,9 +203,14 @@ resource "aws_s3_bucket_public_access_block" "this" {
 }
 
 resource "aws_s3_bucket_versioning" "this" {
-  count  = var.critical_tag_value == "true" ? 1 : 0
   bucket = aws_s3_bucket_policy.this.id
+
   dynamic "versioning_configuration" {
-    status = "Enabled"
+    for_each = var.critical_tag_value == true ? [1] : []
+
+    content {
+      status = "Enabled"
+    }
   }
+  
 }

--- a/S3_log_bucket/main.tf
+++ b/S3_log_bucket/main.tf
@@ -212,5 +212,5 @@ resource "aws_s3_bucket_versioning" "this" {
       status = "Enabled"
     }
   }
-  
+
 }

--- a/S3_log_bucket/main.tf
+++ b/S3_log_bucket/main.tf
@@ -201,3 +201,11 @@ resource "aws_s3_bucket_public_access_block" "this" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+resource "aws_s3_bucket_versioning" "this" {
+  count  = var.critical_tag_value == "true" ? 1 : 0
+  bucket = aws_s3_bucket_policy.this.id
+  dynamic "versioning_configuration" {
+    status = "Enabled"
+  }
+}


### PR DESCRIPTION
# Summary | Résumé

Enabling bucket version by default when tag `Critical` is set to `true`

Related to https://github.com/cds-snc/security-risk-register/issues/37