### PR TITLE
chore: add RDS cluster endpoint output

### DIFF
--- a/rds/README.md
+++ b/rds/README.md
@@ -39,6 +39,7 @@ No modules.
 | [random_string.random](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.read_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
@@ -81,10 +82,11 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_proxy_connection_string_arn"></a> [proxy\_connection\_string\_arn](#output\_proxy\_connection\_string\_arn) | The arn for the connectionstring to the RDS proxy |
+| <a name="output_proxy_connection_string_arn"></a> [proxy\_connection\_string\_arn](#output\_proxy\_connection\_string\_arn) | The ARN for the connection string to the RDS proxy |
 | <a name="output_proxy_connection_string_value"></a> [proxy\_connection\_string\_value](#output\_proxy\_connection\_string\_value) | n/a |
 | <a name="output_proxy_endpoint"></a> [proxy\_endpoint](#output\_proxy\_endpoint) | n/a |
 | <a name="output_proxy_security_group_arn"></a> [proxy\_security\_group\_arn](#output\_proxy\_security\_group\_arn) | n/a |
 | <a name="output_proxy_security_group_id"></a> [proxy\_security\_group\_id](#output\_proxy\_security\_group\_id) | n/a |
 | <a name="output_rds_cluster_arn"></a> [rds\_cluster\_arn](#output\_rds\_cluster\_arn) | The ARN of the RDS cluster |
+| <a name="output_rds_cluster_endpoint"></a> [rds\_cluster\_endpoint](#output\_rds\_cluster\_endpoint) | n/a |
 | <a name="output_rds_cluster_id"></a> [rds\_cluster\_id](#output\_rds\_cluster\_id) | The ID of the RDS cluster |

--- a/rds/locals.tf
+++ b/rds/locals.tf
@@ -1,3 +1,5 @@
+data "aws_region" "current" {}
+
 locals {
   common_tags = {
     (var.billing_tag_key) = var.billing_tag_value
@@ -8,6 +10,7 @@ locals {
   is_mysql           = var.engine == "aurora-mysql"
   database_port      = local.is_mysql ? 3306 : 5432
   engine_family      = local.is_mysql ? "MYSQL" : "POSTGRESQL"
+  region             = data.aws_region.current.name
   security_group_ids = distinct(concat([aws_security_group.rds_proxy.id], var.security_group_ids))
 
   # Configure the database logs that are exported to CloudWatch.  Default to none for MySQL and `postgresql` for Postgres if no values are specified

--- a/rds/outputs.tf
+++ b/rds/outputs.tf
@@ -8,8 +8,12 @@ output "rds_cluster_id" {
   value       = aws_rds_cluster.cluster.id
 }
 
+output "rds_cluster_endpoint" {
+  value = aws_rds_cluster.cluster.endpoint
+}
+
 output "proxy_connection_string_arn" {
-  description = "The arn for the connectionstring to the RDS proxy"
+  description = "The ARN for the connection string to the RDS proxy"
   value       = aws_secretsmanager_secret.proxy_connection_string.arn
 }
 

--- a/rds/proxy_role.tf
+++ b/rds/proxy_role.tf
@@ -45,7 +45,7 @@ data "aws_iam_policy_document" "read_connection_string" {
       test     = "StringEquals"
       variable = "kms:ViaService"
       values = [
-        "secretsmanager.ca-central-1.amazonaws.com"
+        "secretsmanager.${local.region}.amazonaws.com"
       ]
     }
   }

--- a/rds/secret.tf
+++ b/rds/secret.tf
@@ -27,4 +27,3 @@ resource "aws_secretsmanager_secret_version" "proxy_connection_string" {
     "postgresql://${var.username}:${var.password}@${aws_db_proxy.proxy.endpoint}/${var.database_name}"
   )
 }
-


### PR DESCRIPTION
# Summary
Add an output with the cluster's connection endpoint.

This will be used for scenarios where the RDS proxy needs to be bypassed like RDS blue/green deployments.

# Related
- https://github.com/cds-snc/platform-core-services/issues/561