### PR TITLE
fix: increase RDS activity stream lambda resources

### DIFF
--- a/rds_activity_stream/lambda.tf
+++ b/rds_activity_stream/lambda.tf
@@ -42,8 +42,8 @@ resource "aws_lambda_function" "decrypt" {
   function_name = local.decrypt_lambda_function
   handler       = "decrypt.handler"
   runtime       = local.python_version
-  memory_size   = 256
-  timeout       = 5
+  memory_size   = 1024
+  timeout       = 10
   role          = aws_iam_role.decrypt.arn
 
   filename         = data.archive_file.decrypt_code.output_path


### PR DESCRIPTION
# Summary
Increase the memory and timeout of the decrypt Lambda function so it can keep up with the activity of databases under high load.

# Related
- https://github.com/cds-snc/platform-core-services/issues/508