### PR TITLE
feat: `scheduled_shutdown` unit/integration tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,5 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/debian
 {
-	"name": "Debian",
+	"name": "terraform-modules",
 	"image": "mcr.microsoft.com/devcontainers/go:bullseye",
 	"features": {
 		"ghcr.io/devcontainers/features/python:1": {
@@ -20,26 +18,11 @@
 		"vscode": {
 			"extensions": [
 				"GitHub.copilot",
+				"HashiCorp.HCL",
 				"hashicorp.terraform",
 				"redhat.vscode-yaml",
 				"golang.go"
 			]
 		}
 	}
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
-	// "mounts": [
-	//     {
-	//         "source": "/var/run/docker.sock",
-	//         "target": "/var/run/docker-host.sock",
-	//         "type": "bind"
-	//     }
-	// ]
-	// Configure tool-specific properties.
-	// "customizations": {},
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
 
       - name: Setup Python
         if: steps.changes.outputs.module == 'true'
-        uses: actions/setup-python@f8dce14123d5d1ccf3724c3a06c7a4d9e6c7de6f # v2.2.2
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
-          python-version: 3.11
+          python-version: "3.11"
 
       - name: Python tests
         if: steps.changes.outputs.module == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: "CI unit and integration tests"
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  python-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - schedule_shutdown/lambda
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        id: changes
+        with:
+          filters: |
+            module:
+              - '${{ matrix.module }}/**'
+
+      - name: Setup Python
+        if: steps.changes.outputs.module == 'true'
+        uses: actions/setup-python@f8dce14123d5d1ccf3724c3a06c7a4d9e6c7de6f # v2.2.2
+        with:
+          python-version: 3.11
+
+      - name: Python tests
+        if: steps.changes.outputs.module == 'true'
+        working-directory: ${{ matrix.module }}
+        run: |
+          make install
+          make ARGS=--check fmt
+          make lint
+          make test
+
+  terraform-test:
+    runs-on: ubuntu-latest
+    env:
+      TERRAFORM_VERSION: 1.6.1
+      CONFTEST_VERSION: 0.27.0
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - schedule_shutdown
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        id: changes
+        with:
+          filters: |
+            module:
+              - '${{ matrix.module }}/**/*.tf'
+              - '${{ matrix.module }}/tests/**'
+
+      - name: Setup Terraform tools
+        if: steps.changes.outputs.module == 'true'
+        uses: cds-snc/terraform-tools-setup@v1
+
+      - name: Terraform tests
+        if: steps.changes.outputs.module == 'true'
+        working-directory: ${{ matrix.module }}
+        run: |
+          make test

--- a/schedule_shutdown/Makefile
+++ b/schedule_shutdown/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt docs
+.PHONY: fmt docs test
 
 fmt:
 	@terraform fmt -recursive
@@ -7,3 +7,7 @@ docs:
 	@rm -rf .terraform
 	@rm -f .terraform.lock.hcl
 	@terraform-docs markdown -c ../.terraform-docs.yml . > README.md
+
+test:
+	terraform init &&\
+	terraform test --var-file=./tests/globals.tfvars

--- a/schedule_shutdown/examples/simple/main.tf
+++ b/schedule_shutdown/examples/simple/main.tf
@@ -1,0 +1,22 @@
+module "simple" {
+  source = "../.."
+
+  cloudwatch_alarm_arns = [
+    "arn:aws:cloudwatch:ca-central-1:123456789012:alarm:my-alarm",
+  ]
+  ecs_service_arns = [
+    "arn:aws:ecs:ca-central-1:123456789012:service/my-cluster/my-service",
+    "arn:aws:ecs:ca-central-1:123456789012:service/my-cluster/other-service",
+  ]
+  rds_cluster_arns = [
+    "arn:aws:rds:ca-central-1:123456789012:cluster:my-cluster",
+  ]
+  route53_healthcheck_arns = [
+    "arn:aws:route53:::healthcheck/my-healthcheck",
+  ]
+
+  schedule_shutdown = "cron(0 22 * * ? *)"       # 10pm UTC, every day
+  schedule_startup  = "cron(0 12 ? * MON-FRI *)" # 12pm UTC, Monday-Friday
+
+  billing_tag_value = "simple"
+}

--- a/schedule_shutdown/lambda/schedule.py
+++ b/schedule_shutdown/lambda/schedule.py
@@ -1,6 +1,5 @@
 """
 Lambda function to start or stop resources based on a schedule.
-Currently supports ECS services and RDS clusters.
 """
 import os
 import boto3

--- a/schedule_shutdown/tests/globals.tfvars
+++ b/schedule_shutdown/tests/globals.tfvars
@@ -1,0 +1,1 @@
+billing_tag_value = "tests"

--- a/schedule_shutdown/tests/integration.main.tftest.hcl
+++ b/schedule_shutdown/tests/integration.main.tftest.hcl
@@ -1,0 +1,42 @@
+provider "aws" {
+  region = "ca-central-1"
+}
+
+run "module_defaults" {
+  command = apply
+
+  assert {
+    condition     = aws_lambda_function.schedule.runtime == "python3.11"
+    error_message = "Lambda runtime does not match expected value"
+  }
+
+  assert {
+    condition = aws_lambda_function.schedule.environment[0].variables == tomap({
+      CLOUDWATCH_ALARM_ARNS    = ""
+      ECS_SERVICE_ARNS         = ""
+      RDS_CLUSTER_ARNS         = ""
+      ROUTE53_HEALTHCHECK_ARNS = ""
+    })
+    error_message = "Lambda environment variables do not match expected values"
+  }
+
+  assert {
+    condition     = length(data.aws_iam_policy_document.cloudwatch_alarm_policy) == 0
+    error_message = "IAM CloudWatch alarm policy should not exist"
+  }
+
+  assert {
+    condition     = length(data.aws_iam_policy_document.ecs_service_policy) == 0
+    error_message = "IAM ECS service policy should not exist"
+  }
+
+  assert {
+    condition     = length(data.aws_iam_policy_document.rds_cluster_policy) == 0
+    error_message = "IAM RDS cluster policy should not exist"
+  }
+
+  assert {
+    condition     = length(data.aws_iam_policy_document.route53_healthcheck_policy) == 0
+    error_message = "IAM Route53 healthcheck policy should not exist"
+  }
+}

--- a/schedule_shutdown/tests/unit.iam.tftest.hcl
+++ b/schedule_shutdown/tests/unit.iam.tftest.hcl
@@ -1,0 +1,34 @@
+provider "aws" {
+  region = "ca-central-1"
+}
+
+variables {
+  cloudwatch_alarm_arns    = ["arn1", "arn2"]
+  ecs_service_arns         = ["arn3", "arn4"]
+  rds_cluster_arns         = ["arn5", "arn6"]
+  route53_healthcheck_arns = ["arn7", "arn8"]
+}
+
+run "iam_inputs" {
+  command = plan
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.cloudwatch_alarm_policy[0].json, "\"Resource\": [\n        \"arn2\",\n        \"arn1\"\n      ]\n")
+    error_message = "CloudWatch alarm policy does not have expected resources"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.ecs_service_policy[0].json, "\"Resource\": [\n        \"arn4\",\n        \"arn3\"\n      ]\n")
+    error_message = "ECS service policy does not have expected resources"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.rds_cluster_policy[0].json, "\"Resource\": [\n        \"arn6\",\n        \"arn5\"\n      ]\n")
+    error_message = "RDS cluster policy does not have expected resources"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.route53_healthcheck_policy[0].json, "\"Resource\": [\n        \"arn8\",\n        \"arn7\"\n      ]\n")
+    error_message = "Route53 healthcheck policy does not have expected resources"
+  }
+}

