### PR TITLE
feat: RDS activity stream config inputs for decrypt lambda

### DIFF
--- a/rds_activity_stream/README.md
+++ b/rds_activity_stream/README.md
@@ -63,6 +63,8 @@ No requirements.
 | <a name="input_activity_stream_mode"></a> [activity\_stream\_mode](#input\_activity\_stream\_mode) | (Optional, default 'async') The activity stream recording mode to enable on the RDS cluster. Valid values are 'sync' or 'async'. | `string` | `"async"` | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag. | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag. | `string` | n/a | yes |
+| <a name="input_decrypt_lambda_memory_size"></a> [decrypt\_lambda\_memory\_size](#input\_decrypt\_lambda\_memory\_size) | (Optional, default 1024) The amount of memory in MB that the Lambda function will have available for processing. | `number` | `1024` | no |
+| <a name="input_decrypt_lambda_timeout"></a> [decrypt\_lambda\_timeout](#input\_decrypt\_lambda\_timeout) | (Optional, default 10) The maximum amount of time in seconds that the Lambda function will process before timing out. | `number` | `10` | no |
 | <a name="input_rds_cluster_arn"></a> [rds\_cluster\_arn](#input\_rds\_cluster\_arn) | (Required) The ARN of the RDS cluster to enable the activity stream on. | `string` | n/a | yes |
 | <a name="input_rds_stream_name"></a> [rds\_stream\_name](#input\_rds\_stream\_name) | (Required) The name that will be used to represent this activity stream's resources.  It must be unique within the account. | `string` | n/a | yes |
 

--- a/rds_activity_stream/input.tf
+++ b/rds_activity_stream/input.tf
@@ -26,6 +26,18 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "decrypt_lambda_memory_size" {
+  description = "(Optional, default 1024) The amount of memory in MB that the Lambda function will have available for processing."
+  type        = number
+  default     = 1024
+}
+
+variable "decrypt_lambda_timeout" {
+  description = "(Optional, default 10) The maximum amount of time in seconds that the Lambda function will process before timing out."
+  type        = number
+  default     = 10
+}
+
 variable "rds_cluster_arn" {
   description = "(Required) The ARN of the RDS cluster to enable the activity stream on."
   type        = string

--- a/rds_activity_stream/lambda.tf
+++ b/rds_activity_stream/lambda.tf
@@ -42,8 +42,8 @@ resource "aws_lambda_function" "decrypt" {
   function_name = local.decrypt_lambda_function
   handler       = "decrypt.handler"
   runtime       = local.python_version
-  memory_size   = 1024
-  timeout       = 10
+  memory_size   = var.decrypt_lambda_memory_size
+  timeout       = var.decrypt_lambda_timeout
   role          = aws_iam_role.decrypt.arn
 
   filename         = data.archive_file.decrypt_code.output_path


### PR DESCRIPTION
# Summary
Add variables that allow the decrypt lambda's memory size and timeout to be configurable.

# Related
- https://github.com/cds-snc/platform-core-services/issues/508