### PR TITLE
Add warning to keep version to below 4.0.0 for module

### DIFF
--- a/gh_oidc_role/README.md
+++ b/gh_oidc_role/README.md
@@ -2,6 +2,8 @@
 Creates an OpenID Connect Role that can be used for authenticating workflows in Github Actions
 This allows for a more secure way to connect to AWS as it doesn't rely on static credentials but uses temporary credentials created for each run.
 
+**Warning - there is a breaking change in terraform-module release 4.0.0, so if you are using the gh\_oicd\_role module stick to a version below 4.0.0 unless you properly migrate to use the aft-account\_request github repo or fix the gh\_oidc\_role module.**
+
 ## Requirements
 
 No requirements.

--- a/gh_oidc_role/main.tf
+++ b/gh_oidc_role/main.tf
@@ -3,6 +3,8 @@
 * Creates an OpenID Connect Role that can be used for authenticating workflows in Github Actions
 * This allows for a more secure way to connect to AWS as it doesn't rely on static credentials but uses temporary credentials created for each run.
 * 
+* ** Warning - there is a breaking change in terraform-module release 4.0.0, so if you are using the gh_oicd_role module stick to a version below 4.0.0 unless you properly migrate to use the aft-account_request github repo or fix the gh_oidc_role module.** 
+* 
 */
 
 locals {

--- a/gh_oidc_role/main.tf
+++ b/gh_oidc_role/main.tf
@@ -3,8 +3,7 @@
 * Creates an OpenID Connect Role that can be used for authenticating workflows in Github Actions
 * This allows for a more secure way to connect to AWS as it doesn't rely on static credentials but uses temporary credentials created for each run.
 * 
-* **Warning - there is a breaking change in terraform-module release 4.0.0, so if you are using the gh_oicd_role module stick to a 
-* version below 4.0.0 unless you properly migrate to use the aft-account_request github repo or fix the gh_oidc_role module.** 
+* **Warning - there is a breaking change in terraform-module release 4.0.0, so if you are using the gh_oicd_role module stick to a version below 4.0.0 unless you properly migrate to use the aft-account_request github repo or fix the gh_oidc_role module.**
 * 
 */
 

--- a/gh_oidc_role/main.tf
+++ b/gh_oidc_role/main.tf
@@ -3,7 +3,8 @@
 * Creates an OpenID Connect Role that can be used for authenticating workflows in Github Actions
 * This allows for a more secure way to connect to AWS as it doesn't rely on static credentials but uses temporary credentials created for each run.
 * 
-* ** Warning - there is a breaking change in terraform-module release 4.0.0, so if you are using the gh_oicd_role module stick to a version below 4.0.0 unless you properly migrate to use the aft-account_request github repo or fix the gh_oidc_role module.** 
+* **Warning - there is a breaking change in terraform-module release 4.0.0, so if you are using the gh_oicd_role module stick to a 
+* version below 4.0.0 unless you properly migrate to use the aft-account_request github repo or fix the gh_oidc_role module.** 
 * 
 */
 


### PR DESCRIPTION
# Summary | Résumé

Added a warning to the gh_oidc_role when generating terraform docs to keep the version to below 4.0.0 since version 4.0.0 contains a breaking change (if someone even reads it...)