### PR TITLE
docs: fix readme and add link to ECS module

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [Attach TF plan policy](attach_tf_plan_policy)
 - [AWS Government of Canada password policy](aws_goc_password_policy)
 - [Empty log group alarm](empty_log_group_alarm)
+- [ECS](ecs)
 - [GuardDuty](guardduty)
 - [GuardDuty member](guardduty_member)
 - [Github Open ID Connect](gh_oidc_role)

--- a/ecs/README.md
+++ b/ecs/README.md
@@ -1,3 +1,4 @@
+# Elastic Container Service Cluster (ECS)
 
 This module creates a pre-configured ECS cluster with a single service and task definition using Fargate.
 

--- a/ecs/main.tf
+++ b/ecs/main.tf
@@ -1,4 +1,5 @@
-/* # Elastic Container Service Cluster (ECS) 
+/* 
+* # Elastic Container Service Cluster (ECS)
 *
 * This module creates a pre-configured ECS cluster with a single service and task definition using Fargate. 
 */


### PR DESCRIPTION
# Summary
Update the ECS module docs and add a link from the main README.