--- a/schedule_shutdown/tests/unit.main.tftest.hcl
+++ b/schedule_shutdown/tests/unit.main.tftest.hcl
@@ -1,0 +1,58 @@
+provider "aws" {
+  region = "ca-central-1"
+}
+
+variables {
+  lambda_runtime = "python3.8"
+
+  cloudwatch_alarm_arns    = ["arn1", "arn2"]
+  ecs_service_arns         = ["arn3", "arn4"]
+  rds_cluster_arns         = ["arn5", "arn6"]
+  route53_healthcheck_arns = ["arn7", "arn8"]
+
+  schedule_startup  = "rate(5 minutes)"
+  schedule_shutdown = "rate(1 minute)"
+}
+
+run "eventbridge_inputs" {
+  command = plan
+
+  assert {
+    condition     = aws_cloudwatch_event_rule.schedule["startup"].schedule_expression == "rate(5 minutes)"
+    error_message = "Startup schedule did not match expected value"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_event_rule.schedule["shutdown"].schedule_expression == "rate(1 minute)"
+    error_message = "Shutdown schedule did not match expected value"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_event_target.schedule["startup"].input == "{\"action\":\"startup\"}"
+    error_message = "Startup target input did not match expected value"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_event_target.schedule["shutdown"].input == "{\"action\":\"shutdown\"}"
+    error_message = "Shutdown target input did not match expected value"
+  }
+}
+
+run "lambda_inputs" {
+  command = plan
+
+  assert {
+    condition     = aws_lambda_function.schedule.runtime == "python3.8"
+    error_message = "Lambda runtime does not match expected value"
+  }
+
+  assert {
+    condition = aws_lambda_function.schedule.environment[0].variables == tomap({
+      CLOUDWATCH_ALARM_ARNS    = "arn1,arn2"
+      ECS_SERVICE_ARNS         = "arn3,arn4"
+      RDS_CLUSTER_ARNS         = "arn5,arn6"
+      ROUTE53_HEALTHCHECK_ARNS = "arn7,arn8"
+    })
+    error_message = "Lambda environment variables do not match expected values"
+  }
+}


### PR DESCRIPTION
# Summary
Add [Terraform unit and integration tests](https://developer.hashicorp.com/terraform/language/tests) to the `schedule_shutdown` module.

Add a new GitHub workflow to run these tests on PRs.

# Related
- Closes https://github.com/cds-snc/platform-core-services/issues/473