### PR TITLE
fix: prefix SSM param name with function name

### DIFF
--- a/sentinel_forwarder/main.tf
+++ b/sentinel_forwarder/main.tf
@@ -152,7 +152,7 @@ resource "aws_cloudwatch_log_group" "sentinel_forwarder_lambda" {
 # Lambda function secrets
 #
 resource "aws_ssm_parameter" "sentinel_forwarder_auth" {
-  name = "sentinel_forwarder_auth"
+  name = "${var.function_name}-auth"
   type = "SecureString"
   value = chomp(<<-EOT
   CUSTOMER_ID=${var.customer_id}

--- a/sentinel_forwarder/tests/unit.main.tftest.hcl
+++ b/sentinel_forwarder/tests/unit.main.tftest.hcl
@@ -12,6 +12,11 @@ run "default_values" {
   command = plan
 
   assert {
+    condition     = aws_ssm_parameter.sentinel_forwarder_auth.name == "sentinel-forwarder-auth"
+    error_message = "Attribute does not match expected value"
+  }
+
+  assert {
     condition = aws_ssm_parameter.sentinel_forwarder_auth.value == chomp(<<-EOT
     CUSTOMER_ID=bruce
     SHARED_KEY=manbat


### PR DESCRIPTION
# Summary
Update the Sentinel Forwarder module's authentication SSM parameter name to include the Lambda function name.

This allows multiple instances of the module to be used in the same AWS account.

# Related
- https://github.com/cds-snc/platform-core-services/issues/557
- https://github.com/cds-snc/site-reliability-engineering/issues/1215