### PR TITLE
feat: add variable number of azs to VPC

### DIFF
--- a/.github/workflows/conftest/test_plan.tf
+++ b/.github/workflows/conftest/test_plan.tf
@@ -17,7 +17,8 @@ module "vpc" {
   source            = "../../../vpc"
   name              = "vpc"
   billing_tag_value = "cal"
-  high_availability = true
+  availability_zones = 3
+  cidrsubnet_newbits = 8
   enable_eip        = false
 }
 

--- a/vpc/README.md
+++ b/vpc/README.md
@@ -89,6 +89,7 @@ No modules.
 | <a name="input_block_rdp"></a> [block\_rdp](#input\_block\_rdp) | (Optional, default 'true') Whether or not to block Port 3389 | `bool` | `true` | no |
 | <a name="input_block_ssh"></a> [block\_ssh](#input\_block\_ssh) | (Optional, default 'true') Whether or not to block Port 22 | `bool` | `true` | no |
 | <a name="input_cidr"></a> [cidr](#input\_cidr) | (Optional, default '10.0.0.0/16') The CIDR block for the VPC | `string` | `"10.0.0.0/16"` | no |
+| <a name="input_cidrsubnet_newbits"></a> [cidrsubnet\_newbits](#input\_cidrsubnet\_newbits) | (Optional, default '10') The number of additional bits with which to extend the cidr subnet prefix | `number` | `10` | no |
 | <a name="input_enable_eip"></a> [enable\_eip](#input\_enable\_eip) | (Optional, default 'true') Enables Elastic IPs, disabling is mainly used for testing purposes | `bool` | `true` | no |
 | <a name="input_enable_flow_log"></a> [enable\_flow\_log](#input\_enable\_flow\_log) | (Optional, default 'false') Whether or not to enable VPC Flow Logs | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | (Required) The name of the vpc | `string` | n/a | yes |

--- a/vpc/README.md
+++ b/vpc/README.md
@@ -22,13 +22,15 @@ Single Zone mode deployes in the first AZ in a region that is found by the avail
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5 |
 
 ## Modules
 
@@ -81,6 +83,7 @@ No modules.
 | <a name="input_allow_https_request_in_response"></a> [allow\_https\_request\_in\_response](#input\_allow\_https\_request\_in\_response) | (Optional, default 'false') Allow a response back to the internet in reply to a request | `bool` | `false` | no |
 | <a name="input_allow_https_request_out"></a> [allow\_https\_request\_out](#input\_allow\_https\_request\_out) | (Optional, default 'false') Allow HTTPS connections on port 443 out to the internet | `bool` | `false` | no |
 | <a name="input_allow_https_request_out_response"></a> [allow\_https\_request\_out\_response](#input\_allow\_https\_request\_out\_response) | (Optional, default 'false') Allow a response back from the internet in reply to a request | `bool` | `false` | no |
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | (Optional, default '1') The number of availability zones to use | `number` | `1` | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_block_rdp"></a> [block\_rdp](#input\_block\_rdp) | (Optional, default 'true') Whether or not to block Port 3389 | `bool` | `true` | no |
@@ -88,7 +91,6 @@ No modules.
 | <a name="input_cidr"></a> [cidr](#input\_cidr) | (Optional, default '10.0.0.0/16') The CIDR block for the VPC | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_enable_eip"></a> [enable\_eip](#input\_enable\_eip) | (Optional, default 'true') Enables Elastic IPs, disabling is mainly used for testing purposes | `bool` | `true` | no |
 | <a name="input_enable_flow_log"></a> [enable\_flow\_log](#input\_enable\_flow\_log) | (Optional, default 'false') Whether or not to enable VPC Flow Logs | `bool` | `false` | no |
-| <a name="input_high_availability"></a> [high\_availability](#input\_high\_availability) | (Optional, default 'false') Create 3 public and 3 private subnets across 3 availability zones in the region. | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | (Required) The name of the vpc | `string` | n/a | yes |
 | <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | (Optional, default []) A list of private subnets inside the VPC | `list(string)` | `[]` | no |
 | <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | (Optional, default []) A list of public subnets inside the VPC | `list(string)` | `[]` | no |

--- a/vpc/examples/high_availability/main.tf
+++ b/vpc/examples/high_availability/main.tf
@@ -3,8 +3,8 @@ module "high_availability_vpc" {
   source = "../../"
   name   = "high_availability"
 
-  high_availability = true
-  enable_flow_log   = true
+  availability_zones = 3
+  enable_flow_log    = true
 
   # Allow VPC resources to send requests out to the internet and recieve a response
   allow_https_request_out          = true

--- a/vpc/examples/high_availability_single_nat/main.tf
+++ b/vpc/examples/high_availability_single_nat/main.tf
@@ -4,7 +4,7 @@ module "high_availability_single_nat_vpc" {
   name   = "high_availability_single_nat"
 
   availability_zones = 3
-  enable_flow_log   = true
+  enable_flow_log    = true
 
   # Only provision one NAT gateway to be shared by all your private subnets
   single_nat_gateway = true

--- a/vpc/examples/high_availability_single_nat/main.tf
+++ b/vpc/examples/high_availability_single_nat/main.tf
@@ -3,7 +3,7 @@ module "high_availability_single_nat_vpc" {
   source = "../../"
   name   = "high_availability_single_nat"
 
-  high_availability = true
+  availability_zones = 3
   enable_flow_log   = true
 
   # Only provision one NAT gateway to be shared by all your private subnets

--- a/vpc/inputs.tf
+++ b/vpc/inputs.tf
@@ -91,3 +91,9 @@ variable "single_nat_gateway" {
   type        = bool
   default     = false
 }
+
+variable "cidrsubnet_newbits" {
+  type        = number
+  default     = 10
+  description = "(Optional, default '10') The number of additional bits with which to extend the cidr subnet prefix"
+}

--- a/vpc/inputs.tf
+++ b/vpc/inputs.tf
@@ -14,10 +14,10 @@ variable "billing_tag_value" {
   type        = string
 }
 
-variable "high_availability" {
-  description = "(Optional, default 'false') Create 3 public and 3 private subnets across 3 availability zones in the region."
-  type        = bool
-  default     = false
+variable "availability_zones" {
+  description = "(Optional, default '1') The number of availability zones to use"
+  type        = number
+  default     = 1
 }
 
 variable "enable_flow_log" {
@@ -37,7 +37,6 @@ variable "block_rdp" {
   type        = bool
   default     = true
 }
-
 
 variable "enable_eip" {
   description = "(Optional, default 'true') Enables Elastic IPs, disabling is mainly used for testing purposes"

--- a/vpc/locals.tf
+++ b/vpc/locals.tf
@@ -3,7 +3,7 @@ locals {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = "true"
   }
-  zone_names        = var.high_availability ? data.aws_availability_zones.available.names : [data.aws_availability_zones.available.names[0]]
+  zone_names        = [for i in range(var.availability_zones) : data.aws_availability_zones.available.names[i]]
   max_subnet_length = length(local.zone_names)
   nat_gateway_count = var.single_nat_gateway ? 1 : local.max_subnet_length
   nat_gateway_ips   = var.enable_eip ? tolist(aws_eip.nat.*.id) : [""]

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -59,8 +59,8 @@ resource "aws_nat_gateway" "nat_gw" {
 
 locals {
   // If a single subnet then use 10 for newbits, otherwise use 8
-  private_cidr_blocks = local.max_subnet_length == 1 ? [cidrsubnet(aws_vpc.main.cidr_block, 10, 0)] : [for i in range(local.max_subnet_length) : cidrsubnet(aws_vpc.main.cidr_block, 8, i)]
-  public_cidr_blocks  = local.max_subnet_length == 1 ? [cidrsubnet(aws_vpc.main.cidr_block, 10, 1)] : [for i in range(local.max_subnet_length) : cidrsubnet(aws_vpc.main.cidr_block, 8, i + local.max_subnet_length)]
+  private_cidr_blocks = [for i in range(local.max_subnet_length) : cidrsubnet(aws_vpc.main.cidr_block, var.cidrsubnet_newbits, i)]
+  public_cidr_blocks  = [for i in range(local.max_subnet_length) : cidrsubnet(aws_vpc.main.cidr_block, var.cidrsubnet_newbits, i + local.max_subnet_length)]
 }
 
 resource "aws_subnet" "private" {

--- a/vpc/tests/unit.custom_subnets.tftest.hcl
+++ b/vpc/tests/unit.custom_subnets.tftest.hcl
@@ -3,12 +3,12 @@ provider "aws" {
 }
 
 variables {
-  name              = "tests"
-  high_availability = true
-  enable_eip        = false
-  cidr              = "172.16.0.0/16"
-  public_subnets    = ["172.16.0.0/20", "172.16.16.0/20", "172.16.32.0/20"]
-  private_subnets   = ["172.16.128.0/20", "172.16.144.0/20", "172.16.160.0/20"]
+  name               = "tests"
+  enable_eip         = false
+  cidr               = "172.16.0.0/16"
+  availability_zones = 3
+  public_subnets     = ["172.16.0.0/20", "172.16.16.0/20", "172.16.32.0/20"]
+  private_subnets    = ["172.16.128.0/20", "172.16.144.0/20", "172.16.160.0/20"]
 }
 
 # Multi zone VPC with custom subnet CIDR ranges

--- a/vpc/tests/unit.high_availability.tftest.hcl
+++ b/vpc/tests/unit.high_availability.tftest.hcl
@@ -6,7 +6,7 @@ variables {
   name                             = "tests"
   cidr                             = "10.10.0.0/24"
   enable_flow_log                  = true
-  high_availability                = true
+  aws_availability_zones           = 3
   allow_https_request_out          = true
   allow_https_request_out_response = true
   allow_https_request_in           = true

--- a/vpc/tests/unit.high_availability.tftest.hcl
+++ b/vpc/tests/unit.high_availability.tftest.hcl
@@ -5,8 +5,9 @@ provider "aws" {
 variables {
   name                             = "tests"
   cidr                             = "10.10.0.0/24"
+  cidrsubnet_newbits               = 8
   enable_flow_log                  = true
-  aws_availability_zones           = 3
+  availability_zones               = 3
   allow_https_request_out          = true
   allow_https_request_out_response = true
   allow_https_request_in           = true

--- a/vpc/tests/unit.high_availability_single_nat.tftest.hcl
+++ b/vpc/tests/unit.high_availability_single_nat.tftest.hcl
@@ -4,7 +4,7 @@ provider "aws" {
 
 variables {
   name               = "tests"
-  high_availability  = true
+  availability_zones = 3
   single_nat_gateway = true
 }
 

--- a/vpc/versions.tf
+++ b/vpc/versions.tf
@@ -1,0 +1,6 @@
+terraform {
+
+  required_providers {
+    aws = ">= 5"
+  }
+}


### PR DESCRIPTION
Does the following: 

- allow a variable amount of availability zones  (will fail at compile time if the number of az's is higher then those available in a region.)
- removes the `high_availability` flag
- Allows you to specify the `cidrsubnet_newbits` as the existing functionality didn't work nice with a variable number of AZ's or a cidr range that is too small, defaults to `10`
- removes the deprecated `vpc = true` flag from inside the module and replaces it with `domain = "vpc"` to match the new syntax in the aws provider v5


BREAKING CHANGE - will no longer work with provders < 5