### PR TITLE
feat: add azure cli to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,8 @@
 		},
 		"ghcr.io/dhoeric/features/terraform-docs:1": {
 			"version": "latest"
-		}
+		},
+		"azure-cli": "latest"
 	},
 	"customizations": {
 		"vscode": {


### PR DESCRIPTION
# Summary | Résumé

Just a quick change to add Azure CLI to the devcontainer settings as there are modules that are built for Azure