### PR TITLE
fix: add client VPN output for CloudWatch log group

### DIFF
--- a/client_vpn/README.md
+++ b/client_vpn/README.md
@@ -63,4 +63,5 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_client_vpn_cloudwatch_log_group_name"></a> [client\_vpn\_cloudwatch\_log\_group\_name](#output\_client\_vpn\_cloudwatch\_log\_group\_name) | Client VPN's CloudWatch log group name |
 | <a name="output_client_vpn_security_group_id"></a> [client\_vpn\_security\_group\_id](#output\_client\_vpn\_security\_group\_id) | Client VPN's security group ID |

--- a/client_vpn/output.tf
+++ b/client_vpn/output.tf
@@ -1,3 +1,8 @@
+output "client_vpn_cloudwatch_log_group_name" {
+  description = "Client VPN's CloudWatch log group name"
+  value       = aws_cloudwatch_log_group.this.name
+}
+
 output "client_vpn_security_group_id" {
   description = "Client VPN's security group ID"
   value       = aws_security_group.this.id


### PR DESCRIPTION
# Summary
Add an output with the client VPN's CloudWatch log group name. This can be used for things like the Sentinel log forwarder's subscriptions.

# Related
- https://github.com/cds-snc/platform-core-services/issues/508