### PR TITLE
Simple Static Website - ignore "version" tag on lifecycle

### DIFF
--- a/simple_static_website/main.tf
+++ b/simple_static_website/main.tf
@@ -57,7 +57,8 @@ resource "aws_s3_bucket" "this" {
 
   lifecycle {
     ignore_changes = [
-      tags["version"]
+      tags["version"],
+      tags_all["version"]
     ]
   }
 }

--- a/simple_static_website/main.tf
+++ b/simple_static_website/main.tf
@@ -57,8 +57,8 @@ resource "aws_s3_bucket" "this" {
 
   lifecycle {
     ignore_changes = [
-      tags["version"],
-      tags_all["version"]
+      tags["Version"],
+      tags_all["Version"]
     ]
   }
 }

--- a/simple_static_website/main.tf
+++ b/simple_static_website/main.tf
@@ -54,6 +54,12 @@ resource "random_string" "suffix" {
 resource "aws_s3_bucket" "this" {
   bucket        = var.s3_bucket_name == "" ? "${var.domain_name_source}-${random_string.suffix.result}" : var.s3_bucket_name
   force_destroy = var.force_destroy_s3_bucket
+
+  lifecycle {
+    ignore_changes = [
+      tags["version"]
+    ]
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "this" {


### PR DESCRIPTION
# Summary | Résumé

[We are getting a weird issue where the "version" tag on tags and tags_all is getting created somewhere else. This causes confusion on the TF plans.](https://github.com/cds-snc/notification-terraform/pull/1399#issuecomment-2189529957) 

Not sure where these tags are coming from, but I figure we can safely ignore them.

# Test instructions | Instructions pour tester la modification

TF Apply works
