### PR TITLE
fix: non-critical s3_log_access bucket

### DIFF
--- a/S3_log_bucket/main.tf
+++ b/S3_log_bucket/main.tf
@@ -205,12 +205,7 @@ resource "aws_s3_bucket_public_access_block" "this" {
 resource "aws_s3_bucket_versioning" "this" {
   bucket = aws_s3_bucket_policy.this.id
 
-  dynamic "versioning_configuration" {
-    for_each = var.critical_tag_value == true ? [1] : []
-
-    content {
-      status = "Enabled"
-    }
+  versioning_configuration {
+    status = var.critical_tag_value ? "Enabled" : "Disabled"
   }
-
 }


### PR DESCRIPTION
# Summary
Fix the S3 bucket versioning resource so that it creates successfully if the bucket is marked as non-critical.

# Related
- https://github.com/cds-snc/terraform-modules/pull/263