### PR TITLE
feat: support Aurora MySQL engine backtracking

### DIFF
--- a/rds/README.md
+++ b/rds/README.md
@@ -44,6 +44,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | (Optional, default 'false') This flag allows RDS to perform a major engine upgrade. <br/> **Please Note:** This could break things so make sure you know that your code is compatible with the new features in this version. | `bool` | `false` | no |
+| <a name="input_backtrack_window"></a> [backtrack\_window](#input\_backtrack\_window) | (Optional, defaults to 72 hours) The number of days to retain a backtrack. Set to 0 to disable backtracking.  This is only valid for the `aurora-mysql` engine type. | `number` | `259200` | no |
 | <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | (Required) The amount of days to keep backups for. | `number` | n/a | yes |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |

--- a/rds/input.tf
+++ b/rds/input.tf
@@ -40,6 +40,7 @@ variable "engine_version" {
   type        = string
   description = "(Required) The database version to use. Engine version is contingent on instance_class see [this list of supported combinations](https://docs.amazonaws.cn/en_us/AmazonRDS/latest/AuroraUserGuide/Concepts.DBInstanceClass.html#Concepts.DBInstanceClass.SupportAurora)"
 }
+
 variable "allow_major_version_upgrade" {
   type        = bool
   description = "(Optional, default 'false') This flag allows RDS to perform a major engine upgrade. <br/> **Please Note:** This could break things so make sure you know that your code is compatible with the new features in this version."
@@ -193,4 +194,10 @@ variable "security_group_notifications_topic_arn" {
   type        = string
   description = "(Optional) The SNS topic ARN to send notifications about security group changes to."
   default     = ""
+}
+
+variable "backtrack_window" {
+  type        = number
+  description = "(Optional, defaults to 72 hours) The number of days to retain a backtrack. Set to 0 to disable backtracking.  This is only valid for the `aurora-mysql` engine type."
+  default     = 259200
 }

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -42,6 +42,7 @@ resource "aws_rds_cluster" "cluster" {
   allow_major_version_upgrade = var.allow_major_version_upgrade
   apply_immediately           = var.upgrade_immediately
 
+  backtrack_window             = var.engine == "aurora-mysql" ? var.backtrack_window : 0
   backup_retention_period      = var.backup_retention_period
   preferred_backup_window      = var.preferred_backup_window
   preferred_maintenance_window = var.preferred_maintenance_window


### PR DESCRIPTION
# Summary
Update the RDS cluster configuration to support the `backtrack_window` setting for `aurora-mysql` clusters:
https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Managing.Backtrack.html

This allows you to rewind the cluster to a specific point in time within the window, making it easier to recover from failed upgrades and security incidents.

# Related
- https://github.com/cds-snc/platform-core-services/issues/471