### PR TITLE
feat: add support for lambda function associations

### DIFF
--- a/simple_static_website/README.md
+++ b/simple_static_website/README.md
@@ -69,6 +69,7 @@ No modules.
 | <a name="input_force_destroy_s3_bucket"></a> [force\_destroy\_s3\_bucket](#input\_force\_destroy\_s3\_bucket) | (Optional, default 'false') If true, the s3 bucket will be deleted even if it's full. Not advised for production use. | `bool` | `false` | no |
 | <a name="input_hosted_zone_id"></a> [hosted\_zone\_id](#input\_hosted\_zone\_id) | (Optional, default '') Hosted zone ID used to create the domain name source ALIAS record pointing to Cloudfront.  If not specified, a new hosted zone will be created. | `string` | `""` | no |
 | <a name="input_index_document"></a> [index\_document](#input\_index\_document) | (Optional, default 'index.html') The name of the index document. | `string` | `"index.html"` | no |
+| <a name="input_lambda_function_association"></a> [lambda\_function\_association](#input\_lambda\_function\_association) | (Optional) Map containing lambda function association configuration. A maximum of 4 can be specified. | `list(map(string))` | `[]` | no |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | (Optional, default '') Name of the S3 bucket.  If not specified the domain\_name\_source + a random number will be used. | `string` | `""` | no |
 | <a name="input_single_page_app"></a> [single\_page\_app](#input\_single\_page\_app) | (Optional, default 'false') If true, the index document will be returned for all 403 requests to the origin. | `bool` | `false` | no |
 

--- a/simple_static_website/cloudfront.tf
+++ b/simple_static_website/cloudfront.tf
@@ -38,6 +38,16 @@ resource "aws_cloudfront_distribution" "simple_static_website" {
       }
     }
 
+    dynamic "lambda_function_association" {
+      for_each = var.lambda_function_association
+
+      content {
+        event_type   = lookup(lambda_function_association.value, "event_type", null)
+        include_body = lookup(lambda_function_association.value, "include_body", false)
+        lambda_arn   = lookup(lambda_function_association.value, "lambda_arn", null)
+      }
+    }
+
     viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
     default_ttl            = 86400

--- a/simple_static_website/input.tf
+++ b/simple_static_website/input.tf
@@ -30,6 +30,16 @@ variable "domain_name_source" {
   }
 }
 
+variable "lambda_function_association" {
+  description = "(Optional) Map containing lambda function association configuration. A maximum of 4 can be specified."
+  type        = list(map(string))
+  default     = []
+  validation {
+    condition     = length(var.lambda_function_association) <= 4
+    error_message = "No more than 4 lambda function associations can be specified."
+  }
+}
+
 variable "s3_bucket_name" {
   description = "(Optional, default '') Name of the S3 bucket.  If not specified the domain_name_source + a random number will be used."
   type        = string


### PR DESCRIPTION
# Summary
Add the ability to specify lambda function associations with the website's CloudFront distribution.

# Related
- https://github.com/cds-snc/platform-core-services/issues/542