### PR TITLE
fix: increase default timeout of transport lambda

### DIFF
--- a/S3_scan_object/main.tf
+++ b/S3_scan_object/main.tf
@@ -17,6 +17,7 @@ resource "aws_lambda_function" "s3_scan_object" {
   runtime       = "python3.8"
   handler       = "main.handler"
   memory_size   = 512
+  timeout       = 120
 
   filename         = data.archive_file.s3_scan_object.output_path
   source_code_hash = filebase64sha256(data.archive_file.s3_scan_object.output_path)


### PR DESCRIPTION
# Summary
Update the S3 scan object's transport lambda timeout to 2 minutes. This is to give it time to wait for an available Scan Files function to be available in the case of a cold start.

# Related
- #250 