### PR TITLE
Changing webhook url to be a variable. 

### DIFF
--- a/spend_notifier/examples/main.tf
+++ b/spend_notifier/examples/main.tf
@@ -1,7 +1,7 @@
 module "spend_notifier_example" {
   source                     = "github.com/cds-snc/terraform-modules//spend_notifier?ref=v9.2.5"
-  daily_spend_notifier_hook  = "d5bfc2dc-07d9-4553-adbb-08a0b44a4bea"
-  weekly_spend_notifier_hook = "d5bfc2dc-07d9-4553-adbb-08a0b44a4bea"
+  daily_spend_notifier_hook  = var.webhook_url
+  weekly_spend_notifier_hook = var.webhook_url 
   billing_tag_value          = "My billing tag value"
   account_name               = "My account name"
 }

--- a/spend_notifier/examples/main.tf
+++ b/spend_notifier/examples/main.tf
@@ -1,7 +1,7 @@
 module "spend_notifier_example" {
   source                     = "github.com/cds-snc/terraform-modules//spend_notifier?ref=v9.2.5"
-  daily_spend_notifier_hook  = var.webhook_url
-  weekly_spend_notifier_hook = var.webhook_url 
+  daily_spend_notifier_hook  = var.daily_spend_notifier_hook
+  weekly_spend_notifier_hook = var.weekly_spend_notifier_hook
   billing_tag_value          = "My billing tag value"
   account_name               = "My account name"
 }


### PR DESCRIPTION

# Summary | Résumé

Changed the example to use a variable instead of the webhook to prevent people to accidentally commit a webhook URL as is into their code. The webhook that was used in the example was not active and is disabled, but wanted to make sure that it is clear that the webhook URL should be passed in as a variable since it is considered sensitive information. 