### PR TITLE
fix: set ECS task revision when using latest task def

### DIFF
--- a/ecs/main.tf
+++ b/ecs/main.tf
@@ -45,7 +45,7 @@ data "aws_ecs_cluster" "this" {
 resource "aws_ecs_service" "this" {
   name             = var.service_name
   cluster          = var.create_cluster ? aws_ecs_cluster.this[0].name : var.cluster_name
-  task_definition  = var.service_use_latest_task_def ? aws_ecs_task_definition.this.family : aws_ecs_task_definition.this.arn
+  task_definition  = var.service_use_latest_task_def ? "${aws_ecs_task_definition.this.family}:${max(aws_ecs_task_definition.this.revision, data.aws_ecs_task_definition.latest[0].revision)}" : aws_ecs_task_definition.this.arn
   platform_version = var.platform_version
   launch_type      = "FARGATE"
   propagate_tags   = "SERVICE"
@@ -106,6 +106,11 @@ resource "aws_ecs_service" "this" {
 ################################################################################
 # Task Definition  
 ################################################################################
+
+data "aws_ecs_task_definition" "latest" {
+  count           = var.service_use_latest_task_def ? 0 : 1
+  task_definition = aws_ecs_task_definition.this.family
+}
 
 resource "aws_ecs_task_definition" "this" {
   family                = local.task_definition_family

--- a/ecs/main.tf
+++ b/ecs/main.tf
@@ -45,7 +45,7 @@ data "aws_ecs_cluster" "this" {
 resource "aws_ecs_service" "this" {
   name             = var.service_name
   cluster          = var.create_cluster ? aws_ecs_cluster.this[0].name : var.cluster_name
-  task_definition  = var.service_use_latest_task_def ? "${aws_ecs_task_definition.this.family}:${max(aws_ecs_task_definition.this.revision, data.aws_ecs_task_definition.latest[0].revision)}" : aws_ecs_task_definition.this.arn
+  task_definition  = var.service_use_latest_task_def ? "${aws_ecs_task_definition.this.family}:${max(aws_ecs_task_definition.this.revision, data.aws_ecs_task_definition.this_latest.revision)}" : aws_ecs_task_definition.this.arn
   platform_version = var.platform_version
   launch_type      = "FARGATE"
   propagate_tags   = "SERVICE"
@@ -107,8 +107,7 @@ resource "aws_ecs_service" "this" {
 # Task Definition  
 ################################################################################
 
-data "aws_ecs_task_definition" "latest" {
-  count           = var.service_use_latest_task_def ? 0 : 1
+data "aws_ecs_task_definition" "this_latest" {
   task_definition = aws_ecs_task_definition.this.family
 }
 


### PR DESCRIPTION
# Summary
Update the ECS module so that if the latest task definition is being used, the latest task def revision is automatically added.

This will prevent TF plan flip-flops removing this revision if it has been set by another process.