### PR TITLE
fix: Path bug

### DIFF
--- a/simple_static_website/cloudfront.tf
+++ b/simple_static_website/cloudfront.tf
@@ -50,7 +50,7 @@ resource "aws_cloudfront_distribution" "simple_static_website" {
       error_code            = 403
       error_caching_min_ttl = 3600
       response_code         = 200
-      response_page_path    = var.index_document
+      response_page_path    = "/${var.index_document}"
     }
   }
 


### PR DESCRIPTION
Fixes a bug where the path needs to be absolute in the `response_page_path` attribute for the SPA config in the simple static page.