### PR TITLE
Making spend notifier more customizable

### DIFF
--- a/spend_notifier/eventbridge.tf
+++ b/spend_notifier/eventbridge.tf
@@ -8,7 +8,7 @@ resource "aws_cloudwatch_event_rule" "weekly_budget_spend" {
 
 resource "aws_cloudwatch_event_target" "weekly_budget_spend" {
   count = var.enable_weekly_spend_notification ? 1 : 0
-  rule  = aws_cloudwatch_event_rule.weekly_budget_spend.name
+  rule  = aws_cloudwatch_event_rule.weekly_budget_spend[0].name
   arn   = aws_lambda_function.spend_notifier.arn
   input = jsonencode({
     "hook" = "${var.weekly_spend_notifier_hook}"
@@ -27,7 +27,7 @@ resource "aws_cloudwatch_event_rule" "daily_budget_spend" {
 
 resource "aws_cloudwatch_event_target" "daily_budget_spend" {
   count = var.enable_daily_spend_notification ? 1 : 0
-  rule  = aws_cloudwatch_event_rule.daily_budget_spend.name
+  rule  = aws_cloudwatch_event_rule.daily_budget_spend[0].name
   arn   = aws_lambda_function.spend_notifier.arn
   input = jsonencode({
     "hook" = "${var.daily_spend_notifier_hook}"

--- a/spend_notifier/eventbridge.tf
+++ b/spend_notifier/eventbridge.tf
@@ -1,13 +1,15 @@
 resource "aws_cloudwatch_event_rule" "weekly_budget_spend" {
+  count               = var.enable_weekly_spend_notification ? 1 : 0
   name                = "weeklyBudgetSpend"
-  schedule_expression = "cron(0 12 ? * SUN *)"
+  schedule_expression = "cron(${var.weekly_schedule_expression})"
 
   tags = local.common_tags
 }
 
 resource "aws_cloudwatch_event_target" "weekly_budget_spend" {
-  rule = aws_cloudwatch_event_rule.weekly_budget_spend.name
-  arn  = aws_lambda_function.spend_notifier.arn
+  count = var.enable_weekly_spend_notification ? 1 : 0
+  rule  = aws_cloudwatch_event_rule.weekly_budget_spend.name
+  arn   = aws_lambda_function.spend_notifier.arn
   input = jsonencode({
     "hook" = "${var.weekly_spend_notifier_hook}"
     }
@@ -15,15 +17,18 @@ resource "aws_cloudwatch_event_target" "weekly_budget_spend" {
 }
 
 resource "aws_cloudwatch_event_rule" "daily_budget_spend" {
+  count               = var.enable_daily_spend_notification ? 1 : 0
   name                = "dailyBudgetSpend"
-  schedule_expression = "cron(0 12 * * ? *)"
+  schedule_expression = "cron(${var.daily_schedule_expression})"
 
   tags = local.common_tags
 }
 
+
 resource "aws_cloudwatch_event_target" "daily_budget_spend" {
-  rule = aws_cloudwatch_event_rule.daily_budget_spend.name
-  arn  = aws_lambda_function.spend_notifier.arn
+  count = var.enable_daily_spend_notification ? 1 : 0
+  rule  = aws_cloudwatch_event_rule.daily_budget_spend.name
+  arn   = aws_lambda_function.spend_notifier.arn
   input = jsonencode({
     "hook" = "${var.daily_spend_notifier_hook}"
   })

--- a/spend_notifier/examples/main.tf
+++ b/spend_notifier/examples/main.tf
@@ -1,7 +1,11 @@
 module "spend_notifier_example" {
-  source                     = "github.com/cds-snc/terraform-modules//spend_notifier?ref=v9.2.7"
-  daily_spend_notifier_hook  = var.daily_spend_notifier_hook
-  weekly_spend_notifier_hook = var.weekly_spend_notifier_hook
-  billing_tag_value          = "My billing tag value"
-  account_name               = "My account name"
+  source                           = "github.com/cds-snc/terraform-modules//spend_notifier?ref=v9.2.7"
+  daily_spend_notifier_hook        = var.daily_spend_notifier_hook
+  weekly_spend_notifier_hook       = var.weekly_spend_notifier_hook
+  billing_tag_value                = "My billing tag value"
+  account_name                     = "My account name"
+  enable_daily_spend_notification  = true
+  enable_weekly_spend_notification = true
+  daily_schedule_expression        = "0 12 * * ? *"
+  weekly_schedule_expression       = "0 12 ? * SUN *"
 }

--- a/spend_notifier/inputs.tf
+++ b/spend_notifier/inputs.tf
@@ -21,3 +21,28 @@ variable "account_name" {
   type        = string
   default     = null
 }
+
+variable "enable_daily_spend_notification" {
+  description = "(Optional) Enable daily spend notification"
+  type        = bool
+  default     = true 
+}
+
+variable "enable_weekly_spend_notification" {
+  description = "(Optional) Enable weekly spend notification"
+  type        = bool
+  default     = true 
+}
+
+variable "weekly_schedule_expression" {
+  description = "(Optional) The schedule expression for the weekly spend notification"
+  type        = string
+  default     = "0 12 ? * SUN *"
+}
+
+variable "daily_schedule_expression" {
+  description = "(Optional) The schedule expression for the daily spend notification"
+  type        = string
+  default     = "0 12 * * ? *"
+}
+

--- a/spend_notifier/lambda.tf
+++ b/spend_notifier/lambda.tf
@@ -35,7 +35,7 @@ resource "aws_lambda_permission" "allow_daily_budget" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.spend_notifier.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.daily_budget_spend.arn
+  source_arn    = aws_cloudwatch_event_rule.daily_budget_spend[0].arn
 }
 
 resource "aws_lambda_permission" "allow_weekly_budget" {
@@ -43,7 +43,7 @@ resource "aws_lambda_permission" "allow_weekly_budget" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.spend_notifier.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.weekly_budget_spend.arn
+  source_arn    = aws_cloudwatch_event_rule.weekly_budget_spend[0].arn
 }
 
 

--- a/spend_notifier/lambda.tf
+++ b/spend_notifier/lambda.tf
@@ -31,6 +31,7 @@ resource "aws_lambda_function" "spend_notifier" {
 
 
 resource "aws_lambda_permission" "allow_daily_budget" {
+  count         = var.enable_daily_spend_notification ? 1 : 0
   statement_id  = "AllowDailyBudget"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.spend_notifier.function_name
@@ -39,6 +40,7 @@ resource "aws_lambda_permission" "allow_daily_budget" {
 }
 
 resource "aws_lambda_permission" "allow_weekly_budget" {
+  count         = var.enable_weekly_spend_notification ? 1 : 0
   statement_id  = "AllowWeeklyBudget"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.spend_notifier.function_name


### PR DESCRIPTION
# Summary | Résumé

Added additional input variables to make the spend notifier more customizable. Now, you can pass in whether you want weekly or daily notifications plus set the cron schedule required. 