### PR TITLE
Feat/critical add log bucket forwarder

### DIFF
--- a/S3/README.md
+++ b/S3/README.md
@@ -21,13 +21,13 @@ The License file for this module can be found in this directory
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_s3_log_bucket"></a> [s3\_log\_bucket](#module\_s3\_log\_bucket) | ../S3_log_bucket | n/a |
-| <a name="module_sentinel_forwarder"></a> [sentinel\_forwarder](#module\_sentinel\_forwarder) | ../sentinel_forwarder | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_logging.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 
 ## Inputs

--- a/S3/README.md
+++ b/S3/README.md
@@ -18,7 +18,10 @@ The License file for this module can be found in this directory
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_s3_log_bucket"></a> [s3\_log\_bucket](#module\_s3\_log\_bucket) | ../S3_log_bucket | n/a |
+| <a name="module_sentinel_forwarder"></a> [sentinel\_forwarder](#module\_sentinel\_forwarder) | ../sentinel_forwarder | n/a |
 
 ## Resources
 
@@ -37,8 +40,10 @@ No modules.
 | <a name="input_block_public_policy"></a> [block\_public\_policy](#input\_block\_public\_policy) | (Optional, default 'true') Reject requests to add Bucket policy if the specified bucket policy allows public access. | `bool` | `true` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | (Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name. | `string` | `null` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | (Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket. | `string` | `null` | no |
+| <a name="input_configure_critical_bucket_logs"></a> [configure\_critical\_bucket\_logs](#input\_configure\_critical\_bucket\_logs) | (Optional, default=false) Provides the ability to automatically configure a critical bucket default settings for S3 server log backups and forwarder to Sentinel.<br>For more control, the same behaviour can be manually generated using the distinct modules: S3\_log\_bucket and Sentinel\_forwarder. | `bool` | `false` | no |
 | <a name="input_critical_tag_key"></a> [critical\_tag\_key](#input\_critical\_tag\_key) | (Optional) The name of the critical tag. | `string` | `"Critical"` | no |
 | <a name="input_critical_tag_value"></a> [critical\_tag\_value](#input\_critical\_tag\_value) | (Required: default=false) The value of the critical tag. If set to true, protection SCP rules will be applied to the resource. | `bool` | `false` | no |
+| <a name="input_customer_id"></a> [customer\_id](#input\_customer\_id) | (Optional) The Azure customer id for the Sentinel Forwarder. Only required if the *configure\_critical\_bucket\_logs* variable is set to true. | `string` | `null` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |
 | <a name="input_ignore_public_acls"></a> [ignore\_public\_acls](#input\_ignore\_public\_acls) | (Optional, default 'true') Ignore public ACLs on this bucket and any objects that it contains. | `bool` | `true` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | (Optional) KMS key ARN that will be used to encrypt S3 objects.  If not specified, default S3 service key is used for encryption. | `string` | `null` | no |
@@ -47,6 +52,7 @@ No modules.
 | <a name="input_object_lock_configuration"></a> [object\_lock\_configuration](#input\_object\_lock\_configuration) | (Optional, Forces new resource) Map containing S3 object locking configuration. | `any` | `{}` | no |
 | <a name="input_replication_configuration"></a> [replication\_configuration](#input\_replication\_configuration) | (Optional) Map containing cross-region replication configuration. | `any` | `{}` | no |
 | <a name="input_restrict_public_buckets"></a> [restrict\_public\_buckets](#input\_restrict\_public\_buckets) | (Optional, default 'true') Only the bucket owner and AWS Services can access this buckets if it has a public policy. | `bool` | `true` | no |
+| <a name="input_shared_key"></a> [shared\_key](#input\_shared\_key) | (Optional) The Azure shared key for the Sentinel Forwarder. Only required if the *configure\_critical\_bucket\_logs* variable is set to true. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
 | <a name="input_versioning"></a> [versioning](#input\_versioning) | (Optional) Map containing versioning configuration. | `map(string)` | `{}` | no |
 

--- a/S3/input.tf
+++ b/S3/input.tf
@@ -84,6 +84,24 @@ variable "logging" {
   default     = {}
 }
 
+variable "configure_critical_bucket_logs" {
+  description = "(Optional, default=false) Provides the ability to automatically configure a critical bucket default settings for S3 server log backups and forwarder to Sentinel.\nFor more control, the same behaviour can be manually generated using the distinct modules: S3_log_bucket and Sentinel_forwarder."
+  type        = bool
+  default     = false
+}
+
+variable "customer_id" {
+  description = "(Optional) The Azure customer id for the Sentinel Forwarder. Only required if the *configure_critical_bucket_logs* variable is set to true."
+  type        = string
+  default     = null
+}
+
+variable "shared_key" {
+  description = "(Optional) The Azure shared key for the Sentinel Forwarder. Only required if the *configure_critical_bucket_logs* variable is set to true."
+  type        = string
+  default     = null
+}
+
 variable "lifecycle_rule" {
   description = "(Optional) List of maps containing configuration of object lifecycle management."
   type        = any

--- a/S3/locals.tf
+++ b/S3/locals.tf
@@ -4,4 +4,23 @@ locals {
     Terraform              = "true"
     (var.critical_tag_key) = var.critical_tag_value ? "true" : "false"
   }
+  # conditional logging block: 
+  # if configure_critical_bucket_logs is true, then set the S3 Log Bucket required parameters:
+  # 1. s3_log_bucket
+  s3_log_bucket = var.configure_critical_bucket_logs ? {
+    bucket_name = "${var.bucket_name}-server-logs"
+    billing_tag_key   = var.billing_tag_key
+    billing_tag_value = var.billing_tag_value
+  } : {}
+  # 2. sentinel_forwarder
+  sentinel_forwarder = var.configure_critical_bucket_logs ? {
+    function_name     = "${var.bucket_name}-logs-sentinel-forwarder"
+    billing_tag_key   = var.billing_tag_key
+    billing_tag_value = var.billing_tag_value
+    log_type          = "AWSS3ServerAccessLogs"
+    bucket_arn        = module.s3_log_bucket[0].s3_bucket_arn
+    bucket_id         = module.s3_log_bucket[0].s3_bucket_id
+    filter_prefix     = "logs/"
+    kms_key_arn       = ""
+  } : {}
 }

--- a/S3/locals.tf
+++ b/S3/locals.tf
@@ -4,23 +4,9 @@ locals {
     Terraform              = "true"
     (var.critical_tag_key) = var.critical_tag_value ? "true" : "false"
   }
-  # conditional logging block: 
-  # if configure_critical_bucket_logs is true, then set the S3 Log Bucket required parameters:
-  # 1. s3_log_bucket
   s3_log_bucket = var.configure_critical_bucket_logs ? {
     bucket_name = "${var.bucket_name}-server-logs"
     billing_tag_key   = var.billing_tag_key
     billing_tag_value = var.billing_tag_value
-  } : {}
-  # 2. sentinel_forwarder
-  sentinel_forwarder = var.configure_critical_bucket_logs ? {
-    function_name     = "${var.bucket_name}-logs-sentinel-forwarder"
-    billing_tag_key   = var.billing_tag_key
-    billing_tag_value = var.billing_tag_value
-    log_type          = "AWSS3ServerAccessLogs"
-    bucket_arn        = module.s3_log_bucket[0].s3_bucket_arn
-    bucket_id         = module.s3_log_bucket[0].s3_bucket_id
-    filter_prefix     = "logs/"
-    kms_key_arn       = ""
   } : {}
 }

--- a/S3/locals.tf
+++ b/S3/locals.tf
@@ -5,8 +5,32 @@ locals {
     (var.critical_tag_key) = var.critical_tag_value ? "true" : "false"
   }
   s3_log_bucket = var.configure_critical_bucket_logs ? {
-    bucket_name = "${var.bucket_name}-server-logs"
-    billing_tag_key   = var.billing_tag_key
-    billing_tag_value = var.billing_tag_value
+    bucket_name                  = "${var.bucket_name}-server-logs"
+    billing_tag_key              = var.billing_tag_key
+    billing_tag_value            = var.billing_tag_value
+    customer_id                  = var.customer_id
+    shared_key                   = var.shared_key
+    configure_sentinel_forwarder = true
   } : {}
+  logging_configuration = concat(
+    [
+      for key, value in var.logging : {
+        target_bucket = key
+        target_prefix = value
+      }
+    ],
+    var.configure_critical_bucket_logs ? [
+      {
+        target_bucket = local.s3_log_bucket.bucket_name
+        target_prefix = "logs/"
+      }
+    ] : []
+  )
+
+  logging_configuration_objects = [
+    for config in local.logging_configuration : {
+      target_bucket = config.target_bucket
+      target_prefix = config.target_prefix
+    }
+  ]
 }

--- a/S3/main.tf
+++ b/S3/main.tf
@@ -30,14 +30,14 @@ resource "aws_s3_bucket" "this" {
     }
   }
 
-  dynamic "logging" {
-    for_each = length(keys(var.logging)) == 0 ? [] : [var.logging]
+  # dynamic "logging" {
+  #   for_each = length(keys(var.logging)) == 0 ? [] : [var.logging]
 
-    content {
-      target_bucket = logging.value.target_bucket
-      target_prefix = lookup(logging.value, "target_prefix", null)
-    }
-  }
+  #   content {
+  #     target_bucket = logging.value.target_bucket
+  #     target_prefix = lookup(logging.value, "target_prefix", null)
+  #   }
+  # }
 
   dynamic "lifecycle_rule" {
     for_each = try(jsondecode(var.lifecycle_rule), var.lifecycle_rule)
@@ -173,19 +173,28 @@ resource "aws_s3_bucket_public_access_block" "this" {
   restrict_public_buckets = var.restrict_public_buckets
 }
 
+resource "aws_s3_bucket_logging" "this" {
+  
+  count = length(local.logging_configuration_objects)
+
+  bucket        = aws_s3_bucket.this.id
+  target_bucket = element(local.logging_configuration_objects, count.index).target_bucket
+  target_prefix = element(local.logging_configuration_objects, count.index).target_prefix
+}
+
 module "s3_log_bucket" {
   source = "../S3_log_bucket"
 
   count = var.configure_critical_bucket_logs ? 1 : 0
 
-  configure_sentinel_forwarder = true
-  
+  configure_sentinel_forwarder = local.s3_log_bucket.configure_sentinel_forwarder
+
   billing_tag_key   = local.s3_log_bucket.billing_tag_key
   billing_tag_value = local.s3_log_bucket.billing_tag_value
-  
-  bucket_name       = local.s3_log_bucket.bucket_name
-  
-  customer_id       = var.customer_id
-  shared_key        = var.shared_key
+
+  bucket_name = local.s3_log_bucket.bucket_name
+
+  customer_id = local.s3_log_bucket.customer_id
+  shared_key  = local.s3_log_bucket.shared_key
 
 }

--- a/S3/main.tf
+++ b/S3/main.tf
@@ -174,7 +174,7 @@ resource "aws_s3_bucket_public_access_block" "this" {
 }
 
 resource "aws_s3_bucket_logging" "this" {
-  
+
   count = length(local.logging_configuration_objects)
 
   bucket        = aws_s3_bucket.this.id

--- a/S3/main.tf
+++ b/S3/main.tf
@@ -178,37 +178,14 @@ module "s3_log_bucket" {
 
   count = var.configure_critical_bucket_logs ? 1 : 0
 
-  bucket_name       = local.s3_log_bucket.bucket_name
+  configure_sentinel_forwarder = true
+  
   billing_tag_key   = local.s3_log_bucket.billing_tag_key
   billing_tag_value = local.s3_log_bucket.billing_tag_value
+  
+  bucket_name       = local.s3_log_bucket.bucket_name
+  
+  customer_id       = var.customer_id
+  shared_key        = var.shared_key
 
-  depends_on = [aws_s3_bucket.this]
-}
-
-module "sentinel_forwarder" {
-  source = "../sentinel_forwarder"
-
-  count = var.configure_critical_bucket_logs ? 1 : 0
-
-  function_name = "${aws_s3_bucket.this.id}-sentinel-forwarder}"
-  customer_id   = var.customer_id
-  shared_key    = var.shared_key
-
-  log_type = local.sentinel_forwarder.log_type
-
-  layer_arn = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:78"
-
-  s3_sources = [
-    {
-      bucket_arn    = local.sentinel_forwarder.bucket_arn
-      bucket_id     = local.sentinel_forwarder.bucket_id
-      filter_prefix = local.sentinel_forwarder.filter_prefix
-      kms_key_arn   = local.sentinel_forwarder.kms_key_arn
-    }
-  ]
-
-  billing_tag_key   = var.billing_tag_key
-  billing_tag_value = var.billing_tag_value
-
-  depends_on = [module.s3_log_bucket, aws_s3_bucket.this]
 }

--- a/S3_log_bucket/README.md
+++ b/S3_log_bucket/README.md
@@ -18,7 +18,9 @@ The License file for this module can be found in this directory.
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_sentinel_forwarder"></a> [sentinel\_forwarder](#module\_sentinel\_forwarder) | ../sentinel_forwarder | n/a |
 
 ## Resources
 
@@ -46,11 +48,14 @@ No modules.
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | (Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name. | `string` | `null` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | (Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket. | `string` | `null` | no |
+| <a name="input_configure_sentinel_forwarder"></a> [configure\_sentinel\_forwarder](#input\_configure\_sentinel\_forwarder) | (Optional, default=false) Provides the ability to automatically configure a sentinel forwader for S3 server logs saved in the log bucket.<br>For more control, the same behaviour can be manually generated using the distinct module: sentinel\_forwarder. | `bool` | `false` | no |
 | <a name="input_critical_tag_key"></a> [critical\_tag\_key](#input\_critical\_tag\_key) | (Optional) The name of the critical tag. | `string` | `"Critical"` | no |
 | <a name="input_critical_tag_value"></a> [critical\_tag\_value](#input\_critical\_tag\_value) | (Required: default=true) The value of the critical tag. If set to true, protection SCP rules will be applied to the resource. | `bool` | `true` | no |
+| <a name="input_customer_id"></a> [customer\_id](#input\_customer\_id) | (Optional) The Azure customer id for the Sentinel Forwarder. Only required if the *configure\_sentinel\_forwarder* variable is set to true. | `string` | `null` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |
 | <a name="input_lifecycle_rule"></a> [lifecycle\_rule](#input\_lifecycle\_rule) | (Optional) List of maps containing configuration of object lifecycle management. | `any` | `[]` | no |
 | <a name="input_object_ownership"></a> [object\_ownership](#input\_object\_ownership) | (Optional), overrides object ownership value in aws\_s3\_bucket\_ownership\_controls. Defaults to BucketOwnerPreferred | `string` | `"BucketOwnerPreferred"` | no |
+| <a name="input_shared_key"></a> [shared\_key](#input\_shared\_key) | (Optional) The Azure shared key for the Sentinel Forwarder. Only required if the *configure\_sentinel\_forwarder* variable is set to true. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
 | <a name="input_versioning_status"></a> [versioning\_status](#input\_versioning\_status) | (Optional) The versioning status of the bucket.  Valid values are 'Enabled', 'Disabled' or 'Suspended'. | `string` | `"Disabled"` | no |
 

--- a/S3_log_bucket/input.tf
+++ b/S3_log_bucket/input.tf
@@ -82,3 +82,21 @@ variable "versioning_status" {
     error_message = "Versioning status must be 'Enabled', 'Disabled' or 'Suspended'."
   }
 }
+
+variable "configure_sentinel_forwarder" {
+  description = "(Optional, default=false) Provides the ability to automatically configure a sentinel forwader for S3 server logs saved in the log bucket.\nFor more control, the same behaviour can be manually generated using the distinct module: sentinel_forwarder."
+  type        = bool
+  default     = false
+}
+
+variable "customer_id" {
+  description = "(Optional) The Azure customer id for the Sentinel Forwarder. Only required if the *configure_sentinel_forwarder* variable is set to true."
+  type        = string
+  default     = null
+}
+
+variable "shared_key" {
+  description = "(Optional) The Azure shared key for the Sentinel Forwarder. Only required if the *configure_sentinel_forwarder* variable is set to true."
+  type        = string
+  default     = null
+}

--- a/S3_log_bucket/locals.tf
+++ b/S3_log_bucket/locals.tf
@@ -8,7 +8,7 @@ locals {
     function_name     = "${var.bucket_name}-logs-sentinel-forwarder"
     billing_tag_key   = var.billing_tag_key
     billing_tag_value = var.billing_tag_value
-    log_type          = "AWSS3ServerAccessLogs"
+    log_type          = "s3serveraccesslogs"
     bucket_arn        = aws_s3_bucket.this.arn
     bucket_id         = aws_s3_bucket.this.id
     filter_prefix     = "logs/"

--- a/S3_log_bucket/locals.tf
+++ b/S3_log_bucket/locals.tf
@@ -4,4 +4,14 @@ locals {
     Terraform              = "true"
     (var.critical_tag_key) = var.critical_tag_value ? "true" : "false"
   }
+  sentinel_forwarder = var.configure_sentinel_forwarder ? {
+    function_name     = "${var.bucket_name}-logs-sentinel-forwarder"
+    billing_tag_key   = var.billing_tag_key
+    billing_tag_value = var.billing_tag_value
+    log_type          = "AWSS3ServerAccessLogs"
+    bucket_arn        = aws_s3_bucket.this.arn
+    bucket_id         = aws_s3_bucket.this.id
+    filter_prefix     = "logs/"
+    kms_key_arn       = ""
+  } : {}
 }

--- a/S3_log_bucket/main.tf
+++ b/S3_log_bucket/main.tf
@@ -209,3 +209,30 @@ resource "aws_s3_bucket_versioning" "this" {
     status = var.versioning_status
   }
 }
+
+
+module "sentinel_forwarder" {
+  source = "../sentinel_forwarder"
+
+  count = var.configure_sentinel_forwarder ? 1 : 0
+
+  function_name = "${aws_s3_bucket.this.id}-sentinel-forwarder"
+  customer_id   = var.customer_id
+  shared_key    = var.shared_key
+
+  layer_arn = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:79"
+
+  log_type = local.sentinel_forwarder.log_type
+
+  s3_sources = [
+    {
+      bucket_arn    = local.sentinel_forwarder.bucket_arn
+      bucket_id     = local.sentinel_forwarder.bucket_id
+      filter_prefix = local.sentinel_forwarder.filter_prefix
+      kms_key_arn   = local.sentinel_forwarder.kms_key_arn
+    }
+  ]
+
+  billing_tag_key   = var.billing_tag_key
+  billing_tag_value = var.billing_tag_value
+}


### PR DESCRIPTION
# Summary | Résumé

Add an option for the S3 module users to automatically generate a log bucket that receives the server access logs and an associated sentinel forwarder lambda that pushes the logs to Sentinel upon reception.

TODO:

- [ ] Update the sentinel connector to process aws s3 server logs
