### PR TITLE
fix: RDS activity stream always download lambda dependencies

### DIFF
--- a/rds_activity_stream/README.md
+++ b/rds_activity_stream/README.md
@@ -16,8 +16,8 @@ No requirements.
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
-| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
@@ -44,8 +44,8 @@ No requirements.
 | [aws_lambda_layer_version.decrypt_deps](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version) | resource |
 | [aws_lambda_permission.lambda_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_rds_cluster_activity_stream.activity_stream](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_activity_stream) | resource |
+| [null_resource.decrypt_deps](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_string.bucket_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
-| [terraform_data.decrypt_deps](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [archive_file.decrypt_code](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [archive_file.decrypt_deps](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |


### PR DESCRIPTION
# Summary
Update the lambda dependencies to always download.  This will cause the lambda layer data archive to be available during Terraform operations.

The downside is that this will re-create the lambda layer on every Terraform apply but this bug is currently blocking the Notify Terraform workflows.

# Related
- https://github.com/cds-snc/platform-core-services/issues/508