### PR TITLE
fix: upgrade to AWS SDK v3

### DIFF
--- a/spend_notifier/examples/main.tf
+++ b/spend_notifier/examples/main.tf
@@ -1,9 +1,9 @@
 module "spend_notifier_example" {
-  source                           = "github.com/cds-snc/terraform-modules//spend_notifier?ref=v9.3.8"
+  source                           = "../"
   daily_spend_notifier_hook        = var.daily_spend_notifier_hook
   weekly_spend_notifier_hook       = var.weekly_spend_notifier_hook
   billing_tag_value                = "My billing tag value"
-  account_name                     = "My account name"
+  account_name                     = "123456789012"
   enable_daily_spend_notification  = true
   enable_weekly_spend_notification = true
   daily_schedule_expression        = "0 12 * * ? *"

--- a/spend_notifier/lambda.tf
+++ b/spend_notifier/lambda.tf
@@ -10,7 +10,7 @@ data "archive_file" "spend_notifier" {
 resource "aws_lambda_function" "spend_notifier" {
   function_name = "spend_notifier"
   role          = aws_iam_role.spend_notifier.arn
-  runtime       = "nodejs18.x"
+  runtime       = "nodejs20.x"
   handler       = "spend_notifier.handler"
   memory_size   = 512
 


### PR DESCRIPTION
# Summary
Update the Lambda code to use the Node.js AWS SDK v3 which is bundled with Node.js 18+ runtime environments.

Update the Lambda runtime to Node.js 20.

# Related
- https://github.com/cds-snc/platform-core-services/issues/560