### PR TITLE
fix: remove duplicate incident config argument

### DIFF
--- a/sentinel_alert_rule/main.tf
+++ b/sentinel_alert_rule/main.tf
@@ -67,28 +67,13 @@ resource "azurerm_sentinel_alert_rule_scheduled" "this" {
     }
   }
 
-  incident_configuration {
-    create_incident = var.incident_configuration.create_incident
-
-    grouping {
-      enabled                 = var.incident_configuration.grouping.enabled
-      entity_matching_method  = var.incident_configuration.grouping.entity_matching_method
-      group_by_alert_details  = var.incident_configuration.grouping.group_by_alert_details
-      group_by_custom_details = var.incident_configuration.grouping.group_by_custom_details
-      group_by_entities       = var.incident_configuration.grouping.group_by_entities
-      lookback_duration       = var.incident_configuration.grouping.lookback_duration
-      reopen_closed_incidents = var.incident_configuration.grouping.reopen_closed_incidents
-    }
-  }
-
-  # A dynamic block for incident configuration to set grouping to true by default when query_frequency is not PT5M and no variables are provided for the grouping
   dynamic "incident_configuration" {
-    for_each = can(regex("PT5M", var.query_frequency)) ? [] : [1]
+    for_each = [1]
 
-    create_incident = var.incident_configuration.create_incident
     content {
+      create_incident = var.incident_configuration.create_incident
       grouping {
-        enabled                 = true
+        enabled                 = var.query_frequency != "PT5M" ? true : var.incident_configuration.grouping.enabled
         entity_matching_method  = var.incident_configuration.grouping.entity_matching_method
         group_by_alert_details  = var.incident_configuration.grouping.group_by_alert_details
         group_by_custom_details = var.incident_configuration.grouping.group_by_custom_details
@@ -98,5 +83,4 @@ resource "azurerm_sentinel_alert_rule_scheduled" "this" {
       }
     }
   }
-
 }


### PR DESCRIPTION
# Summary | Résumé

Fix the sentinel alert module by removing the duplicate incident_configuration block.