### PR TITLE
feat: scale CloudWatch alarm, Route53 healthcheck

### DIFF
--- a/schedule_shutdown/README.md
+++ b/schedule_shutdown/README.md
@@ -1,6 +1,12 @@
 # Schedule shutdown
 Lambda function to schedule resource shutdown and startup to save costs.  The function is triggered by CloudWatch Events
-controlled by schedule expressions.  Currently the function supports ECS services and RDS clusters.
+controlled by schedule expressions.   
+
+Currently the function supports scaling the following resources:
+- CloudWatch alarms: enables/disables the alarm actions.
+- ECS services: scales the service between 0 and 1 tasks.
+- RDS clusters: stops/starts the cluster.
+- Route53 healthchecks: enables/disables the healthcheck.
 
 ## Requirements
 
@@ -31,10 +37,12 @@ No modules.
 | [aws_lambda_permission.schedule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [archive_file.schedule](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cloudwatch_alarm_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cloudwatch_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecs_service_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.rds_cluster_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.route53_healthcheck_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
@@ -42,8 +50,11 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
-| <a name="input_ecs_service_arns"></a> [ecs\_service\_arns](#input\_ecs\_service\_arns) | (Optional) ECS service ARNs to scale down to zero. | `list(string)` | `[]` | no |
+| <a name="input_cloudwatch_alarm_arns"></a> [cloudwatch\_alarm\_arns](#input\_cloudwatch\_alarm\_arns) | (Optional) CloudWatch alarm ARNs to enable/disable. | `list(string)` | `[]` | no |
+| <a name="input_ecs_service_arns"></a> [ecs\_service\_arns](#input\_ecs\_service\_arns) | (Optional) ECS service ARNs to scale up/down. | `list(string)` | `[]` | no |
+| <a name="input_lambda_runtime"></a> [lambda\_runtime](#input\_lambda\_runtime) | (Optional, defaults to 3.11) The Python runtime to use for the lambda function. | `string` | `"python3.11"` | no |
 | <a name="input_rds_cluster_arns"></a> [rds\_cluster\_arns](#input\_rds\_cluster\_arns) | (Optional) RDS cluster ARNs to shutdown and startup. | `list(string)` | `[]` | no |
+| <a name="input_route53_healthcheck_arns"></a> [route53\_healthcheck\_arns](#input\_route53\_healthcheck\_arns) | (Optional) Route53 healthcheck ARNs to enable/disable. | `list(string)` | `[]` | no |
 | <a name="input_schedule_shutdown"></a> [schedule\_shutdown](#input\_schedule\_shutdown) | (Optional, every day at 10pm UTC) The schedule expression for when resources should be stopped. | `string` | `"cron(0 22 * * ? *)"` | no |
 | <a name="input_schedule_startup"></a> [schedule\_startup](#input\_schedule\_startup) | (Optional, Monday-Friday at 10am UTC) The schedule expression for when resources should be started. | `string` | `"cron(0 10 ? * MON-FRI *)"` | no |
 

--- a/schedule_shutdown/input.tf
+++ b/schedule_shutdown/input.tf
@@ -9,14 +9,32 @@ variable "billing_tag_value" {
   type        = string
 }
 
-variable "ecs_service_arns" {
-  description = "(Optional) ECS service ARNs to scale down to zero."
+variable "cloudwatch_alarm_arns" {
+  description = "(Optional) CloudWatch alarm ARNs to enable/disable."
   type        = list(string)
   default     = []
 }
 
+variable "ecs_service_arns" {
+  description = "(Optional) ECS service ARNs to scale up/down."
+  type        = list(string)
+  default     = []
+}
+
+variable "lambda_runtime" {
+  description = "(Optional, defaults to 3.11) The Python runtime to use for the lambda function."
+  type        = string
+  default     = "python3.11"
+}
+
 variable "rds_cluster_arns" {
   description = "(Optional) RDS cluster ARNs to shutdown and startup."
+  type        = list(string)
+  default     = []
+}
+
+variable "route53_healthcheck_arns" {
+  description = "(Optional) Route53 healthcheck ARNs to enable/disable."
   type        = list(string)
   default     = []
 }

--- a/schedule_shutdown/lambda/schedule.py
+++ b/schedule_shutdown/lambda/schedule.py
@@ -5,37 +5,53 @@ Currently supports ECS services and RDS clusters.
 import os
 import boto3
 
-ECS_SERVICE_ARNS = os.getenv("ECS_SERVICE_ARNS")
-RDS_CLUSTER_ARNS = os.getenv("RDS_CLUSTER_ARNS")
-ECS_SERVICES = ECS_SERVICE_ARNS.split(",") if ECS_SERVICE_ARNS else []
-RDS_CLUSTERS = RDS_CLUSTER_ARNS.split(",") if RDS_CLUSTER_ARNS else []
+
+def get_resource_list(resources):
+    "Get a list of resources from the comma delimited string"
+    return resources.split(",") if resources else None
+
+
+# The key is the service's client name in boto3
+# A "{service}_scale" method should exist to handle the shutdown/startup
+SERVICES = {
+    "cloudwatch": get_resource_list(os.getenv("CLOUDWATCH_ALARM_ARNS")),
+    "ecs": get_resource_list(os.getenv("ECS_SERVICE_ARNS")),
+    "rds": get_resource_list(os.getenv("RDS_CLUSTER_ARNS")),
+    "route53": get_resource_list(os.getenv("ROUTE53_HEALTHCHECK_ARNS")),
+}
 
 
 # pylint: disable=unused-argument
 def handler(event, context):
-    "Lambda handler function"
+    "Lambda handler responsible for starting or stopping resources"
 
     # Validate the action
     action = event.get("action")
     if action not in ["startup", "shutdown"]:
         raise ValueError(f"Unknown action {action}")
 
-    # ECS cluster scaling
-    if ECS_SERVICES:
-        ecs_client = boto3.client("ecs")
-        for ecs_arn in ECS_SERVICES:
-            ecs_service_scale(ecs_client, ecs_arn, action)
-
-    # RDS cluster scaling
-    if RDS_CLUSTERS:
-        rds_client = boto3.client("rds")
-        for rds_arn in RDS_CLUSTERS:
-            rds_cluster_scale(rds_client, rds_arn, action)
+    for service, resources in SERVICES.items():
+        if resources:
+            client = boto3.client(service)
+            for resource in resources:
+                globals()[f"{service}_scale"](client, resource, action)
 
     return True
 
 
-def ecs_service_scale(client, service_arn, action):
+def cloudwatch_scale(client, alarm_arn, action):
+    "Enable or disable a given CloudWatch alarm's actions based on the action"
+    alarm_name = alarm_arn.split(":")[-1]
+    function_name = (
+        "disable_alarm_actions" if action == "shutdown" else "enable_alarm_actions"
+    )
+
+    print(f"Updating CloudWatch alarm {alarm_name} to {function_name}")
+    response = getattr(client, function_name)(AlarmNames=[alarm_name])
+    print(f"Scale response: {response}")
+
+
+def ecs_scale(client, service_arn, action):
     "Scale a given ECS service to a desired count"
     desired_count = 0 if action == "shutdown" else 1
     cluster_name = service_arn.split("/")[1]
@@ -50,11 +66,22 @@ def ecs_service_scale(client, service_arn, action):
     print(f"Scale response: {response}")
 
 
-def rds_cluster_scale(client, cluster_arn, action):
+def rds_scale(client, cluster_arn, action):
     "Start or stop a given RDS cluster based on the action"
     cluster_name = cluster_arn.split(":")[-1]
     function_name = "stop_db_cluster" if action == "shutdown" else "start_db_cluster"
 
     print(f"Updating RDS cluster {cluster_name} to {function_name}")
     response = getattr(client, function_name)(DBClusterIdentifier=cluster_name)
+    print(f"Scale response: {response}")
+
+
+def route53_scale(client, healthcheck_arn, action):
+    "Enable or disable a given Route53 health check based on the action"
+    healthcheck_id = healthcheck_arn.split("/")[-1]
+    disabled = action == "shutdown"
+    print(f"Setting Route53 healthcheck {healthcheck_id} Disabled={disabled}")
+    response = client.update_health_check(
+        HealthCheckId=healthcheck_id, Disabled=disabled
+    )
     print(f"Scale response: {response}")

--- a/schedule_shutdown/lambda/schedule_test.py
+++ b/schedule_shutdown/lambda/schedule_test.py
@@ -1,8 +1,5 @@
 import pytest
-import unittest
-from unittest.mock import patch, MagicMock
-import os
-import boto3
+from unittest.mock import patch
 import schedule
 
 

--- a/schedule_shutdown/lambda/schedule_test.py
+++ b/schedule_shutdown/lambda/schedule_test.py
@@ -7,18 +7,39 @@ import schedule
 
 
 @patch("boto3.client")
-@patch("schedule.ecs_service_scale")
-@patch("schedule.rds_cluster_scale")
-def test_handler(mock_rds_cluster_scale, mock_ecs_service_scale, mock_client):
+@patch("schedule.cloudwatch_scale")
+@patch("schedule.ecs_scale")
+@patch("schedule.rds_scale")
+@patch("schedule.route53_scale")
+def test_handler(
+    mock_route53_scale,
+    mock_rds_scale,
+    mock_ecs_scale,
+    mock_cloudwatch_scale,
+    mock_client,
+):
     event = {"action": "startup"}
     context = None
+    mock_services = {
+        "cloudwatch": ["arn1", "arn2"],
+        "ecs": ["arn1", "arn2", "arn3"],
+        "rds": ["arn1"],
+        "route53": None,
+    }
 
-    with patch("schedule.ECS_SERVICES", new=["arn1", "arn2", "arn3"]), patch(
-        "schedule.RDS_CLUSTERS", new=["arn1", "arn2"]
-    ):
+    with patch("schedule.SERVICES", new=mock_services):
         schedule.handler(event, context)
-        assert mock_ecs_service_scale.call_count == 3
-        assert mock_rds_cluster_scale.call_count == 2
+        assert mock_cloudwatch_scale.call_count == 2
+        assert mock_ecs_scale.call_count == 3
+        assert mock_rds_scale.call_count == 1
+        assert mock_route53_scale.call_count == 0
+
+
+def test_get_resource_list():
+    assert schedule.get_resource_list(None) is None
+    assert schedule.get_resource_list("") is None
+    assert schedule.get_resource_list("arn1") == ["arn1"]
+    assert schedule.get_resource_list("arn1,arn2") == ["arn1", "arn2"]
 
 
 @patch("boto3.client")
@@ -33,6 +54,20 @@ def test_handler_invalid_action(mock_client):
 
 
 @pytest.mark.parametrize(
+    "action, function_name",
+    [
+        ("shutdown", "disable_alarm_actions"),
+        ("startup", "enable_alarm_actions"),
+    ],
+)
+@patch("boto3.client")
+def test_cloudwatch_scale(mock_client, action, function_name):
+    alarm_arn = "arn:aws:cloudwatch:ca-central-1:123456789012:alarm:FancyAlarm"
+    schedule.cloudwatch_scale(mock_client, alarm_arn, action)
+    getattr(mock_client, function_name).assert_called_with(AlarmNames=["FancyAlarm"])
+
+
+@pytest.mark.parametrize(
     "action, desired_count",
     [
         ("shutdown", 0),
@@ -40,12 +75,14 @@ def test_handler_invalid_action(mock_client):
     ],
 )
 @patch("boto3.client")
-def test_ecs_service_scale(mock_client, action, desired_count):
-    service_arn = "arn:aws:ecs:ca-central-1:123456789012:service/my-cluster/my-service"
-    schedule.ecs_service_scale(mock_client, service_arn, action)
+def test_ecs_scale(mock_client, action, desired_count):
+    service_arn = (
+        "arn:aws:ecs:ca-central-1:123456789012:service/some-cluster/with-a-service"
+    )
+    schedule.ecs_scale(mock_client, service_arn, action)
     mock_client.update_service.assert_called_with(
-        cluster="my-cluster",
-        service="my-service",
+        cluster="some-cluster",
+        service="with-a-service",
         desiredCount=desired_count,
     )
 
@@ -58,9 +95,26 @@ def test_ecs_service_scale(mock_client, action, desired_count):
     ],
 )
 @patch("boto3.client")
-def test_rds_cluster_scale(mock_client, action, function_name):
-    cluster_arn = "arn:aws:rds:ca-central-1:123456789012:cluster:my-cluster"
-    schedule.rds_cluster_scale(mock_client, cluster_arn, action)
+def test_rds_scale(mock_client, action, function_name):
+    cluster_arn = "arn:aws:rds:ca-central-1:123456789012:cluster:so-very-much-data"
+    schedule.rds_scale(mock_client, cluster_arn, action)
     getattr(mock_client, function_name).assert_called_with(
-        DBClusterIdentifier="my-cluster"
+        DBClusterIdentifier="so-very-much-data"
+    )
+
+
+@pytest.mark.parametrize(
+    "action, disabled",
+    [
+        ("shutdown", True),
+        ("startup", False),
+    ],
+)
+@patch("boto3.client")
+def test_route53_scale(mock_client, action, disabled):
+    healthcheck_arn = "arn:aws:route53:::healthcheck/mmm-healthy"
+    schedule.route53_scale(mock_client, healthcheck_arn, action)
+    mock_client.update_health_check.assert_called_with(
+        HealthCheckId="mmm-healthy",
+        Disabled=disabled,
     )

--- a/schedule_shutdown/locals.tf
+++ b/schedule_shutdown/locals.tf
@@ -1,8 +1,10 @@
 
 locals {
-  is_ecs_arns = length(var.ecs_service_arns) > 0
-  is_rds_arns = length(var.rds_cluster_arns) > 0
-  lambda_name = "schedule-shutdown"
+  is_cloudwatch_alarm_arns    = length(var.cloudwatch_alarm_arns) > 0
+  is_ecs_arns                 = length(var.ecs_service_arns) > 0
+  is_rds_arns                 = length(var.rds_cluster_arns) > 0
+  is_route53_healthcheck_arns = length(var.route53_healthcheck_arns) > 0
+  lambda_name                 = "schedule-shutdown"
 
   schedule = {
     "shutdown" : var.schedule_shutdown,

--- a/schedule_shutdown/main.tf
+++ b/schedule_shutdown/main.tf
@@ -1,7 +1,13 @@
 /* 
 * # Schedule shutdown
 * Lambda function to schedule resource shutdown and startup to save costs.  The function is triggered by CloudWatch Events
-* controlled by schedule expressions.  Currently the function supports ECS services and RDS clusters.
+* controlled by schedule expressions.   
+* 
+* Currently the function supports scaling the following resources:
+* - CloudWatch alarms: enables/disables the alarm actions.
+* - ECS services: scales the service between 0 and 1 tasks.
+* - RDS clusters: stops/starts the cluster.
+* - Route53 healthchecks: enables/disables the healthcheck.
 */
 resource "aws_lambda_function" "schedule" {
   function_name = local.lambda_name
@@ -9,7 +15,7 @@ resource "aws_lambda_function" "schedule" {
 
   filename    = data.archive_file.schedule.output_path
   handler     = "schedule.handler"
-  runtime     = "python3.11"
+  runtime     = var.lambda_runtime
   timeout     = 60
   memory_size = 128
 
@@ -18,8 +24,10 @@ resource "aws_lambda_function" "schedule" {
 
   environment {
     variables = {
-      ECS_SERVICE_ARNS = join(",", var.ecs_service_arns)
-      RDS_CLUSTER_ARNS = join(",", var.rds_cluster_arns)
+      CLOUDWATCH_ALARM_ARNS    = join(",", var.cloudwatch_alarm_arns)
+      ECS_SERVICE_ARNS         = join(",", var.ecs_service_arns)
+      RDS_CLUSTER_ARNS         = join(",", var.rds_cluster_arns)
+      ROUTE53_HEALTHCHECK_ARNS = join(",", var.route53_healthcheck_arns)
     }
   }
 


### PR DESCRIPTION
# Summary
Update the `schedule_shutdown` module to allow it to enable and disable CloudWatch alarms and Route53 healthchecks as part of the scheduled shutdown and startup.

# Related
- https://github.com/cds-snc/platform-core-services/issues/473