### PR TITLE
fix: add Lambda function name to query

### DIFF
--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -67,7 +67,7 @@ resource "aws_cloudwatch_log_group" "this" {
 }
 
 resource "aws_cloudwatch_query_definition" "lambda_statistics" {
-  name = "Lambda Statistics"
+  name = "Lambda Statistics - ${var.name}"
 
   log_group_names = [
     "aws_cloudwatch_log_group.this"


### PR DESCRIPTION
# Summary
Update the CloudWatch query definition to include the function name.  This will prevent name clashes for projects that are using this module more than once.
