### PR TITLE
fix: upgrade deprecated Node.js Lambda runtime

### DIFF
--- a/spend_notifier/lambda.tf
+++ b/spend_notifier/lambda.tf
@@ -10,7 +10,7 @@ data "archive_file" "spend_notifier" {
 resource "aws_lambda_function" "spend_notifier" {
   function_name = "spend_notifier"
   role          = aws_iam_role.spend_notifier.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs18.x"
   handler       = "spend_notifier.handler"
   memory_size   = 512
 


### PR DESCRIPTION
# Summary
Update to Node.js 18.x Lambda runtime.

# Related
- https://github.com/cds-snc/platform-core-services/issues/560