### PR TITLE
fix: append service name to CloudWatch log group name

### DIFF
--- a/ecs/cloudwatch.tf
+++ b/ecs/cloudwatch.tf
@@ -3,7 +3,7 @@
 ################################################################################
 
 resource "aws_cloudwatch_log_group" "this" {
-  name              = "/aws/ecs/${var.cluster_name}"
+  name              = "/aws/ecs/${var.cluster_name}/${var.service_name}"
   retention_in_days = var.cloudwatch_log_group_retention_in_days
   tags              = local.common_tags
 }


### PR DESCRIPTION
# Summary
Update the CloudWatch log group so that it includes the ECS service name.  This is being done to allow the module to define services in an existing cluster.

# Related
- https://github.com/cds-snc/platform-core-services/issues/536