### PR TITLE
feat: allow the bucket ACL to be specified

### DIFF
--- a/S3/README.md
+++ b/S3/README.md
@@ -31,6 +31,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_acl"></a> [acl](#input\_acl) | (Optional, defaults to 'private') ACL to apply to the bucket | `string` | `"private"` | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional) The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Rquired) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_block_public_acls"></a> [block\_public\_acls](#input\_block\_public\_acls) | (Optional, default 'true') Reject requests to create public ACLs. | `bool` | `true` | no |

--- a/S3/input.tf
+++ b/S3/input.tf
@@ -1,6 +1,12 @@
 ###
 # Common tags
 ###
+variable "acl" {
+  description = "(Optional, defaults to 'private') ACL to apply to the bucket"
+  type        = string
+  default     = "private"
+}
+
 variable "billing_tag_key" {
   description = "(Optional) The name of the billing tag"
   type        = string

--- a/S3/main.tf
+++ b/S3/main.tf
@@ -15,7 +15,7 @@ resource "aws_s3_bucket" "this" {
   bucket        = var.bucket_name
   bucket_prefix = var.bucket_prefix
 
-  acl = "private"
+  acl = var.acl
 
   tags          = merge(local.common_tags, var.tags)
   force_destroy = var.force_destroy


### PR DESCRIPTION
# Summary
Update the S3 bucket so that an ACL can be specified.  This will allow ACLs to be disabled which is the recommended approach when a bucket policy is used.

# Related
- https://github.com/cds-snc/cds-aws-lz/pull/235