### PR TITLE
Truncating the name since so that 64 characters are not exceeded. 

### DIFF
--- a/ecs/cloudwatch.tf
+++ b/ecs/cloudwatch.tf
@@ -12,7 +12,7 @@ resource "aws_cloudwatch_log_group" "this" {
 module "sentinel_forwarder" {
   count             = var.sentinel_forwarder ? 1 : 0
   source            = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=main"
-  function_name     = "${var.cluster_name}-sentinel-forwarder"
+  function_name     = "${var.cluster_name}"
   billing_tag_value = var.billing_tag_value
 
   layer_arn   = var.sentinel_forwarder_layer_arn

--- a/ecs/cloudwatch.tf
+++ b/ecs/cloudwatch.tf
@@ -12,7 +12,7 @@ resource "aws_cloudwatch_log_group" "this" {
 module "sentinel_forwarder" {
   count             = var.sentinel_forwarder ? 1 : 0
   source            = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=main"
-  function_name     = "${var.cluster_name}"
+  function_name     = substr(var.cluster_name, 0, 64) 
   billing_tag_value = var.billing_tag_value
 
   layer_arn   = var.sentinel_forwarder_layer_arn

--- a/ecs/cloudwatch.tf
+++ b/ecs/cloudwatch.tf
@@ -12,7 +12,7 @@ resource "aws_cloudwatch_log_group" "this" {
 module "sentinel_forwarder" {
   count             = var.sentinel_forwarder ? 1 : 0
   source            = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=main"
-  function_name     = substr(var.cluster_name, 0, 64) 
+  function_name     = substr(var.cluster_name, 0, 64)
   billing_tag_value = var.billing_tag_value
 
   layer_arn   = var.sentinel_forwarder_layer_arn


### PR DESCRIPTION

# Summary | Résumé

Truncating the name of the lambda function for Sentinel since "sentinel-forwarder" is not necessary since "SentinelForwarderLambda" is automatically added to the function name by the Sentinel terraform module. This fixes an error similar to this one:
![Screenshot 2023-10-25 at 10 40 48 AM](https://github.com/cds-snc/terraform-modules/assets/85905333/3a180fec-3c01-4509-87ae-5cde6aa88dc5)
