### PR TITLE
feat: share a single SQS queue

### DIFF
--- a/S3_scan_object/README.md
+++ b/S3_scan_object/README.md
@@ -51,11 +51,10 @@ No modules.
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_s3_scan_object_role_arn"></a> [s3\_scan\_object\_role\_arn](#input\_s3\_scan\_object\_role\_arn) | (Optional, default S3 Scan Object role) S3 scan object lambda execution role ARN | `string` | `"arn:aws:iam::806545929748:role/s3-scan-object"` | no |
-| <a name="input_s3_upload_bucket_name"></a> [s3\_upload\_bucket\_name](#input\_s3\_upload\_bucket\_name) | (Required) Name of the existing S3 upload bucket to scan objects in. | `string` | n/a | yes |
+| <a name="input_s3_upload_bucket_names"></a> [s3\_upload\_bucket\_names](#input\_s3\_upload\_bucket\_names) | (Required) Names of the existing S3 upload bucket to scan objects in. | `list(string)` | n/a | yes |
 | <a name="input_s3_upload_bucket_policy_create"></a> [s3\_upload\_bucket\_policy\_create](#input\_s3\_upload\_bucket\_policy\_create) | (Optional, defaut 'true') Create the S3 upload bucket policy to allow Scan Files access. | `bool` | `true` | no |
 | <a name="input_scan_files_assume_role_create"></a> [scan\_files\_assume\_role\_create](#input\_scan\_files\_assume\_role\_create) | (Optional, default 'true') Create the IAM role that Scan Files assumes.  Defaults to `true`.  If this is set to `false`, it is assumed that the role already exists in the account. | `bool` | `true` | no |
 | <a name="input_scan_files_role_arn"></a> [scan\_files\_role\_arn](#input\_scan\_files\_role\_arn) | (Optional, default Scan Files API role) Scan Files lambda execution role ARN | `string` | `"arn:aws:iam::806545929748:role/scan-files-api"` | no |
-| <a name="input_scan_queue_suffix"></a> [scan\_queue\_suffix](#input\_scan\_queue\_suffix) | (Optional, default blank) Suffix to add the scan queue resources.  This allows multiple instances of the module to be used in the same account. | `string` | `""` | no |
 
 ## Outputs
 

--- a/S3_scan_object/examples/existing_policy/main.tf
+++ b/S3_scan_object/examples/existing_policy/main.tf
@@ -1,7 +1,7 @@
 module "existing_policy" {
   source = "../../"
 
-  s3_upload_bucket_name          = module.upload_bucket.s3_bucket_id
+  s3_upload_bucket_names         = [module.upload_bucket.s3_bucket_id]
   s3_upload_bucket_policy_create = false
   billing_tag_value              = "terratest"
 }
@@ -11,7 +11,7 @@ resource "random_id" "upload_bucket" {
 }
 
 module "upload_bucket" {
-  source            = "github.com/cds-snc/terraform-modules//S3?ref=v6.1.3"
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=v6.1.5"
   bucket_name       = "an-existing-upload-bucket-${random_id.upload_bucket.hex}"
   billing_tag_value = "terratest"
 

--- a/S3_scan_object/examples/simple/main.tf
+++ b/S3_scan_object/examples/simple/main.tf
@@ -1,17 +1,30 @@
 module "simple" {
   source = "../../"
 
-  s3_upload_bucket_name = module.upload_bucket.s3_bucket_id
-  billing_tag_value     = "terratest"
+  s3_upload_bucket_names = [
+    module.upload_bucket_one.s3_bucket_id,
+    module.upload_bucket_two.s3_bucket_id
+  ]
+  billing_tag_value = "terratest"
 }
 
 resource "random_id" "upload_bucket" {
   byte_length = 4
 }
 
-module "upload_bucket" {
-  source            = "github.com/cds-snc/terraform-modules//S3?ref=v6.1.3"
+module "upload_bucket_one" {
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=v6.1.5"
   bucket_name       = "an-existing-upload-bucket-${random_id.upload_bucket.hex}"
+  billing_tag_value = "terratest"
+
+  versioning = {
+    enabled = true
+  }
+}
+
+module "upload_bucket_two" {
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=v6.1.5"
+  bucket_name       = "another-existing-upload-bucket-${random_id.upload_bucket.hex}"
   billing_tag_value = "terratest"
 
   versioning = {

--- a/S3_scan_object/examples/simple/main.tf
+++ b/S3_scan_object/examples/simple/main.tf
@@ -5,6 +5,7 @@ module "simple" {
     module.upload_bucket_one.s3_bucket_id,
     module.upload_bucket_two.s3_bucket_id
   ]
+
   billing_tag_value = "terratest"
 }
 

--- a/S3_scan_object/iam.tf
+++ b/S3_scan_object/iam.tf
@@ -61,6 +61,6 @@ data "aws_iam_policy_document" "scan_files" {
       "s3:PutObjectTagging",
       "s3:PutObjectVersionTagging"
     ]
-    resources = concat(local.upload_bucket_arns, local.upload_bucket_arns_items)
+    resources = concat(local.upload_buckets[*].arn, local.upload_buckets[*].arn_items)
   }
 }

--- a/S3_scan_object/iam.tf
+++ b/S3_scan_object/iam.tf
@@ -5,7 +5,7 @@ data "aws_iam_role" "scan_files" {
 
 resource "aws_iam_role" "scan_files" {
   count              = var.scan_files_assume_role_create ? 1 : 0
-  name               = "ScanFilesGetObjects${var.scan_queue_suffix}"
+  name               = "ScanFilesGetObjects"
   assume_role_policy = data.aws_iam_policy_document.scan_files_assume_role[0].json
   tags               = local.common_tags
 }
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "scan_files_assume_role" {
 
 resource "aws_iam_policy" "scan_files" {
   count  = var.scan_files_assume_role_create ? 1 : 0
-  name   = "ScanFilesGetObjects${var.scan_queue_suffix}"
+  name   = "ScanFilesGetObjects"
   path   = "/"
   policy = data.aws_iam_policy_document.scan_files[0].json
   tags   = local.common_tags
@@ -61,6 +61,6 @@ data "aws_iam_policy_document" "scan_files" {
       "s3:PutObjectTagging",
       "s3:PutObjectVersionTagging"
     ]
-    resources = join(local.upload_bucket_arns, local.upload_bucket_arns_items)
+    resources = concat(local.upload_bucket_arns, local.upload_bucket_arns_items)
   }
 }

--- a/S3_scan_object/iam.tf
+++ b/S3_scan_object/iam.tf
@@ -61,9 +61,6 @@ data "aws_iam_policy_document" "scan_files" {
       "s3:PutObjectTagging",
       "s3:PutObjectVersionTagging"
     ]
-    resources = [
-      local.upload_bucket_arn,
-      "${local.upload_bucket_arn}/*"
-    ]
+    resources = join(local.upload_bucket_arns, local.upload_bucket_arns_items)
   }
 }

--- a/S3_scan_object/input.tf
+++ b/S3_scan_object/input.tf
@@ -9,9 +9,9 @@ variable "billing_tag_value" {
   type        = string
 }
 
-variable "s3_upload_bucket_name" {
-  description = "(Required) Name of the existing S3 upload bucket to scan objects in."
-  type        = string
+variable "s3_upload_bucket_names" {
+  description = "(Required) Names of the existing S3 upload bucket to scan objects in."
+  type        = list(string)
 }
 
 variable "s3_upload_bucket_policy_create" {
@@ -35,11 +35,5 @@ variable "scan_files_assume_role_create" {
 variable "scan_files_role_arn" {
   description = "(Optional, default Scan Files API role) Scan Files lambda execution role ARN"
   default     = "arn:aws:iam::806545929748:role/scan-files-api"
-  type        = string
-}
-
-variable "scan_queue_suffix" {
-  description = "(Optional, default blank) Suffix to add the scan queue resources.  This allows multiple instances of the module to be used in the same account."
-  default     = ""
   type        = string
 }

--- a/S3_scan_object/kms.tf
+++ b/S3_scan_object/kms.tf
@@ -6,7 +6,7 @@ resource "aws_kms_key" "s3_scan_object_queue" {
 }
 
 resource "aws_kms_alias" "s3_scan_object_queue" {
-  name          = "alias/s3_scan_object_queue${var.scan_queue_suffix}"
+  name          = "alias/s3_scan_object_queue"
   target_key_id = aws_kms_key.s3_scan_object_queue.key_id
 }
 

--- a/S3_scan_object/locals.tf
+++ b/S3_scan_object/locals.tf
@@ -3,9 +3,13 @@ data "aws_caller_identity" "current" {}
 locals {
   account_id                 = data.aws_caller_identity.current.account_id
   scan_files_assume_role_arn = var.scan_files_assume_role_create ? aws_iam_role.scan_files[0].arn : data.aws_iam_role.scan_files[0].arn
-  upload_bucket_arns         = formatlist("arn:aws:s3:::%s", var.s3_upload_bucket_names)
-  upload_bucket_arns_items   = formatlist("%s/*", local.upload_bucket_arns)
-  upload_bucket_ids          = var.s3_upload_bucket_names
+  upload_buckets = [
+    for name in var.s3_upload_bucket_names : {
+      id        = name
+      arn       = "arn:aws:s3:::${name}"
+      arn_items = "arn:aws:s3:::${name}/*"
+    }
+  ]
 
   common_tags = {
     (var.billing_tag_key) = var.billing_tag_value

--- a/S3_scan_object/locals.tf
+++ b/S3_scan_object/locals.tf
@@ -3,8 +3,9 @@ data "aws_caller_identity" "current" {}
 locals {
   account_id                 = data.aws_caller_identity.current.account_id
   scan_files_assume_role_arn = var.scan_files_assume_role_create ? aws_iam_role.scan_files[0].arn : data.aws_iam_role.scan_files[0].arn
-  upload_bucket_arn          = "arn:aws:s3:::${var.s3_upload_bucket_name}"
-  upload_bucket_id           = var.s3_upload_bucket_name
+  upload_bucket_arns         = formatlist("arn:aws:s3:::%s", var.s3_upload_bucket_names)
+  upload_bucket_arns_items   = formatlist("%s/*", local.upload_bucket_arns)
+  upload_bucket_ids          = var.s3_upload_bucket_names
 
   common_tags = {
     (var.billing_tag_key) = var.billing_tag_value

--- a/S3_scan_object/main.tf
+++ b/S3_scan_object/main.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "s3_scan_object" {
     condition {
       test     = "ArnEquals"
       variable = "aws:SourceArn"
-      values   = local.upload_bucket_arns
+      values   = local.upload_buckets[*].arn
     }
   }
 

--- a/S3_scan_object/main.tf
+++ b/S3_scan_object/main.tf
@@ -9,7 +9,7 @@
 * - You can build your own Lambda Docker image using the code in [cds-snc/scan-files/module/s3-scan-object](https://github.com/cds-snc/scan-files/tree/main/module/s3-scan-object).
 */
 resource "aws_sqs_queue" "s3_scan_object" {
-  name                       = "s3-scan-object${var.scan_queue_suffix}"
+  name                       = "s3-scan-object"
   kms_master_key_id          = aws_kms_key.s3_scan_object_queue.arn
   visibility_timeout_seconds = 300
   tags                       = local.common_tags

--- a/S3_scan_object/main.tf
+++ b/S3_scan_object/main.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "s3_scan_object" {
     condition {
       test     = "ArnEquals"
       variable = "aws:SourceArn"
-      values   = [local.upload_bucket_arn]
+      values   = local.upload_bucket_arns
     }
   }
 

--- a/S3_scan_object/s3.tf
+++ b/S3_scan_object/s3.tf
@@ -2,9 +2,8 @@
 # Bucket policy
 #
 resource "aws_s3_bucket_policy" "upload_bucket" {
-  for_each = toset(var.s3_upload_bucket_policy_create ? local.upload_bucket_ids : [])
-
-  bucket = each.key
+  count  = var.s3_upload_bucket_policy_create ? length(local.upload_bucket_ids) : 0
+  bucket = local.upload_bucket_ids[count.index]
   policy = data.aws_iam_policy_document.upload_bucket[0].json
 }
 
@@ -85,8 +84,8 @@ data "aws_iam_policy_document" "scan_files_download" {
 # Trigger scan when file is created
 #
 resource "aws_s3_bucket_notification" "s3_scan_object" {
-  for_each = toset(local.upload_bucket_ids)
-  bucket   = each.key
+  count  = length(local.upload_bucket_ids)
+  bucket = local.upload_bucket_ids[count.index]
 
   queue {
     id        = "ScanObjectCreated"

--- a/S3_scan_object/s3.tf
+++ b/S3_scan_object/s3.tf
@@ -77,7 +77,7 @@ data "aws_iam_policy_document" "scan_files_download" {
       "s3:GetObjectVersion",
       "s3:GetObjectVersionTagging"
     ]
-    resources = join(local.upload_bucket_arns, local.upload_bucket_arns_items)
+    resources = concat(local.upload_bucket_arns, local.upload_bucket_arns_items)
   }
 }
 


### PR DESCRIPTION
# Summary
Update the `S3_scan_objects` module so that multiple buckets can share the same SQS queue.

This allows a single AWS account to have multiple S3 buckets being scanned.