### PR TITLE
fix: add missing TF init

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -39,4 +39,6 @@ jobs:
 
       - name: Terraform Apply
         working-directory: terraform
-        run: terraform apply -auto-approve
+        run: |
+          terraform init
+          terraform apply -auto-approve


### PR DESCRIPTION
# Summary
Update the TF apply workflow so that terraform init is called first.

# Related
- #351 
- #352 