### PR TITLE
fix: s3_scan_object async invoke scan

### DIFF
--- a/S3_scan_object/README.md
+++ b/S3_scan_object/README.md
@@ -62,6 +62,7 @@ No modules.
 | <a name="input_alarm_on_lambda_error"></a> [alarm\_on\_lambda\_error](#input\_alarm\_on\_lambda\_error) | (Optional) Create CloudWatch alarm if the transport lambda fails.  If `true`, you must also provide `alarm_ok_sns_topic_arn` and `alarm_error_sns_topic_arn` inputs. | `bool` | `false` | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
+| <a name="input_log_level"></a> [log\_level](#input\_log\_level) | (optional, default 'INFO') Log level of the transport lambda function | `string` | `"INFO"` | no |
 | <a name="input_product_name"></a> [product\_name](#input\_product\_name) | (Required) Name of the product using the module | `string` | n/a | yes |
 | <a name="input_reserved_concurrent_executions"></a> [reserved\_concurrent\_executions](#input\_reserved\_concurrent\_executions) | (Optional, default 10) The number of concurrent executions for the S3 event transport lambda that triggers the start of a scan. | `number` | `10` | no |
 | <a name="input_s3_scan_object_function_arn"></a> [s3\_scan\_object\_function\_arn](#input\_s3\_scan\_object\_function\_arn) | (Optional, default S3 Scan Object function ARN) S3 scan object lambda function ARN | `string` | `"arn:aws:lambda:ca-central-1:806545929748:function:s3-scan-object"` | no |

--- a/S3_scan_object/examples/existing_policy/main.tf
+++ b/S3_scan_object/examples/existing_policy/main.tf
@@ -14,7 +14,7 @@ resource "random_id" "upload_bucket" {
 }
 
 module "upload_bucket" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v3.0.8//S3"
+  source            = "github.com/cds-snc/terraform-modules?ref=v5.1.10//S3"
   bucket_name       = "an-existing-upload-bucket-${random_id.upload_bucket.hex}"
   billing_tag_value = "terratest"
 

--- a/S3_scan_object/examples/simple/main.tf
+++ b/S3_scan_object/examples/simple/main.tf
@@ -9,6 +9,8 @@ module "simple" {
   alarm_error_sns_topic_arn = aws_sns_topic.cloudwatch_alarms_chaos_and_madness.arn
 
   billing_tag_value = "terratest"
+
+  log_level = "DEBUG"
 }
 
 resource "aws_sns_topic" "cloudwatch_alarms_ok" {
@@ -24,7 +26,7 @@ resource "random_id" "upload_bucket" {
 }
 
 module "upload_bucket" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v3.0.8//S3"
+  source            = "github.com/cds-snc/terraform-modules?ref=v5.1.10//S3"
   bucket_name       = "an-existing-upload-bucket-${random_id.upload_bucket.hex}"
   billing_tag_value = "terratest"
 

--- a/S3_scan_object/input.tf
+++ b/S3_scan_object/input.tf
@@ -27,6 +27,12 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "log_level" {
+  description = "(optional, default 'INFO') Log level of the transport lambda function"
+  type        = string
+  default     = "INFO"
+}
+
 variable "product_name" {
   description = "(Required) Name of the product using the module"
   type        = string

--- a/S3_scan_object/lambda/main_test.py
+++ b/S3_scan_object/lambda/main_test.py
@@ -13,6 +13,7 @@ class LambdaContext:
 def test_handler(mock_json_loads, mock_client):
   main.handler({"Hello": "There"}, LambdaContext("1234asdf-5678-ghjk-9012-qwer12324poiy5678"))
   mock_client.invoke.assert_called_with(
-    FunctionName='arn:aws:lambda:ca-central-1:123456789012:function:anakin', 
+    FunctionName='arn:aws:lambda:ca-central-1:123456789012:function:anakin',
+    InvocationType="Event",
     Payload='{"Hello": "There", "AccountId": "GeneralKenobi", "RequestId": "1234asdf-5678-ghjk-9012-qwer12324poiy5678"}'
   )

--- a/S3_scan_object/main.tf
+++ b/S3_scan_object/main.tf
@@ -27,6 +27,7 @@ resource "aws_lambda_function" "s3_scan_object" {
   environment {
     variables = {
       ACCOUNT_ID                  = local.account_id
+      LOG_LEVEL                   = var.log_level
       S3_SCAN_OBJECT_FUNCTION_ARN = var.s3_scan_object_function_arn
     }
   }


### PR DESCRIPTION
# Summary
Update the module's transport lambda to invoke `s3_scan_object` asynchronously as a response is not required for processing.

Also update the logging of the transport lambda and provide a way for module users to specify a log level.

# Related
- cds-snc/platform-core-services#297