### PR TITLE
fix: set a blank target_prefix if none specified

### DIFF
--- a/S3/main.tf
+++ b/S3/main.tf
@@ -35,7 +35,7 @@ resource "aws_s3_bucket" "this" {
 
     content {
       target_bucket = logging.value.target_bucket
-      target_prefix = lookup(logging.value, "target_prefix", null)
+      target_prefix = lookup(logging.value, "target_prefix", "logs/")
     }
   }
 


### PR DESCRIPTION
# Summary
Update the module so that if no logging `target_prefix` is set, it defaults to blank.  This is to address a change in the AWS API where the `LoggingEnabled.TargetPrefix` request element is now required.