### PR TITLE
fix: RDS copy tags to snapshot, enable logging

### DIFF
--- a/rds/README.md
+++ b/rds/README.md
@@ -19,6 +19,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_cloudwatch_log_group.log_exports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_db_event_subscription.rds_sg_events_alerts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_event_subscription) | resource |
 | [aws_db_proxy.proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_proxy) | resource |
@@ -49,6 +50,7 @@ No modules.
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_database_name"></a> [database\_name](#input\_database\_name) | (Required) The name of the database to be created inside the cluster. | `string` | n/a | yes |
+| <a name="input_enabled_cloudwatch_logs_exports"></a> [enabled\_cloudwatch\_logs\_exports](#input\_enabled\_cloudwatch\_logs\_exports) | (Optional, default empty list) The database log types to export to CloudWatch. Valid values are `audit`, `error`, `general`, `slowquery`, `postgresql`. | `list(string)` | `[]` | no |
 | <a name="input_engine"></a> [engine](#input\_engine) | (Optional, defaults 'aurora-postgresql') The database engine to use. Valid values are 'aurora-postgresql' and 'aurora-mysql' | `string` | `"aurora-postgresql"` | no |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | (Required) The database version to use. Engine version is contingent on instance\_class see [this list of supported combinations](https://docs.amazonaws.cn/en_us/AmazonRDS/latest/AuroraUserGuide/Concepts.DBInstanceClass.html#Concepts.DBInstanceClass.SupportAurora) | `string` | n/a | yes |
 | <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | (Optional, default 'db.t3.medium') The type of EC2 instance to run this on. | `string` | `"db.t3.medium"` | no |

--- a/rds/cloudwatch.tf
+++ b/rds/cloudwatch.tf
@@ -1,0 +1,19 @@
+resource "aws_cloudwatch_log_group" "proxy" {
+  name              = "/aws/rds/proxy/${local.proxy_name}"
+  retention_in_days = var.proxy_log_retention_in_days
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name}_proxy_logs"
+  })
+}
+
+resource "aws_cloudwatch_log_group" "log_exports" {
+  for_each = toset(local.enabled_cloudwatch_logs_exports)
+
+  name              = "/aws/rds/cluster/${local.identifier}/${each.value}"
+  retention_in_days = 30
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name}-cluster"
+  })
+}

--- a/rds/input.tf
+++ b/rds/input.tf
@@ -25,6 +25,19 @@ variable "database_name" {
   }
 }
 
+variable "enabled_cloudwatch_logs_exports" {
+  type        = list(string)
+  description = "(Optional, default empty list) The database log types to export to CloudWatch. Valid values are `audit`, `error`, `general`, `slowquery`, `postgresql`."
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for e in var.enabled_cloudwatch_logs_exports : contains(["audit", "error", "general", "slowquery", "postgresql"], e)
+    ])
+    error_message = "CloudWatch log exports valid values are `audit`, `error`, `general`, `slowquery`, and `postgresql`."
+  }
+}
+
 variable "engine" {
   type        = string
   description = "(Optional, defaults 'aurora-postgresql') The database engine to use. Valid values are 'aurora-postgresql' and 'aurora-mysql'"

--- a/rds/locals.tf
+++ b/rds/locals.tf
@@ -11,5 +11,5 @@ locals {
   security_group_ids = distinct(concat([aws_security_group.rds_proxy.id], var.security_group_ids))
 
   # Configure the database logs that are exported to CloudWatch.  Default to `audit` for MySQL and `postgresql` for Postgres if no values are specified
-  enabled_cloudwatch_logs_exports = length(var.enabled_cloudwatch_logs_exports) ? var.enabled_cloudwatch_logs_exports : (local.is_mysql ? ["audit"] : ["postgresql"])
+  enabled_cloudwatch_logs_exports = length(var.enabled_cloudwatch_logs_exports) > 0 ? var.enabled_cloudwatch_logs_exports : (local.is_mysql ? ["audit"] : ["postgresql"])
 }

--- a/rds/locals.tf
+++ b/rds/locals.tf
@@ -11,5 +11,5 @@ locals {
   security_group_ids = distinct(concat([aws_security_group.rds_proxy.id], var.security_group_ids))
 
   # Configure the database logs that are exported to CloudWatch.  Default to `audit` for MySQL and `postgresql` for Postgres if no values are specified
-  enabled_cloudwatch_logs_exports = length(var.enabled_cloudwatch_logs_exports) ? var.enabled_cloudwatch_logs_exports : [is_mysql ? "audit" : "postgresql"]
+  enabled_cloudwatch_logs_exports = length(var.enabled_cloudwatch_logs_exports) ? var.enabled_cloudwatch_logs_exports : (local.is_mysql ? ["audit"] : ["postgresql"])
 }

--- a/rds/locals.tf
+++ b/rds/locals.tf
@@ -4,8 +4,12 @@ locals {
     Terraform             = "true"
   }
 
+  identifier         = "${var.name}-cluster"
   is_mysql           = var.engine == "aurora-mysql"
   database_port      = local.is_mysql ? 3306 : 5432
   engine_family      = local.is_mysql ? "MYSQL" : "POSTGRESQL"
   security_group_ids = distinct(concat([aws_security_group.rds_proxy.id], var.security_group_ids))
+
+  # Configure the database logs that are exported to CloudWatch.  Default to `audit` for MySQL and `postgresql` for Postgres if no values are specified
+  enabled_cloudwatch_logs_exports = length(var.enabled_cloudwatch_logs_exports) ? var.enabled_cloudwatch_logs_exports : [is_mysql ? "audit" : "postgresql"]
 }


### PR DESCRIPTION
# Summary
Update the RDS cluster resource to:

1. Copy resource tags to snapshots.
2. Allow for the export of database logs to CloudWatch.

If no logs are selected for export, the module defaults to sending `audit` logs for MySQL and `postgresql` for Postgres.

# Related
- https://github.com/cds-snc/platform-core-services/issues/471