### PR TITLE
feat: add terraform-modules-test OIDC role

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,42 @@
+name: "Terraform Apply"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "terraform/**"
+      - ".github/workflows/terraform-apply.yml"
+
+env:
+  AWS_REGION: ca-central-1
+  TERRAFORM_VERSION: 1.6.1
+  CONFTEST_VERSION: 0.42.1
+  TF_VAR_account_id: 124044056575
+  TF_VAR_billing_code: SRE
+  TF_VAR_region: ca-central-1  
+
+permissions:
+  id-token: write
+  contents: read
+  
+jobs:
+  terragrunt-apply:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        with:
+          role-to-assume: arn:aws:iam::124044056575:role/terraform-modules-apply
+          role-session-name: TFApply
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform Apply
+        working-directory: terraform
+        run: terraform apply -auto-approve

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,46 @@
+name: "Terraform Plan"
+
+on:
+  pull_request:
+    paths:
+    - "terraform/**"
+    - ".github/workflows/terraform-plan.yml"
+
+env:
+  AWS_REGION: ca-central-1
+  TERRAFORM_VERSION: 1.6.1
+  CONFTEST_VERSION: 0.42.1
+  TF_VAR_account_id: 124044056575
+  TF_VAR_billing_code: SRE
+  TF_VAR_region: ca-central-1  
+
+permissions:
+  id-token: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  terragrunt-plan:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+    - name: Setup terraform tools
+      uses: cds-snc/terraform-tools-setup@v1
+
+    - name: Configure AWS credentials using OIDC
+      uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+      with:
+        role-to-assume: arn:aws:iam::124044056575:role/terraform-modules-plan
+        role-session-name: TFPlan
+        aws-region: ${{ env.AWS_REGION }}
+
+    - name: Terraform Plan
+      uses: cds-snc/terraform-plan@7f4ce4a4bdffaba639d32a45272804e37a569408 # v3.0.6
+      with:
+        comment-delete: true
+        comment-title: "Terraform"
+        directory: terraform
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        terragrunt: false   

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 .tool-versions
 .terraform*
 !.terraform-docs.yml
+!terraform/.terraform.lock.hcl
 test.tf
