### PR TITLE
Update zones of lambda function & sns topic

### DIFF
--- a/notify_new_iam_user/README.md
+++ b/notify_new_iam_user/README.md
@@ -19,6 +19,7 @@ No modules.
 |------|------|
 | [aws_cloudwatch_event_rule.new_iam_user_added_event_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.new_iam_user_added_event_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_group.lambda_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_role.new_iam_user_response_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.new_iam_user_response_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_lambda_function.new_iam_user_added_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
@@ -26,7 +27,6 @@ No modules.
 | [archive_file.notify_new_iam_user_added](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
@@ -36,6 +36,7 @@ No modules.
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | (Required) Name of the Lambda function. | `string` | `"new_iam_user_added"` | no |
 | <a name="input_logging_level"></a> [logging\_level](#input\_logging\_level) | The logging level of the lambda function | `string` | `"ERROR"` | no |
+| <a name="input_sns_topic"></a> [sns\_topic](#input\_sns\_topic) | (Required, default 'internal-sre-alert') The name of the sns topic to send alerts to | `string` | `"internal-sre-alert"` | no |
 
 ## Outputs
 

--- a/notify_new_iam_user/cloudwatch.tf
+++ b/notify_new_iam_user/cloudwatch.tf
@@ -20,3 +20,12 @@ resource "aws_cloudwatch_event_target" "new_iam_user_added_event_target" {
   target_id = "new_iam_user_added_lambda"
   arn       = aws_lambda_function.new_iam_user_added_lambda.arn
 }
+
+# create cloudwatch log group
+resource "aws_cloudwatch_log_group" "lambda_log_group" {
+  name     = "/aws/lambda/${aws_lambda_function.new_iam_user_added_lambda.function_name}"
+  retention_in_days = 14
+  lifecycle {
+    prevent_destroy = false
+  }
+}

--- a/notify_new_iam_user/cloudwatch.tf
+++ b/notify_new_iam_user/cloudwatch.tf
@@ -23,7 +23,7 @@ resource "aws_cloudwatch_event_target" "new_iam_user_added_event_target" {
 
 # create cloudwatch log group
 resource "aws_cloudwatch_log_group" "lambda_log_group" {
-  name     = "/aws/lambda/${aws_lambda_function.new_iam_user_added_lambda.function_name}"
+  name              = "/aws/lambda/${aws_lambda_function.new_iam_user_added_lambda.function_name}"
   retention_in_days = 14
   lifecycle {
     prevent_destroy = false

--- a/notify_new_iam_user/functions/index.py
+++ b/notify_new_iam_user/functions/index.py
@@ -69,7 +69,7 @@ def violation_message(event):
     message += 'IAM ARN: ' + \
         event['detail']['responseElements']['user']['arn'] + ' \n'
     message += 'IAM User: ' + \
-        event['detail']['responseElements']['user']['userName'] + ' \n'
+        event['detail']['responseElements']['user']['userName'] + '\n'
     message += 'Event: ' + \
         event['detail']['eventName'] + '\n'
     message += 'Actor: ' + \

--- a/notify_new_iam_user/iam.tf
+++ b/notify_new_iam_user/iam.tf
@@ -40,7 +40,7 @@ resource "aws_iam_role_policy" "new_iam_user_response_policy" {
           "logs:CreateLogStream",
           "logs:PutLogEvents"
         ]
-        Resource = "arn:${data.aws_partition.current.partition}:logs:*:*:*"
+        Resource = "arn:aws:logs:*:*:*"
       },
       {
         Action = [
@@ -48,7 +48,7 @@ resource "aws_iam_role_policy" "new_iam_user_response_policy" {
         ]
         Effect   = "Allow"
         Sid      = "AllowSnsActions"
-        Resource = "arn:aws:sns:${local.region}:${local.account_id}:${var.sns_topic}"
+        Resource = "arn:aws:sns:ca-central-1:${local.account_id}:${var.sns_topic}"
       }
     ]
   })

--- a/notify_new_iam_user/lambda.tf
+++ b/notify_new_iam_user/lambda.tf
@@ -28,7 +28,7 @@ resource "aws_lambda_function" "new_iam_user_added_lambda" {
   role          = aws_iam_role.new_iam_user_response_role.arn
   environment {
     variables = {
-      outbound_topic_arn = "arn:aws:sns:${local.region}:${local.account_id}:${var.sns_topic}"
+      outbound_topic_arn = "arn:aws:sns:ca-central-1:${local.account_id}:${var.sns_topic}"
       logging_level      = var.logging_level
     }
   }

--- a/notify_new_iam_user/locals.tf
+++ b/notify_new_iam_user/locals.tf
@@ -1,6 +1,5 @@
 # Get the current AWS account ID and region
 data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
 
 locals {
   common_tags = {
@@ -8,5 +7,5 @@ locals {
     Terraform             = "true"
   }
   account_id = data.aws_caller_identity.current.account_id
-  region     = data.aws_region.current.name
+  region     = "us-east-1" 
 }

--- a/notify_new_iam_user/locals.tf
+++ b/notify_new_iam_user/locals.tf
@@ -7,5 +7,5 @@ locals {
     Terraform             = "true"
   }
   account_id = data.aws_caller_identity.current.account_id
-  region     = "us-east-1" 
+  region     = "us-east-1"
 }


### PR DESCRIPTION
# Summary | Résumé

The following changes were made:

- Updated the module code to live in zone us-east-1 in order for the CreateUser Cloudtrail log to be properly picked up. 
- Since the sre-internal topic lives in ca-central-1, needed to update the topic region
- Created a new cloudwatch log group that the lambda function will send output to.
- Removed an extra space for the username created and this was inserting an extra space in the sre-alert
- Updated documentation. 

If there is a better way to do this, I am all ears!