### PR TITLE
fix: directly set the S3 versioning status

### DIFF
--- a/S3_log_bucket/README.md
+++ b/S3_log_bucket/README.md
@@ -52,6 +52,7 @@ No modules.
 | <a name="input_lifecycle_rule"></a> [lifecycle\_rule](#input\_lifecycle\_rule) | (Optional) List of maps containing configuration of object lifecycle management. | `any` | `[]` | no |
 | <a name="input_object_ownership"></a> [object\_ownership](#input\_object\_ownership) | (Optional), overrides object ownership value in aws\_s3\_bucket\_ownership\_controls. Defaults to BucketOwnerPreferred | `string` | `"BucketOwnerPreferred"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
+| <a name="input_versioning_status"></a> [versioning\_status](#input\_versioning\_status) | (Optional) The versioning status of the bucket.  Valid values are 'Enabled', 'Disabled' or 'Suspended'. | `string` | `"Disabled"` | no |
 
 ## Outputs
 

--- a/S3_log_bucket/input.tf
+++ b/S3_log_bucket/input.tf
@@ -71,3 +71,14 @@ variable "object_ownership" {
   type        = string
   default     = "BucketOwnerPreferred"
 }
+
+variable "versioning_status" {
+  description = "(Optional) The versioning status of the bucket.  Valid values are 'Enabled', 'Disabled' or 'Suspended'."
+  type        = string
+  default     = "Disabled"
+
+  validation {
+    condition     = contains(["Enabled", "Disabled", "Suspended"], var.versioning_status)
+    error_message = "Versioning status must be 'Enabled', 'Disabled' or 'Suspended'"
+  }   
+}

--- a/S3_log_bucket/input.tf
+++ b/S3_log_bucket/input.tf
@@ -80,5 +80,5 @@ variable "versioning_status" {
   validation {
     condition     = contains(["Enabled", "Disabled", "Suspended"], var.versioning_status)
     error_message = "Versioning status must be 'Enabled', 'Disabled' or 'Suspended'"
-  }   
+  }
 }

--- a/S3_log_bucket/main.tf
+++ b/S3_log_bucket/main.tf
@@ -206,6 +206,6 @@ resource "aws_s3_bucket_versioning" "this" {
   bucket = aws_s3_bucket_policy.this.id
 
   versioning_configuration {
-    status = var.critical_tag_value ? "Enabled" : "Disabled"
+    status = var.versioning_status
   }
 }


### PR DESCRIPTION
# Summary
Update the S3 versioning status to be directly set via the `versioning_status` variable.  This is being done because a bucket that has versioning `Enabled` cannot be set to `Disabled` and must instead go to `Suspended`.

Also updates the module to set versioning disabled by default as an access log bucket only has each log
written once.

# Related
- https://github.com/cds-snc/scan-files/pull/641
