### PR TITLE
fix: add ECS role ARN outputs

### DIFF
--- a/ecs/README.md
+++ b/ecs/README.md
@@ -112,3 +112,5 @@ No requirements.
 | <a name="output_task_definition_arn"></a> [task\_definition\_arn](#output\_task\_definition\_arn) | Full ARN of the Task Definition (including both `family` and `revision`) |
 | <a name="output_task_definition_family"></a> [task\_definition\_family](#output\_task\_definition\_family) | The unique name of the task definition |
 | <a name="output_task_definition_revision"></a> [task\_definition\_revision](#output\_task\_definition\_revision) | Revision of the task in a particular family |
+| <a name="output_task_exec_role_arn"></a> [task\_exec\_role\_arn](#output\_task\_exec\_role\_arn) | ARN of the ECS task execution role (used by ECS to initialize and manage the task) |
+| <a name="output_task_role_arn"></a> [task\_role\_arn](#output\_task\_role\_arn) | ARN of the ECS task role (used by the running task container) |

--- a/ecs/locals.tf
+++ b/ecs/locals.tf
@@ -5,4 +5,6 @@ locals {
   }
   container_name         = var.container_name != null ? var.container_name : local.task_definition_family
   task_definition_family = var.task_name != null ? var.task_name : var.service_name
+  task_exec_role_arn     = var.task_exec_role_arn != null ? var.task_exec_role_arn : aws_iam_role.this_task_exec.arn
+  task_role_arn          = var.task_role_arn != null ? var.task_role_arn : aws_iam_role.this_task.arn
 }

--- a/ecs/main.tf
+++ b/ecs/main.tf
@@ -87,8 +87,8 @@ resource "aws_ecs_task_definition" "this" {
   family                = local.task_definition_family
   cpu                   = var.task_cpu
   memory                = var.task_memory
-  execution_role_arn    = var.task_exec_role_arn != null ? var.task_exec_role_arn : aws_iam_role.this_task_exec.arn
-  task_role_arn         = var.task_role_arn != null ? var.task_role_arn : aws_iam_role.this_task.arn
+  execution_role_arn    = local.task_exec_role_arn
+  task_role_arn         = local.task_role_arn
   container_definitions = jsonencode([local.container_definition])
 
   network_mode             = "awsvpc"

--- a/ecs/output.tf
+++ b/ecs/output.tf
@@ -32,7 +32,7 @@ output "service_name" {
 }
 
 ################################################################################
-# Task Definition
+# Task
 ################################################################################
 
 output "task_definition_arn" {
@@ -48,6 +48,16 @@ output "task_definition_revision" {
 output "task_definition_family" {
   description = "The unique name of the task definition"
   value       = aws_ecs_task_definition.this.family
+}
+
+output "task_exec_role_arn" {
+  description = "ARN of the ECS task execution role (used by ECS to initialize and manage the task)"
+  value       = local.task_exec_role_arn
+}
+
+output "task_role_arn" {
+  description = "ARN of the ECS task role (used by the running task container)"
+  value       = local.task_role_arn
 }
 
 ################################################################################


### PR DESCRIPTION
# Summary
Add outputs with the ECS execution role ARN and task role ARN.

# Related
- https://github.com/cds-snc/cds-superset/issues/21