### PR TITLE
Adding a period to the end of the error message

### DIFF
--- a/S3_log_bucket/input.tf
+++ b/S3_log_bucket/input.tf
@@ -79,6 +79,6 @@ variable "versioning_status" {
 
   validation {
     condition     = contains(["Enabled", "Disabled", "Suspended"], var.versioning_status)
-    error_message = "Versioning status must be 'Enabled', 'Disabled' or 'Suspended'"
+    error_message = "Versioning status must be 'Enabled', 'Disabled' or 'Suspended'."
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Due to a rather silly and unreasonable terraform [requirement](https://developer.hashicorp.com/terraform/language/expressions/custom-conditions), we need to the error message to be "at least one full English sentence starting with an uppercase letter and ending with a period or question". Previously, it did not end with a period, so I just added it. 