### PR TITLE
chore: add rds_activity_stream unit tests

### DIFF
--- a/rds_activity_stream/tests/unit.main.tftest.hcl
+++ b/rds_activity_stream/tests/unit.main.tftest.hcl
@@ -7,6 +7,55 @@ variables {
   rds_cluster_arn = "arn:aws:rds:ca-central-1:123456789012:cluster:test-cluster"
 }
 
-run "test_case" {
+run "default_values" {
   command = plan
+
+  assert {
+    condition     = aws_rds_cluster_activity_stream.activity_stream.mode == "async"
+    error_message = "Attribute not match expected value"
+  }
+
+  assert {
+    condition     = aws_rds_cluster_activity_stream.activity_stream.resource_arn == "arn:aws:rds:ca-central-1:123456789012:cluster:test-cluster"
+    error_message = "Attribute not match expected value"
+  }
+
+  assert {
+    condition     = aws_rds_cluster_activity_stream.activity_stream.resource_arn == "arn:aws:rds:ca-central-1:123456789012:cluster:test-cluster"
+    error_message = "Attribute not match expected value"
+  }
+
+  assert {
+    condition     = aws_kinesis_firehose_delivery_stream.activity_stream.name == "terraform-tests-firehose"
+    error_message = "Attribute not match expected value"
+  }
+
+  assert {
+    condition     = aws_lambda_layer_version.decrypt_deps.compatible_runtimes == toset(["python3.12"])
+    error_message = "Attribute not match expected value"
+  }
+
+  assert {
+    condition     = aws_lambda_function.decrypt.function_name == "terraform-tests-decrypt"
+    error_message = "Attribute not match expected value"
+  }
+
+  assert {
+    condition     = aws_lambda_function.decrypt.runtime == "python3.12"
+    error_message = "Attribute not match expected value"
+  }
+}
+
+run "input_validation" {
+  command = plan
+
+  variables {
+    activity_stream_mode = "foo"
+    rds_stream_name      = "An Invalid Stream Name"
+  }
+
+  expect_failures = [
+    var.activity_stream_mode,
+    var.rds_stream_name,
+  ]
 }


### PR DESCRIPTION
# Summary
Add `terraform plan` unit tests for the module.

# Related
- https://github.com/cds-snc/platform-core-services/issues/508