### PR TITLE
fix: RDS activity stream lambda external data source

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 		"SHELL": "/bin/zsh"
 	},	
 	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/python:1": {
 			"version": "3.12",
 			"installTools": "false"

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ terraform/*.tfvars
 .pytest_cache
 __pycache__
 rds_activity_stream/lambda/layer
+rds_activity_stream/lambda/*.zip
 
 .github/workflows/conftest/policy

--- a/rds_activity_stream/README.md
+++ b/rds_activity_stream/README.md
@@ -16,7 +16,7 @@ No requirements.
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
+| <a name="provider_external"></a> [external](#provider\_external) | n/a |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
@@ -44,7 +44,6 @@ No requirements.
 | [aws_lambda_layer_version.decrypt_deps](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version) | resource |
 | [aws_lambda_permission.lambda_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_rds_cluster_activity_stream.activity_stream](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_activity_stream) | resource |
-| [null_resource.decrypt_deps](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_string.bucket_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [archive_file.decrypt_code](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |

--- a/rds_activity_stream/README.md
+++ b/rds_activity_stream/README.md
@@ -47,13 +47,13 @@ No requirements.
 | [null_resource.decrypt_deps](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_string.bucket_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [archive_file.decrypt_code](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
-| [archive_file.decrypt_deps](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.decrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.decrypt_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.firehose_activity_stream](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.firehose_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [external_external.decrypt_deps](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
 
 ## Inputs
 

--- a/rds_activity_stream/scripts/decrypt_deps.sh
+++ b/rds_activity_stream/scripts/decrypt_deps.sh
@@ -17,11 +17,10 @@ docker run -v "${SRC_DIR}":/var/task public.ecr.aws/sam/build-${PYTHON_VERSION} 
     > /dev/null 2>&1
 
 # Generate a deterministic zip file
-# This is done by removing the compiled bytecode and setting the timestamp of the downloaded
-# files to the date of the `requirements.txt` file's last commit
-REQUIREMENTS_DATE="$(git log -1 --date=format:"%Y%m%d%H%M" --format="%ad" ${SRC_DIR}/lambda/requirements.txt)"
+# This is done by removing the compiled bytecode and setting the timestamp of the
+# downloaded files to the same date.
 find "${SRC_DIR}/lambda/layer" | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf  > /dev/null 2>&1
-find "${SRC_DIR}/lambda/layer" -exec touch -t "$REQUIREMENTS_DATE" {} +  > /dev/null 2>&1
+find "${SRC_DIR}/lambda/layer" -exec touch -t 197001010000 {} + > /dev/null 2>&1
 cd "${SRC_DIR}/lambda/layer"
 zip -r -X "${SRC_DIR}/lambda/decrypt_deps.zip" python/ > /dev/null 2>&1
 

--- a/rds_activity_stream/scripts/decrypt_deps.sh
+++ b/rds_activity_stream/scripts/decrypt_deps.sh
@@ -12,9 +12,11 @@ IFS=$'\n\t'
 eval "$(jq -r '@sh "export PYTHON_VERSION=\(.python_version) SRC_DIR=\(.src_dir)"')"
 
 # Download dependencies
-docker run -v "${SRC_DIR}":/var/task public.ecr.aws/sam/build-${PYTHON_VERSION} \
-    /bin/sh -c "pip install -r lambda/requirements.txt -t lambda/layer/python/; exit" \
-    > /dev/null
+docker run \
+    --user $(id -u):$(id -g) \
+    --volume "${SRC_DIR}":/var/task \
+    public.ecr.aws/sam/build-${PYTHON_VERSION} \
+    /bin/sh -c "pip install -r lambda/requirements.txt -t lambda/layer/python/; exit" > /dev/null
 
 # Generate a deterministic zip file
 # This is done by removing the compiled bytecode and setting the timestamp of the

--- a/rds_activity_stream/scripts/decrypt_deps.sh
+++ b/rds_activity_stream/scripts/decrypt_deps.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+#
+# Downloads the Lambda's Python dependencies and packages them into a deterministic zip file.
+# This will limit the number of times the Lambda layer is recreated by only updating the layer
+# when the `requirements.txt` file changes.
+#
+
+# Parse input
+eval "$(jq -r '@sh "export PYTHON_VERSION=\(.python_version) SRC_DIR=\(.src_dir)"')"
+
+# Download dependencies
+docker run -v "${SRC_DIR}":/var/task public.ecr.aws/sam/build-${PYTHON_VERSION} \
+    /bin/sh -c "pip install -r lambda/requirements.txt -t lambda/layer/python/; exit" \
+    > /dev/null 2>&1
+
+# Generate a deterministic zip file
+# This is done by removing the compiled bytecode and setting the timestamp of the downloaded
+# files to the date of the `requirements.txt` file's last commit
+REQUIREMENTS_DATE="$(git log -1 --date=format:"%Y%m%d%H%M" --format="%ad" ${SRC_DIR}/lambda/requirements.txt)"
+find "${SRC_DIR}/lambda/layer" | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf  > /dev/null 2>&1
+find "${SRC_DIR}/lambda/layer" -exec touch -t "$REQUIREMENTS_DATE" {} +  > /dev/null 2>&1
+cd "${SRC_DIR}/lambda/layer"
+zip -r -X "${SRC_DIR}/lambda/decrypt_deps.zip" python/ > /dev/null 2>&1
+
+# Produce output
+jq -n \
+    --arg layer_zip "${SRC_DIR}/lambda/decrypt_deps.zip" \
+    '{"layer_zip":$layer_zip}'

--- a/rds_activity_stream/scripts/decrypt_deps.sh
+++ b/rds_activity_stream/scripts/decrypt_deps.sh
@@ -14,15 +14,15 @@ eval "$(jq -r '@sh "export PYTHON_VERSION=\(.python_version) SRC_DIR=\(.src_dir)
 # Download dependencies
 docker run -v "${SRC_DIR}":/var/task public.ecr.aws/sam/build-${PYTHON_VERSION} \
     /bin/sh -c "pip install -r lambda/requirements.txt -t lambda/layer/python/; exit" \
-    > /dev/null 2>&1
+    > /dev/null
 
 # Generate a deterministic zip file
 # This is done by removing the compiled bytecode and setting the timestamp of the
 # downloaded files to the same date.
-find "${SRC_DIR}/lambda/layer" | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf  > /dev/null 2>&1
-find "${SRC_DIR}/lambda/layer" -exec touch -t 197001010000 {} + > /dev/null 2>&1
+find "${SRC_DIR}/lambda/layer" | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf  > /dev/null
+find "${SRC_DIR}/lambda/layer" -exec touch -t 197001010000 {} + > /dev/null
 cd "${SRC_DIR}/lambda/layer"
-zip -r -X "${SRC_DIR}/lambda/decrypt_deps.zip" python/ > /dev/null 2>&1
+zip -r -X "${SRC_DIR}/lambda/decrypt_deps.zip" python/ > /dev/null
 
 # Produce output
 jq -n \


### PR DESCRIPTION
# Summary
Update to use an [`external` data source](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) to create the decrypt Lambda layer dependency zip file.  This allows us to create a deterministic zip file that will only change when the `requirements.txt` file is updated.

As a result, the Lambda layer will only be updated when there are dependency changes.

# Related
- https://github.com/cds-snc/platform-core-services/issues/508