### PR TITLE
feat: add SPA config

### DIFF
--- a/simple_static_website/README.md
+++ b/simple_static_website/README.md
@@ -64,6 +64,7 @@ No modules.
 | <a name="input_error_document"></a> [error\_document](#input\_error\_document) | (Optional, default 'error.html') The name of the error document. | `string` | `"error.html"` | no |
 | <a name="input_hosted_zone_id"></a> [hosted\_zone\_id](#input\_hosted\_zone\_id) | (Optional, default '') Hosted zone ID used to create the domain name source ALIAS record pointing to Cloudfront.  If not specified, a new hosted zone will be created. | `string` | `""` | no |
 | <a name="input_index_document"></a> [index\_document](#input\_index\_document) | (Optional, default 'index.html') The name of the index document. | `string` | `"index.html"` | no |
+| <a name="input_single_page_app"></a> [single\_page\_app](#input\_single\_page\_app) | (Optional, default 'false') If true, the index document will be returned for all 403 requests to the origin. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/simple_static_website/cloudfront.tf
+++ b/simple_static_website/cloudfront.tf
@@ -44,6 +44,16 @@ resource "aws_cloudfront_distribution" "simple_static_website" {
     max_ttl                = 86400
   }
 
+  dynamic "custom_error_response" {
+    for_each = var.single_page_app ? [403] : []
+    content {
+      error_code            = 403
+      error_caching_min_ttl = 3600
+      response_code         = 200
+      response_page_path    = var.index_document
+    }
+  }
+
   restrictions {
     geo_restriction {
       restriction_type = "none"

--- a/simple_static_website/input.tf
+++ b/simple_static_website/input.tf
@@ -47,3 +47,9 @@ variable "index_document" {
   type        = string
   default     = "index.html"
 }
+
+variable "single_page_app" {
+  description = "(Optional, default 'false') If true, the index document will be returned for all 403 requests to the origin."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This PR adds the ability for the user to configure the behaviour of the bucket to accommodate a single page app that does URL rewrites in the browser.