### PR TITLE
fix: RDS proxy use standalone security group rule

### DIFF
--- a/rds/README.md
+++ b/rds/README.md
@@ -36,6 +36,8 @@ No modules.
 | [aws_secretsmanager_secret_version.connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.proxy_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_security_group.rds_proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.rds_proxy_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.rds_proxy_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [random_string.random](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.read_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/rds/security_group.tf
+++ b/rds/security_group.tf
@@ -11,21 +11,27 @@ resource "aws_security_group" "rds_proxy" {
     Name = "${var.name}_rds_proxy_sg"
   })
 
-  ingress {
-    from_port = local.database_port
-    to_port   = local.database_port
-    protocol  = "TCP"
-    self      = true
-  }
-
-  egress {
-    from_port = local.database_port
-    to_port   = local.database_port
-    protocol  = "TCP"
-    self      = true
-  }
-
   lifecycle {
     create_before_destroy = true
   }
+}
+
+resource "aws_security_group_rule" "rds_proxy_ingress" {
+  description       = "Proxy ingress to the database"
+  type              = "ingress"
+  from_port         = local.database_port
+  to_port           = local.database_port
+  protocol          = "tcp"
+  self              = true
+  security_group_id = aws_security_group.rds_proxy.id
+}
+
+resource "aws_security_group_rule" "rds_proxy_egress" {
+  description       = "Proxy egress from the database"
+  type              = "egress"
+  from_port         = local.database_port
+  to_port           = local.database_port
+  protocol          = "tcp"
+  self              = true
+  security_group_id = aws_security_group.rds_proxy.id
 }


### PR DESCRIPTION
# Summary 
Update the RDS module to use standalone rules for the proxy security group.  

This will allow module consumers to more easily alter the security group by adding their own custom rules without a TF apply flip-flop on each change.
