### PR TITLE
Add an explicit effect to the policy document so that opa checks pass

### DIFF
--- a/simple_static_website/main.tf
+++ b/simple_static_website/main.tf
@@ -34,6 +34,7 @@ terraform {
 data "aws_iam_policy_document" "s3_policy" {
   statement {
     actions   = ["s3:GetObject"]
+    effect    = "Allow"
     resources = ["${aws_s3_bucket.this.arn}/*"]
 
     principals {


### PR DESCRIPTION

# Summary | Résumé

Adding an explicit allow effect to the document policy since previously our opa checks were failing. 

Thanks @patheard for the help!