### PR TITLE
Put lambda statistics into a LogsInsight folder of their own `Lambda`

### DIFF
--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -68,7 +68,7 @@ resource "aws_cloudwatch_log_group" "this" {
 }
 
 resource "aws_cloudwatch_query_definition" "lambda_statistics" {
-  name = "Lambda Statistics - ${var.name}"
+  name = "Lambda Statistics / ${var.name}"
 
   log_group_names = [
     aws_cloudwatch_log_group.this.name


### PR DESCRIPTION
# Summary | Résumé

Instead of having the Lambda statistics sitting in the root folder of the LogsInsight query listing, have these sitting in a folder of their own named `Lambda Statistics` for better organization.

![image](https://github.com/cds-snc/terraform-modules/assets/805567/3eb62624-6448-481a-9ae7-97690f75d326)

# Test instructions | Instructions pour tester la modification

Deploy some new lambdas after upgrading to latest lambda module version.
