### PR TITLE
fix: add scan queue suffix

### DIFF
--- a/S3_scan_object/README.md
+++ b/S3_scan_object/README.md
@@ -55,6 +55,7 @@ No modules.
 | <a name="input_s3_upload_bucket_policy_create"></a> [s3\_upload\_bucket\_policy\_create](#input\_s3\_upload\_bucket\_policy\_create) | (Optional, defaut 'true') Create the S3 upload bucket policy to allow Scan Files access. | `bool` | `true` | no |
 | <a name="input_scan_files_assume_role_create"></a> [scan\_files\_assume\_role\_create](#input\_scan\_files\_assume\_role\_create) | (Optional, default 'true') Create the IAM role that Scan Files assumes.  Defaults to `true`.  If this is set to `false`, it is assumed that the role already exists in the account. | `bool` | `true` | no |
 | <a name="input_scan_files_role_arn"></a> [scan\_files\_role\_arn](#input\_scan\_files\_role\_arn) | (Optional, default Scan Files API role) Scan Files lambda execution role ARN | `string` | `"arn:aws:iam::806545929748:role/scan-files-api"` | no |
+| <a name="input_scan_queue_suffix"></a> [scan\_queue\_suffix](#input\_scan\_queue\_suffix) | (Optional, default blank) Suffix to add the scan queue resources.  This allows multiple instances of the module to be used in the same account. | `string` | `""` | no |
 
 ## Outputs
 

--- a/S3_scan_object/iam.tf
+++ b/S3_scan_object/iam.tf
@@ -5,7 +5,7 @@ data "aws_iam_role" "scan_files" {
 
 resource "aws_iam_role" "scan_files" {
   count              = var.scan_files_assume_role_create ? 1 : 0
-  name               = "ScanFilesGetObjects"
+  name               = "ScanFilesGetObjects${var.scan_queue_suffix}"
   assume_role_policy = data.aws_iam_policy_document.scan_files_assume_role[0].json
   tags               = local.common_tags
 }
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "scan_files_assume_role" {
 
 resource "aws_iam_policy" "scan_files" {
   count  = var.scan_files_assume_role_create ? 1 : 0
-  name   = "ScanFilesGetObjects"
+  name   = "ScanFilesGetObjects${var.scan_queue_suffix}"
   path   = "/"
   policy = data.aws_iam_policy_document.scan_files[0].json
   tags   = local.common_tags

--- a/S3_scan_object/input.tf
+++ b/S3_scan_object/input.tf
@@ -20,6 +20,12 @@ variable "s3_upload_bucket_policy_create" {
   default     = true
 }
 
+variable "s3_scan_object_role_arn" {
+  description = "(Optional, default S3 Scan Object role) S3 scan object lambda execution role ARN"
+  default     = "arn:aws:iam::806545929748:role/s3-scan-object"
+  type        = string
+}
+
 variable "scan_files_assume_role_create" {
   description = "(Optional, default 'true') Create the IAM role that Scan Files assumes.  Defaults to `true`.  If this is set to `false`, it is assumed that the role already exists in the account."
   type        = bool
@@ -32,8 +38,8 @@ variable "scan_files_role_arn" {
   type        = string
 }
 
-variable "s3_scan_object_role_arn" {
-  description = "(Optional, default S3 Scan Object role) S3 scan object lambda execution role ARN"
-  default     = "arn:aws:iam::806545929748:role/s3-scan-object"
+variable "scan_queue_suffix" {
+  description = "(Optional, default blank) Suffix to add the scan queue resources.  This allows multiple instances of the module to be used in the same account."
+  default     = ""
   type        = string
 }

--- a/S3_scan_object/kms.tf
+++ b/S3_scan_object/kms.tf
@@ -6,7 +6,7 @@ resource "aws_kms_key" "s3_scan_object_queue" {
 }
 
 resource "aws_kms_alias" "s3_scan_object_queue" {
-  name          = "alias/s3_scan_object_queue"
+  name          = "alias/s3_scan_object_queue${var.scan_queue_suffix}"
   target_key_id = aws_kms_key.s3_scan_object_queue.key_id
 }
 

--- a/S3_scan_object/main.tf
+++ b/S3_scan_object/main.tf
@@ -9,7 +9,7 @@
 * - You can build your own Lambda Docker image using the code in [cds-snc/scan-files/module/s3-scan-object](https://github.com/cds-snc/scan-files/tree/main/module/s3-scan-object).
 */
 resource "aws_sqs_queue" "s3_scan_object" {
-  name                       = "s3-scan-object"
+  name                       = "s3-scan-object${var.scan_queue_suffix}"
   kms_master_key_id          = aws_kms_key.s3_scan_object_queue.arn
   visibility_timeout_seconds = 300
   tags                       = local.common_tags


### PR DESCRIPTION
# Summary
Update the `S3_scan_object` module to include a scan queue suffix.  This allows the module to be used more than once in a single AWS account.

# Related
- https://github.com/cds-snc/share-files-securely/pull/24