### PR TITLE
fix: allow the AWS v5 provider for S3 modules

### DIFF
--- a/.github/workflows/conftest/test_plan.tf
+++ b/.github/workflows/conftest/test_plan.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0, < 5"
+      version = ">= 4.9.0"
     }
 
   }

--- a/S3/README.md
+++ b/S3/README.md
@@ -8,13 +8,13 @@ The License file for this module can be found in this directory
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0, < 5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0, < 5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
 
 ## Modules
 

--- a/S3/versions.tf
+++ b/S3/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.26"
 
   required_providers {
-    aws = ">= 4.9.0, < 5"
+    aws = ">= 4.9.0"
   }
 }

--- a/S3_log_bucket/README.md
+++ b/S3_log_bucket/README.md
@@ -8,13 +8,13 @@ The License file for this module can be found in this directory.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0, < 5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0, < 5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
 
 ## Modules
 

--- a/S3_log_bucket/versions.tf
+++ b/S3_log_bucket/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.26"
 
   required_providers {
-    aws = ">= 4.9.0, < 5"
+    aws = ">= 4.9.0"
   }
 }


### PR DESCRIPTION
# Summary
Update the S3 module version constraints to allow the v5 AWS provider.

These were added because it was expected that the v5 provider would have breaking changes for the deprecated attributes of the `aws_s3_bucket`, but the changes were not made.