### PR TITLE
Lambda log retention override

### DIFF
--- a/lambda/input.tf
+++ b/lambda/input.tf
@@ -138,3 +138,9 @@ variable "vpc" {
   }
   description = "(Optional) VPC to attach to the Lambda function <br/> **Please Note if this is set it will also attach the AWSLambdaVPCAccessExecutionRole to the lmabda this will enable creation of VPC ENI's as well as reading and writing to logfiles"
 }
+
+variable "log_group_retention_period" {
+  type        = number
+  description = "(Optional) Override the retention period for the lambda log group"
+  default     = 14
+}

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -62,7 +62,7 @@ resource "aws_lambda_function" "this" {
 resource "aws_cloudwatch_log_group" "this" {
   #checkov:skip=CKV_AWS_158:We trust the AWS provided keys
   name              = "/aws/lambda/${var.name}"
-  retention_in_days = "14"
+  retention_in_days = var.log_group_retention_period
   tags              = local.common_tags
 }
 


### PR DESCRIPTION
# Summary | Résumé

We're working on standardiziang our log retention periods across different components and environments. We need to be able to set a custom value for the retention period in the log groups created by the lambda module. 

I've added a new variable and defaulted it to the old value (14). It can now optionally be set in the module declaration to increase it as required.

# Test instructions | Instructions pour tester la modification

Terraform plan against existing lambdas should show no changes
Terraform plan against new and existing resources with the log_group_retention_period set to anything other than 14 should show change
