### PR TITLE
feat: create an RDS cluster without a proxy

### DIFF
--- a/rds/README.md
+++ b/rds/README.md
@@ -1,4 +1,4 @@
-This module will create an RDS Cluster behind an RDS Proxy to manage connections.
+This module will create an RDS Cluster with an optional RDS Proxy to manage connections.
 
 ## Requirements
 
@@ -35,9 +35,9 @@ No modules.
 | [aws_secretsmanager_secret.proxy_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.proxy_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
-| [aws_security_group.rds_proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_security_group_rule.rds_proxy_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.rds_proxy_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.rds_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.rds_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [random_string.random](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.read_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -78,6 +78,7 @@ No modules.
 | <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | (Optional, no default) The name or ARN of the DB cluster snapshot to create the cluster from. | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | (Required) The name of the subnet the DB has to stay in | `set(string)` | n/a | yes |
 | <a name="input_upgrade_immediately"></a> [upgrade\_immediately](#input\_upgrade\_immediately) | (Optional, default false) Apply database engine upgrades immediately. | `bool` | `false` | no |
+| <a name="input_use_proxy"></a> [use\_proxy](#input\_use\_proxy) | (Optional, default 'true') This flag determines if an RDS proxy should be created for the cluster. | `bool` | `true` | no |
 | <a name="input_username"></a> [username](#input\_username) | (Required) The username for the admin user for the db | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | (Required) The vpc to run the cluster and related infrastructure in | `string` | n/a | yes |
 
@@ -85,11 +86,13 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_proxy_connection_string_arn"></a> [proxy\_connection\_string\_arn](#output\_proxy\_connection\_string\_arn) | The ARN for the connection string to the RDS proxy |
-| <a name="output_proxy_connection_string_value"></a> [proxy\_connection\_string\_value](#output\_proxy\_connection\_string\_value) | n/a |
-| <a name="output_proxy_endpoint"></a> [proxy\_endpoint](#output\_proxy\_endpoint) | n/a |
-| <a name="output_proxy_security_group_arn"></a> [proxy\_security\_group\_arn](#output\_proxy\_security\_group\_arn) | n/a |
-| <a name="output_proxy_security_group_id"></a> [proxy\_security\_group\_id](#output\_proxy\_security\_group\_id) | n/a |
-| <a name="output_rds_cluster_arn"></a> [rds\_cluster\_arn](#output\_rds\_cluster\_arn) | The ARN of the RDS cluster |
-| <a name="output_rds_cluster_endpoint"></a> [rds\_cluster\_endpoint](#output\_rds\_cluster\_endpoint) | n/a |
-| <a name="output_rds_cluster_id"></a> [rds\_cluster\_id](#output\_rds\_cluster\_id) | The ID of the RDS cluster |
+| <a name="output_cluster_security_group_arn"></a> [cluster\_security\_group\_arn](#output\_cluster\_security\_group\_arn) | The RDS cluster security group ID. |
+| <a name="output_cluster_security_group_id"></a> [cluster\_security\_group\_id](#output\_cluster\_security\_group\_id) | The RDS cluster security group ID. |
+| <a name="output_proxy_connection_string_arn"></a> [proxy\_connection\_string\_arn](#output\_proxy\_connection\_string\_arn) | The ARN for the connection string to the RDS proxy. |
+| <a name="output_proxy_connection_string_value"></a> [proxy\_connection\_string\_value](#output\_proxy\_connection\_string\_value) | The string value of the RDS proxy connection string.  This includes the username and password. |
+| <a name="output_proxy_endpoint"></a> [proxy\_endpoint](#output\_proxy\_endpoint) | The RDS proxy read/write connection endpoint. |
+| <a name="output_proxy_security_group_arn"></a> [proxy\_security\_group\_arn](#output\_proxy\_security\_group\_arn) | The RDS proxy security group ARN. |
+| <a name="output_proxy_security_group_id"></a> [proxy\_security\_group\_id](#output\_proxy\_security\_group\_id) | The RDS proxy security group ID. |
+| <a name="output_rds_cluster_arn"></a> [rds\_cluster\_arn](#output\_rds\_cluster\_arn) | The ARN of the RDS cluster. |
+| <a name="output_rds_cluster_endpoint"></a> [rds\_cluster\_endpoint](#output\_rds\_cluster\_endpoint) | RDS cluster read/write connection endpoint. |
+| <a name="output_rds_cluster_id"></a> [rds\_cluster\_id](#output\_rds\_cluster\_id) | The ID of the RDS cluster. |

--- a/rds/cloudwatch.tf
+++ b/rds/cloudwatch.tf
@@ -1,4 +1,6 @@
 resource "aws_cloudwatch_log_group" "proxy" {
+  count = var.use_proxy ? 1 : 0
+
   name              = "/aws/rds/proxy/${local.proxy_name}"
   retention_in_days = var.proxy_log_retention_in_days
 

--- a/rds/input.tf
+++ b/rds/input.tf
@@ -108,6 +108,12 @@ variable "snapshot_identifier" {
   default     = null
 }
 
+variable "use_proxy" {
+  type        = bool
+  description = "(Optional, default 'true') This flag determines if an RDS proxy should be created for the cluster."
+  default     = true
+}
+
 ###
 # Common tags
 ###

--- a/rds/locals.tf
+++ b/rds/locals.tf
@@ -6,12 +6,16 @@ locals {
     Terraform             = "true"
   }
 
-  identifier         = "${var.name}-cluster"
-  is_mysql           = var.engine == "aurora-mysql"
-  database_port      = local.is_mysql ? 3306 : 5432
-  engine_family      = local.is_mysql ? "MYSQL" : "POSTGRESQL"
-  region             = data.aws_region.current.name
-  security_group_ids = distinct(concat([aws_security_group.rds_proxy.id], var.security_group_ids))
+  identifier    = "${var.name}-cluster"
+  is_mysql      = var.engine == "aurora-mysql"
+  database_port = local.is_mysql ? 3306 : 5432
+  engine_family = local.is_mysql ? "MYSQL" : "POSTGRESQL"
+  proxy_name    = "${var.name}-proxy"
+  region        = data.aws_region.current.name
+
+  security_group_desc_target = var.use_proxy ? "proxy" : "application"
+  security_group_ids         = distinct(concat([aws_security_group.rds.id], var.security_group_ids))
+  security_group_name        = var.use_proxy ? "${var.name}_rds_proxy_sg" : "${var.name}_rds_sg"
 
   # Configure the database logs that are exported to CloudWatch.  Default to none for MySQL and `postgresql` for Postgres if no values are specified
   enabled_cloudwatch_logs_exports = length(var.enabled_cloudwatch_logs_exports) > 0 ? var.enabled_cloudwatch_logs_exports : (local.is_mysql ? [] : ["postgresql"])

--- a/rds/moved.tf
+++ b/rds/moved.tf
@@ -1,0 +1,75 @@
+#
+# Migrations related to the module's ability to create an 
+# RDS cluster without an RDS proxy.  This will move the previously
+# unindexed resources in the TF state for projects using older
+# versions of the module.
+#
+moved {
+  from = aws_db_proxy.proxy
+  to   = aws_db_proxy.proxy[0]
+}
+
+moved {
+  from = aws_db_proxy_target.target
+  to   = aws_db_proxy_target.target[0]
+}
+
+moved {
+  from = aws_db_proxy_default_target_group.this
+  to   = aws_db_proxy_default_target_group.this[0]
+}
+
+moved {
+  from = aws_iam_role.rds_proxy
+  to   = aws_iam_role.rds_proxy[0]
+}
+
+moved {
+  from = aws_iam_policy.read_connection_string
+  to   = aws_iam_policy.read_connection_string[0]
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.read_connection_string
+  to   = aws_iam_role_policy_attachment.read_connection_string[0]
+}
+
+moved {
+  from = aws_secretsmanager_secret.proxy_connection_string
+  to   = aws_secretsmanager_secret.proxy_connection_string[0]
+}
+
+moved {
+  from = aws_secretsmanager_secret_version.proxy_connection_string
+  to   = aws_secretsmanager_secret_version.proxy_connection_string[0]
+}
+
+moved {
+  from = aws_secretsmanager_secret.connection_string
+  to   = aws_secretsmanager_secret.connection_string[0]
+}
+
+moved {
+  from = aws_secretsmanager_secret_version.connection_string
+  to   = aws_secretsmanager_secret_version.connection_string[0]
+}
+
+moved {
+  from = aws_cloudwatch_log_group.proxy
+  to   = aws_cloudwatch_log_group.proxy[0]
+}
+
+moved {
+  from = aws_security_group.rds_proxy
+  to   = aws_security_group.rds
+}
+
+moved {
+  from = aws_security_group_rule.rds_proxy_ingress
+  to   = aws_security_group_rule.rds_ingress
+}
+
+moved {
+  from = aws_security_group_rule.rds_proxy_egress
+  to   = aws_security_group_rule.rds_egress
+}

--- a/rds/outputs.tf
+++ b/rds/outputs.tf
@@ -1,35 +1,50 @@
 output "rds_cluster_arn" {
-  description = "The ARN of the RDS cluster"
+  description = "The ARN of the RDS cluster."
   value       = aws_rds_cluster.cluster.arn
 }
 
 output "rds_cluster_id" {
-  description = "The ID of the RDS cluster"
+  description = "The ID of the RDS cluster."
   value       = aws_rds_cluster.cluster.id
 }
 
 output "rds_cluster_endpoint" {
-  value = aws_rds_cluster.cluster.endpoint
+  description = "RDS cluster read/write connection endpoint."
+  value       = aws_rds_cluster.cluster.endpoint
 }
 
 output "proxy_connection_string_arn" {
-  description = "The ARN for the connection string to the RDS proxy"
-  value       = aws_secretsmanager_secret.proxy_connection_string.arn
+  description = "The ARN for the connection string to the RDS proxy."
+  value       = var.use_proxy ? aws_secretsmanager_secret.proxy_connection_string[0].arn: null
 }
 
 output "proxy_connection_string_value" {
-  value     = aws_secretsmanager_secret_version.proxy_connection_string.secret_string
-  sensitive = true
+  description = "The string value of the RDS proxy connection string.  This includes the username and password."
+  value       = var.use_proxy ? aws_secretsmanager_secret_version.proxy_connection_string[0].secret_string: null
+  sensitive   = true
 }
 
 output "proxy_endpoint" {
-  value = aws_db_proxy.proxy.endpoint
+  description = "The RDS proxy read/write connection endpoint."
+  value       = var.use_proxy ? aws_db_proxy.proxy[0].endpoint: null
 }
 
 output "proxy_security_group_id" {
-  value = aws_security_group.rds_proxy.id
+  description = "The RDS proxy security group ID."
+  value       = var.use_proxy ? aws_security_group.rds.id: null
 }
 
 output "proxy_security_group_arn" {
-  value = aws_security_group.rds_proxy.arn
+  description = "The RDS proxy security group ARN."
+  value       = var.use_proxy ? aws_security_group.rds.arn: null
+}
+
+output "cluster_security_group_id" {
+  description = "The RDS cluster security group ID."
+  value       = aws_security_group.rds.id
+}
+
+output "cluster_security_group_arn" {
+  description = "The RDS cluster security group ID."
+  value       = aws_security_group.rds.arn
 }

--- a/rds/outputs.tf
+++ b/rds/outputs.tf
@@ -15,28 +15,28 @@ output "rds_cluster_endpoint" {
 
 output "proxy_connection_string_arn" {
   description = "The ARN for the connection string to the RDS proxy."
-  value       = var.use_proxy ? aws_secretsmanager_secret.proxy_connection_string[0].arn: null
+  value       = var.use_proxy ? aws_secretsmanager_secret.proxy_connection_string[0].arn : null
 }
 
 output "proxy_connection_string_value" {
   description = "The string value of the RDS proxy connection string.  This includes the username and password."
-  value       = var.use_proxy ? aws_secretsmanager_secret_version.proxy_connection_string[0].secret_string: null
+  value       = var.use_proxy ? aws_secretsmanager_secret_version.proxy_connection_string[0].secret_string : null
   sensitive   = true
 }
 
 output "proxy_endpoint" {
   description = "The RDS proxy read/write connection endpoint."
-  value       = var.use_proxy ? aws_db_proxy.proxy[0].endpoint: null
+  value       = var.use_proxy ? aws_db_proxy.proxy[0].endpoint : null
 }
 
 output "proxy_security_group_id" {
   description = "The RDS proxy security group ID."
-  value       = var.use_proxy ? aws_security_group.rds.id: null
+  value       = var.use_proxy ? aws_security_group.rds.id : null
 }
 
 output "proxy_security_group_arn" {
   description = "The RDS proxy security group ARN."
-  value       = var.use_proxy ? aws_security_group.rds.arn: null
+  value       = var.use_proxy ? aws_security_group.rds.arn : null
 }
 
 output "cluster_security_group_id" {

--- a/rds/proxy_role.tf
+++ b/rds/proxy_role.tf
@@ -1,10 +1,14 @@
 resource "aws_iam_role" "rds_proxy" {
+  count = var.use_proxy ? 1 : 0
+
   name               = "${var.name}_rds_proxy"
   tags               = local.common_tags
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  assume_role_policy = data.aws_iam_policy_document.assume_role[0].json
 }
 
 data "aws_iam_policy_document" "assume_role" {
+  count = var.use_proxy ? 1 : 0
+
   statement {
     sid     = "RDSAssume"
     effect  = "Allow"
@@ -18,6 +22,8 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 data "aws_iam_policy_document" "read_connection_string" {
+  count = var.use_proxy ? 1 : 0
+
   statement {
     sid    = 0
     effect = "Allow"
@@ -28,7 +34,7 @@ data "aws_iam_policy_document" "read_connection_string" {
       "secretsmanager:DescribeSecret",
       "secretsmanager:ListSecretVersionIds"
     ]
-    resources = concat([aws_secretsmanager_secret.connection_string.arn], var.proxy_secret_auth_arns)
+    resources = concat([aws_secretsmanager_secret.connection_string[0].arn], var.proxy_secret_auth_arns)
   }
   statement {
     sid       = 1
@@ -52,13 +58,17 @@ data "aws_iam_policy_document" "read_connection_string" {
 }
 
 resource "aws_iam_policy" "read_connection_string" {
+  count = var.use_proxy ? 1 : 0
+
   name   = "${var.name}ReadConnectionString"
   path   = "/"
-  policy = data.aws_iam_policy_document.read_connection_string.json
+  policy = data.aws_iam_policy_document.read_connection_string[0].json
   tags   = local.common_tags
 }
 
 resource "aws_iam_role_policy_attachment" "read_connection_string" {
-  role       = aws_iam_role.rds_proxy.name
-  policy_arn = aws_iam_policy.read_connection_string.arn
+  count = var.use_proxy ? 1 : 0
+
+  role       = aws_iam_role.rds_proxy[0].name
+  policy_arn = aws_iam_policy.read_connection_string[0].arn
 }

--- a/rds/secret.tf
+++ b/rds/secret.tf
@@ -1,4 +1,6 @@
 resource "aws_secretsmanager_secret" "connection_string" {
+  count = var.use_proxy ? 1 : 0
+
   name = "${var.name}-${random_string.random.result}"
   tags = local.common_tags
 }
@@ -7,7 +9,9 @@ resource "aws_secretsmanager_secret" "connection_string" {
 
 // Secret format grabbed from here: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/rds-proxy.html#rds-proxy-secrets-arns
 resource "aws_secretsmanager_secret_version" "connection_string" {
-  secret_id = aws_secretsmanager_secret.connection_string.id
+  count = var.use_proxy ? 1 : 0
+
+  secret_id = aws_secretsmanager_secret.connection_string[0].id
   secret_string = jsonencode({
     username = "${var.username}",
     password = "${var.password}"
@@ -15,15 +19,19 @@ resource "aws_secretsmanager_secret_version" "connection_string" {
 }
 
 resource "aws_secretsmanager_secret" "proxy_connection_string" {
+  count = var.use_proxy ? 1 : 0
+
   name = "${var.name}-${random_string.random.result}-proxy-connection-string"
   tags = local.common_tags
 }
 
 resource "aws_secretsmanager_secret_version" "proxy_connection_string" {
-  secret_id = aws_secretsmanager_secret.proxy_connection_string.id
+  count = var.use_proxy ? 1 : 0
+
+  secret_id = aws_secretsmanager_secret.proxy_connection_string[0].id
   secret_string = (
     local.is_mysql ?
-    "Server=${aws_db_proxy.proxy.endpoint};Port=3306;Database=${var.database_name};Uid=${var.username};Pwd=${var.password};" :
-    "postgresql://${var.username}:${var.password}@${aws_db_proxy.proxy.endpoint}/${var.database_name}"
+    "Server=${aws_db_proxy.proxy[0].endpoint};Port=3306;Database=${var.database_name};Uid=${var.username};Pwd=${var.password};" :
+    "postgresql://${var.username}:${var.password}@${aws_db_proxy.proxy[0].endpoint}/${var.database_name}"
   )
 }

--- a/rds/security_group.tf
+++ b/rds/security_group.tf
@@ -1,14 +1,14 @@
 ###
 # Security group for the proxy and rds database to talk to each other
 ###
-resource "aws_security_group" "rds_proxy" {
-  name   = "${var.name}_rds_proxy_sg"
+resource "aws_security_group" "rds" {
+  name   = local.security_group_name
   vpc_id = var.vpc_id
 
-  description = "The Security group that allows communication between the proxy and the database"
+  description = "The Security group that allows communication between the ${local.security_group_desc_target} and the database"
 
   tags = merge(local.common_tags, {
-    Name = "${var.name}_rds_proxy_sg"
+    Name = local.security_group_name
   })
 
   lifecycle {
@@ -16,22 +16,22 @@ resource "aws_security_group" "rds_proxy" {
   }
 }
 
-resource "aws_security_group_rule" "rds_proxy_ingress" {
-  description       = "Proxy ingress to the database"
+resource "aws_security_group_rule" "rds_ingress" {
+  description       = "Ingress to the database"
   type              = "ingress"
   from_port         = local.database_port
   to_port           = local.database_port
   protocol          = "tcp"
   self              = true
-  security_group_id = aws_security_group.rds_proxy.id
+  security_group_id = aws_security_group.rds.id
 }
 
-resource "aws_security_group_rule" "rds_proxy_egress" {
-  description       = "Proxy egress from the database"
+resource "aws_security_group_rule" "rds_egress" {
+  description       = "Egress from the database"
   type              = "egress"
   from_port         = local.database_port
   to_port           = local.database_port
   protocol          = "tcp"
   self              = true
-  security_group_id = aws_security_group.rds_proxy.id
+  security_group_id = aws_security_group.rds.id
 }

--- a/rds/tests/unit.main.mysql.tftest.hcl
+++ b/rds/tests/unit.main.mysql.tftest.hcl
@@ -130,22 +130,22 @@ run "mysql_cluster" {
   }
 
   assert {
-    condition     = aws_db_proxy.proxy.engine_family == "MYSQL"
+    condition     = aws_db_proxy.proxy[0].engine_family == "MYSQL"
     error_message = "DB proxy engine family did not match expected value"
   }
 
   assert {
-    condition     = aws_db_proxy.proxy.vpc_subnet_ids == toset(["subnet1234", "subnet5678"])
+    condition     = aws_db_proxy.proxy[0].vpc_subnet_ids == toset(["subnet1234", "subnet5678"])
     error_message = "DB proxy subnet IDs did not match expected value"
   }
 
   assert {
-    condition     = aws_db_proxy_default_target_group.this.db_proxy_name == "mysql-proxy"
+    condition     = aws_db_proxy_default_target_group.this[0].db_proxy_name == "mysql-proxy"
     error_message = "DB proxy default target group proxy name did not match expected value"
   }
 
   assert {
-    condition     = aws_db_proxy_target.target.db_proxy_name == "mysql-proxy"
+    condition     = aws_db_proxy_target.target[0].db_proxy_name == "mysql-proxy"
     error_message = "DB proxy target proxy name did not match expected value"
   }
 
@@ -175,7 +175,7 @@ run "mysql_cluster" {
   }
 
   assert {
-    condition     = length(aws_db_proxy.proxy.auth) == 1
+    condition     = length(aws_db_proxy.proxy[0].auth) == 1
     error_message = "RDS proxy auth length did not match expected value"
   }
 }

--- a/rds/tests/unit.main.no.proxy.tftest.hcl
+++ b/rds/tests/unit.main.no.proxy.tftest.hcl
@@ -1,0 +1,82 @@
+provider "aws" {
+  region = "ca-central-1"
+}
+
+variables {
+  name = "postgres"
+
+  database_name  = "postgres"
+  engine         = "aurora-postgresql"
+  engine_version = "15.2"
+  instances      = 1
+  instance_class = "db.t3.medium"
+  username       = "thebigcheese2"
+  password       = "pasword1234"
+
+  backup_retention_period = 7
+  preferred_backup_window = "01:00-03:00"
+
+  vpc_id     = "vpc1234"
+  subnet_ids = ["subnet1234"]
+  use_proxy  = false
+}
+
+run "postgres_cluster" {
+  command = plan
+
+  assert {
+    condition     = length(aws_db_proxy.proxy) == 0
+    error_message = "Proxy resource should not exist"
+  }
+
+  assert {
+    condition     = length(aws_iam_role.rds_proxy) == 0
+    error_message = "Proxy resource should not exist"
+  }
+
+  assert {
+    condition     = length(aws_iam_policy.read_connection_string) == 0
+    error_message = "Proxy resource should not exist"
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy_attachment.read_connection_string) == 0
+    error_message = "Proxy resource should not exist"
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_log_group.proxy) == 0
+    error_message = "Proxy resource should not exist"
+  }
+
+  assert {
+    condition     = length(aws_db_proxy_default_target_group.this) == 0
+    error_message = "aws_db_proxy_default_target_group.this resource should not exist"
+  }
+
+  assert {
+    condition     = length(aws_db_proxy_target.target) == 0
+    error_message = "aws_db_proxy_target.target resource should not exist"
+  }
+
+  assert {
+    condition     = length(aws_secretsmanager_secret.connection_string) == 0
+    error_message = "aws_secretsmanager_secret.connection_string resource should not exist"
+  }
+
+  assert {
+    condition     = length(aws_secretsmanager_secret_version.connection_string) == 0
+    error_message = "aws_secretsmanager_secret_version.connection_string resource should not exist"
+  }
+
+  assert {
+    condition     = length(aws_secretsmanager_secret.proxy_connection_string) == 0
+    error_message = "aws_secretsmanager_secret.proxy_connection_string resource should not exist"
+  }
+
+  assert {
+    condition     = length(aws_secretsmanager_secret_version.proxy_connection_string) == 0
+    error_message = "aws_secretsmanager_secret_version.proxy_connection_string resource should not exist"
+  }
+
+}

--- a/rds/tests/unit.main.postgres.tftest.hcl
+++ b/rds/tests/unit.main.postgres.tftest.hcl
@@ -142,12 +142,12 @@ run "postgres_cluster" {
   }
 
   assert {
-    condition     = aws_db_proxy.proxy.engine_family == "POSTGRESQL"
+    condition     = aws_db_proxy.proxy[0].engine_family == "POSTGRESQL"
     error_message = "DB proxy engine family did not match expected value"
   }
 
   assert {
-    condition     = aws_db_proxy.proxy.vpc_subnet_ids == toset(["subnet1234"])
+    condition     = aws_db_proxy.proxy[0].vpc_subnet_ids == toset(["subnet1234"])
     error_message = "DB proxy subnet IDs did not match expected value"
   }
 
@@ -202,7 +202,7 @@ run "postgres_cluster" {
   }
 
   assert {
-    condition     = length(aws_db_proxy.proxy.auth) == 1
+    condition     = length(aws_db_proxy.proxy[0].auth) == 1
     error_message = "RDS proxy auth length did not match expected value"
   }
 }


### PR DESCRIPTION
# Summary
Update the RDS module so that it can be used to create RDS clusters without an associated proxy.  The change includes a migration file so that existing users of the module will be able to upgrade without any breaking changes.

This is being done for projects that handle the connection pooling internally and do not want to pay extra for the proxy.  However, by default the module's behaviour will be to create the RDS proxy.