+*.tfvars
 *.tfstate*
 
 .DS_Store

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.29.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:SyiKAX/D3ZE9My7P03DrRMf65pNnfSDQXPb0g11lCS0=",
+    "zh:0453c1c64e51cd7050ce46d9280a0195b9073592508077ebf1a1c45f7026f3f5",
+    "zh:3ee87d1a2870b61fdcc80f3f96b669dbcc8171aadb821bec0e1fa0e6fb9595b6",
+    "zh:423c0304eba345167cc37dcd300712f24f03fe4de8eecc15edb0d4f88b29ec79",
+    "zh:6816ce0ed702263297a8e02467bb712c509a9f6e4f132a152a10f1cc19191a81",
+    "zh:6feb8a0aedabd778216238e72273f5c2ee86d8841acc3fb3dc9d8014a2bbdc51",
+    "zh:709ccdc8b37f975d422e7955814671548887613931e234e06249da629b0f2f95",
+    "zh:76c55744020dbdafea25be634f8ac37c1e371f8c397f73bd89bc270d00ee0834",
+    "zh:7e48d6fc488b9dbe2fd4bebefa1b485d04da38b11a6799f8cba178173b7f8782",
+    "zh:951d7ef2adbfb96b1d3e9c4780b2ab4375caf9c6b522a2d023c02ff0698d8e2a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b0bf5974bc1a7d2ce3f3a9a31a8238ad15ad02211f1e84c54832541ec4bd5d10",
+    "zh:cc56d4ab9bcbee95f73dbe90f11d4ff7299b835dddf2b30cfda526a2cccd0f9f",
+    "zh:cfe3a4394f2f7044e03bb63f4fb9c691926607c6784417ac9c0724943da60d09",
+    "zh:d6f82e13f33f70de8df480287b5a961ced5606f041d1c589f706b112f68db890",
+    "zh:fb7be5bcff62d0ca9edd4a1bee4d2ed16e9428e3f9eff3ea4d898ecb234505a3",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.0.5"
+  hashes = [
+    "h1:e4LBdJoZJNOQXPWgOAG0UuPBVhCStu98PieNlqJTmeU=",
+    "zh:01cfb11cb74654c003f6d4e32bbef8f5969ee2856394a96d127da4949c65153e",
+    "zh:0472ea1574026aa1e8ca82bb6df2c40cd0478e9336b7a8a64e652119a2fa4f32",
+    "zh:1a8ddba2b1550c5d02003ea5d6cdda2eef6870ece86c5619f33edd699c9dc14b",
+    "zh:1e3bb505c000adb12cdf60af5b08f0ed68bc3955b0d4d4a126db5ca4d429eb4a",
+    "zh:6636401b2463c25e03e68a6b786acf91a311c78444b1dc4f97c539f9f78de22a",
+    "zh:76858f9d8b460e7b2a338c477671d07286b0d287fd2d2e3214030ae8f61dd56e",
+    "zh:a13b69fb43cb8746793b3069c4d897bb18f454290b496f19d03c3387d1c9a2dc",
+    "zh:a90ca81bb9bb509063b736842250ecff0f886a91baae8de65c8430168001dad9",
+    "zh:c4de401395936e41234f1956ebadbd2ed9f414e6908f27d578614aaa529870d4",
+    "zh:c657e121af8fde19964482997f0de2d5173217274f6997e16389e7707ed8ece8",
+    "zh:d68b07a67fbd604c38ec9733069fbf23441436fecf554de6c75c032f82e1ef19",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/iam_oidc.tf
+++ b/terraform/iam_oidc.tf
@@ -1,0 +1,27 @@
+locals {
+  test_role_name = "terraform-modules-test"
+}
+
+module "test_role" {
+  source            = "github.com/cds-snc/terraform-modules//gh_oidc_role?ref=v7.4.0"
+  billing_tag_value = var.billing_code
+  roles = [
+    {
+      name      = local.test_role_name
+      repo_name = "terraform-modules"
+      claim     = "pull_request"
+    }
+  ]
+}
+
+resource "aws_iam_role_policy_attachment" "test_role" {
+  role       = local.test_role_name
+  policy_arn = data.aws_iam_policy.administrator_access.arn
+  depends_on = [
+    module.test_role
+  ]
+}
+
+data "aws_iam_policy" "administrator_access" {
+  name = "AdministratorAccess"
+}

--- a/terraform/inputs.tf
+++ b/terraform/inputs.tf
@@ -1,14 +1,14 @@
 variable "account_id" {
-    description = "(Required) The AWS account to create resources in."
-    type        = string
+  description = "(Required) The AWS account to create resources in."
+  type        = string
 }
 
 variable "billing_code" {
-    description = "(Required) The billing code to tag resources with."
-    type        = string
+  description = "(Required) The billing code to tag resources with."
+  type        = string
 }
 
 variable "region" {
-    description = "(Required) The region to create resources in."
-    type        = string
+  description = "(Required) The region to create resources in."
+  type        = string
 }

--- a/terraform/inputs.tf
+++ b/terraform/inputs.tf
@@ -1,0 +1,14 @@
+variable "account_id" {
+    description = "(Required) The AWS account to create resources in."
+    type        = string
+}
+
+variable "billing_code" {
+    description = "(Required) The billing code to tag resources with."
+    type        = string
+}
+
+variable "region" {
+    description = "(Required) The region to create resources in."
+    type        = string
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "tfstate-cds-snc-terraform-modules"
+    key            = "tfstate/terraform.tfstate"
+    region         = "ca-central-1"
+    encrypt        = true
+    dynamodb_table = "tfstate-lock"
+  }  
+}
+
+provider "aws" {
+  region              = var.region
+  allowed_account_ids = [var.account_id]
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -12,7 +12,7 @@ terraform {
     region         = "ca-central-1"
     encrypt        = true
     dynamodb_table = "tfstate-lock"
-  }  
+  }
 }
 
 provider "aws" {


### PR DESCRIPTION
# Summary 
Add a role that can be used by PRs to run the Terraform tests.

This will allow us to remove the IAM user with its hard-coded credential.

# Related
- #351 