### PR TITLE
feat: block based on load balancer response

### DIFF
--- a/waf_ip_blocklist/README.md
+++ b/waf_ip_blocklist/README.md
@@ -50,12 +50,15 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_athena_database_name"></a> [athena\_database\_name](#input\_athena\_database\_name) | (Optional, default 'access\_logs') The name of the Athena database where the WAF logs table exists. | `string` | `"access_logs"` | no |
+| <a name="input_athena_lb_table_name"></a> [athena\_lb\_table\_name](#input\_athena\_lb\_table\_name) | (Optional, default 'lb\_logs') The name of the Load Balancer logs table in the Athena database. | `string` | `"lb_logs"` | no |
 | <a name="input_athena_query_results_bucket"></a> [athena\_query\_results\_bucket](#input\_athena\_query\_results\_bucket) | (Required) The name of the S3 bucket where the Athena query results are stored. | `string` | n/a | yes |
 | <a name="input_athena_query_source_bucket"></a> [athena\_query\_source\_bucket](#input\_athena\_query\_source\_bucket) | (Required) The name of the S3 bucket where the source data for the Athena query lives. | `string` | n/a | yes |
 | <a name="input_athena_waf_table_name"></a> [athena\_waf\_table\_name](#input\_athena\_waf\_table\_name) | (Optional, default 'waf\_logs') The name of the WAF logs table in the Athena database. | `string` | `"waf_logs"` | no |
 | <a name="input_athena_workgroup_name"></a> [athena\_workgroup\_name](#input\_athena\_workgroup\_name) | (Optional, default 'primary') The name of the Athena workgroup. | `string` | `"primary"` | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
+| <a name="input_query_lb"></a> [query\_lb](#input\_query\_lb) | (Optional, default true) Should the Load Balancer logs be queried for 4xx responses? | `bool` | `true` | no |
+| <a name="input_query_waf"></a> [query\_waf](#input\_query\_waf) | (Optional, default true) Should the WAF logs be queried for BLOCK responses? | `bool` | `true` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | (Required) The name of the service | `string` | n/a | yes |
 | <a name="input_waf_block_threshold"></a> [waf\_block\_threshold](#input\_waf\_block\_threshold) | (Optional, default 20) The threshold of blocked requests for adding an IP address to the blocklist | `number` | `20` | no |
 | <a name="input_waf_ip_blocklist_update_schedule"></a> [waf\_ip\_blocklist\_update\_schedule](#input\_waf\_ip\_blocklist\_update\_schedule) | (Optional, default 'rate(2 hours)') The schedule expression for updating the WAF IP blocklist | `string` | `"rate(2 hours)"` | no |

--- a/waf_ip_blocklist/README.md
+++ b/waf_ip_blocklist/README.md
@@ -1,7 +1,7 @@
 # WAF IP blocklist
 This module creates a WAF IP blocklist that is automatically updated on a user-defined schedule.
 
-The automatic update is based on a service's WAF logs where an IP address exceeds the block threshold in a 24 hour period.
+The automatic update is based on a service's WAF and load balancer logs where an IP address exceeds the block threshold in a 24 hour period.
 
 The IP block is temporary and the IP address will be removed once it has been at least 24 hours since it has exceeded
 the block threshold.

--- a/waf_ip_blocklist/iam.tf
+++ b/waf_ip_blocklist/iam.tf
@@ -75,7 +75,7 @@ data "aws_iam_policy_document" "athena" {
     ]
     resources = [
       "arn:aws:athena:${local.region}:${local.account_id}:catalog/AwsDataCatalog/database/${var.athena_database_name}",
-      "arn:aws:athena:${local.region}:${local.account_id}:catalog/AwsDataCatalog/database/${var.athena_database_name}/table/${var.athena_waf_table_name}"
+      "arn:aws:athena:${local.region}:${local.account_id}:catalog/AwsDataCatalog/database/${var.athena_database_name}/table/*"
     ]
   }
 
@@ -90,7 +90,7 @@ data "aws_iam_policy_document" "athena" {
     resources = [
       "arn:aws:glue:${local.region}:${local.account_id}:catalog",
       "arn:aws:glue:${local.region}:${local.account_id}:database/${var.athena_database_name}",
-      "arn:aws:glue:${local.region}:${local.account_id}:table/${var.athena_database_name}/${var.athena_waf_table_name}"
+      "arn:aws:glue:${local.region}:${local.account_id}:table/${var.athena_database_name}/*"
     ]
   }
 }

--- a/waf_ip_blocklist/input.tf
+++ b/waf_ip_blocklist/input.tf
@@ -14,6 +14,12 @@ variable "athena_query_source_bucket" {
   type        = string
 }
 
+variable "athena_lb_table_name" {
+  description = "(Optional, default 'lb_logs') The name of the Load Balancer logs table in the Athena database."
+  type        = string
+  default     = "lb_logs"
+}
+
 variable "athena_waf_table_name" {
   description = "(Optional, default 'waf_logs') The name of the WAF logs table in the Athena database."
   type        = string
@@ -35,6 +41,18 @@ variable "billing_tag_key" {
 variable "billing_tag_value" {
   description = "(Required) The value of the billing tag"
   type        = string
+}
+
+variable "query_lb" {
+  description = "(Optional, default true) Should the Load Balancer logs be queried for 4xx responses?"
+  type        = bool
+  default     = true
+}
+
+variable "query_waf" {
+  description = "(Optional, default true) Should the WAF logs be queried for BLOCK responses?"
+  type        = bool
+  default     = true
 }
 
 variable "service_name" {

--- a/waf_ip_blocklist/lambda/blocklist.py
+++ b/waf_ip_blocklist/lambda/blocklist.py
@@ -48,6 +48,7 @@ def handler(_event, _context):
                 query, ATHENA_DATABASE, ATHENA_OUTPUT_BUCKET, ATHENA_WORKGROUP
             )
             ip_addresses.update(get_query_results(query_execution_id))
+            print(f"Found following {ip_addresses}")
 
     if ip_addresses:
         update_waf_ip_set(

--- a/waf_ip_blocklist/lambda/blocklist.py
+++ b/waf_ip_blocklist/lambda/blocklist.py
@@ -19,7 +19,7 @@ WAF_IP_SET_NAME = os.environ["WAF_IP_SET_NAME"]
 
 # Optional
 ATHENA_DATABASE = os.getenv("ATHENA_DATABASE", "access_logs")
-ATHENA_LB_TABLE = os.getenv("ATHENA_WAF_TABLE", "lb_logs")
+ATHENA_LB_TABLE = os.getenv("ATHENA_LB_TABLE", "lb_logs")
 ATHENA_WAF_TABLE = os.getenv("ATHENA_WAF_TABLE", "waf_logs")
 BLOCK_THRESHOLD = os.getenv("BLOCK_THRESHOLD", "20")
 QUERY_LB = os.getenv("QUERY_LB", "true") == "true"

--- a/waf_ip_blocklist/lambda/blocklist.py
+++ b/waf_ip_blocklist/lambda/blocklist.py
@@ -19,34 +19,50 @@ WAF_IP_SET_NAME = os.environ["WAF_IP_SET_NAME"]
 
 # Optional
 ATHENA_DATABASE = os.getenv("ATHENA_DATABASE", "access_logs")
-ATHENA_TABLE = os.getenv("ATHENA_TABLE", "waf_logs")
+ATHENA_LB_TABLE = os.getenv("ATHENA_WAF_TABLE", "lb_logs")
+ATHENA_WAF_TABLE = os.getenv("ATHENA_WAF_TABLE", "waf_logs")
 BLOCK_THRESHOLD = os.getenv("BLOCK_THRESHOLD", "20")
+QUERY_LB = os.getenv("QUERY_LB", "true") == "true"
+QUERY_WAF = os.getenv("QUERY_WAF", "true") == "true"
 WAF_RULE_IDS_SKIP = os.getenv("WAF_RULE_IDS_SKIP", "").split(",")
 WAF_SCOPE = os.getenv("WAF_SCOPE", "REGIONAL")
 
 
 def handler(_event, _context):
-    """Query the WAF logs and update the WAF IP set with the new IPs"""
-    query = get_query_from_file(
-        "./query.sql", ATHENA_TABLE, WAF_RULE_IDS_SKIP, BLOCK_THRESHOLD
+    """Query the WAF and LB logs and update the WAF IP set with the new IPs"""
+    query_lb = get_query_from_file(
+        "./query_lb.sql", ATHENA_LB_TABLE, [], BLOCK_THRESHOLD
     )
-    query_execution_id = start_athena_query(
-        query, ATHENA_DATABASE, ATHENA_OUTPUT_BUCKET, ATHENA_WORKGROUP
+    query_waf = get_query_from_file(
+        "./query_waf.sql", ATHENA_WAF_TABLE, WAF_RULE_IDS_SKIP, BLOCK_THRESHOLD
     )
-    ip_addresses = get_query_results(query_execution_id)
+
+    ip_addresses = set()
+    queries_to_execute = [
+        (QUERY_LB, query_lb),
+        (QUERY_WAF, query_waf),
+    ]
+    for do_query, query in queries_to_execute:
+        if do_query:
+            query_execution_id = start_athena_query(
+                query, ATHENA_DATABASE, ATHENA_OUTPUT_BUCKET, ATHENA_WORKGROUP
+            )
+            ip_addresses.update(get_query_results(query_execution_id))
 
     if ip_addresses:
-        update_waf_ip_set(ip_addresses, WAF_IP_SET_NAME, WAF_IP_SET_ID, WAF_SCOPE)
+        update_waf_ip_set(
+            sorted(ip_addresses), WAF_IP_SET_NAME, WAF_IP_SET_ID, WAF_SCOPE
+        )
 
 
-def get_query_from_file(file_path, waf_logs_table, waf_rule_ids_skip, block_threshold):
+def get_query_from_file(file_path, log_table, skip_list, block_threshold):
     """Read the query from a file"""
     with open(file_path, "r", encoding="utf-8") as file:
         query_template = file.read()
-        joined_rule_ids = ",".join([f"'{rule_id}'" for rule_id in waf_rule_ids_skip])
+        joined_skip_list = ",".join([f"'{item}'" for item in skip_list])
         query = query_template.format(
-            waf_logs_table=waf_logs_table,
-            waf_rule_ids_skip=joined_rule_ids,
+            log_table=log_table,
+            skip_list=joined_skip_list,
             block_threshold=block_threshold,
         )
         print(query)

--- a/waf_ip_blocklist/lambda/blocklist_test.py
+++ b/waf_ip_blocklist/lambda/blocklist_test.py
@@ -1,7 +1,7 @@
 import tempfile
 import os
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import call, patch
 
 os.environ["AWS_DEFAULT_REGION"] = "ca-central-1"
 os.environ["ATHENA_OUTPUT_BUCKET"] = "test_bucket"
@@ -16,44 +16,72 @@ import blocklist
 @patch("blocklist.waf_client")
 def test_handler_with_ips_to_block(mock_waf_client, mock_athena_client):
     # Setup
-    mock_athena_client.start_query_execution.return_value = {
-        "QueryExecutionId": "test_query_id"
-    }
+    mock_athena_client.start_query_execution.side_effect = [
+        {"QueryExecutionId": "test_query_lb_id"},
+        {"QueryExecutionId": "test_query_waf_id"},
+    ]
     mock_athena_client.get_query_execution.return_value = {
         "QueryExecution": {"Status": {"State": "SUCCEEDED"}}
     }
-    mock_athena_client.get_query_results.return_value = {
-        "ResultSet": {
-            "Rows": [
-                {"Data": [{"VarCharValue": "header"}]},
-                {"Data": [{"VarCharValue": "192.168.1.1"}]},
-                {"Data": [{"VarCharValue": "192.168.1.2"}]},
-            ]
-        }
-    }
+    mock_athena_client.get_query_results.side_effect = [
+        {
+            "ResultSet": {
+                "Rows": [
+                    {"Data": [{"VarCharValue": "header"}]},
+                    {"Data": [{"VarCharValue": "192.168.1.1"}]},
+                    {"Data": [{"VarCharValue": "192.168.1.2"}]},
+                ]
+            }
+        },
+        {
+            "ResultSet": {
+                "Rows": [
+                    {"Data": [{"VarCharValue": "header"}]},
+                    {"Data": [{"VarCharValue": "192.168.1.1"}]},
+                    {"Data": [{"VarCharValue": "192.168.1.3"}]},
+                ]
+            }
+        },
+    ]
     mock_waf_client.get_ip_set.return_value = {"LockToken": "test_lock_token"}
 
     # Execute
     blocklist.handler(None, None)
 
     # Verify
-    mock_athena_client.start_query_execution.assert_called_once_with(
-        QueryString="-- List of IP addresses that have been blocked by WAF\nSELECT \n    httpRequest.clientIp,\n    COUNT(*) as count\nFROM \n    waf_logs\nWHERE \n    action = 'BLOCK'\n    AND terminatingruleid NOT IN ('') \n    AND from_unixtime(timestamp/1000) >= date_add('day', -1, current_timestamp)\nGROUP BY \n    httpRequest.clientIp\nHAVING COUNT(*) > 20\nORDER BY count DESC",
-        QueryExecutionContext={"Database": "access_logs"},
-        ResultConfiguration={"OutputLocation": "s3://test_bucket/"},
-        WorkGroup="test_workgroup",
+    mock_athena_client.start_query_execution.assert_has_calls(
+        [
+            call(
+                QueryString="-- List of IP addresses that have triggered 4xx HTTP responses\nSELECT\n    client_ip,\n    COUNT(*) as count\nFROM\n    lb_logs\nWHERE\n    (\n        elb_status_code = 403\n        OR target_status_code LIKE '4__'\n    )\n    AND from_iso8601_timestamp(time) >= date_add('day', -1, current_timestamp)\nGROUP BY\n    client_ip\nHAVING COUNT(*) > 20\nORDER BY count DESC",
+                QueryExecutionContext={"Database": "access_logs"},
+                ResultConfiguration={"OutputLocation": "s3://test_bucket/"},
+                WorkGroup="test_workgroup",
+            ),
+            call(
+                QueryString="-- List of IP addresses that have been blocked by WAF\nSELECT \n    httpRequest.clientIp,\n    COUNT(*) as count\nFROM \n    waf_logs\nWHERE \n    action = 'BLOCK'\n    AND terminatingruleid NOT IN ('') \n    AND from_unixtime(timestamp/1000) >= date_add('day', -1, current_timestamp)\nGROUP BY \n    httpRequest.clientIp\nHAVING COUNT(*) > 20\nORDER BY count DESC",
+                QueryExecutionContext={"Database": "access_logs"},
+                ResultConfiguration={"OutputLocation": "s3://test_bucket/"},
+                WorkGroup="test_workgroup",
+            ),
+        ]
     )
-    mock_athena_client.get_query_execution.assert_called_once_with(
-        QueryExecutionId="test_query_id"
+    mock_athena_client.get_query_execution.assert_has_calls(
+        [
+            call(QueryExecutionId="test_query_lb_id"),
+            call(QueryExecutionId="test_query_waf_id"),
+        ]
     )
-    mock_athena_client.get_query_results.assert_called_once_with(
-        QueryExecutionId="test_query_id"
+    mock_athena_client.get_query_results.assert_has_calls(
+        [
+            call(QueryExecutionId="test_query_lb_id"),
+            call(QueryExecutionId="test_query_waf_id"),
+        ]
     )
     mock_waf_client.update_ip_set.assert_called_once_with(
         Name="test_ip_set_name",
         Scope="REGIONAL",
         Id="test_ip_set_id",
-        Addresses=["192.168.1.1/32", "192.168.1.2/32"],
+        Addresses=["192.168.1.1/32", "192.168.1.2/32", "192.168.1.3/32"],
         LockToken="test_lock_token",
     )
 
@@ -62,9 +90,10 @@ def test_handler_with_ips_to_block(mock_waf_client, mock_athena_client):
 @patch("blocklist.waf_client")
 def test_handler_with_no_ips_to_block(mock_waf_client, mock_athena_client):
     # Setup
-    mock_athena_client.start_query_execution.return_value = {
-        "QueryExecutionId": "test_query_id"
-    }
+    mock_athena_client.start_query_execution.side_effect = [
+        {"QueryExecutionId": "test_query_lb_id"},
+        {"QueryExecutionId": "test_query_waf_id"},
+    ]
     mock_athena_client.get_query_execution.return_value = {
         "QueryExecution": {"Status": {"State": "SUCCEEDED"}}
     }
@@ -76,16 +105,68 @@ def test_handler_with_no_ips_to_block(mock_waf_client, mock_athena_client):
     blocklist.handler(None, None)
 
     # Verify
-    mock_athena_client.start_query_execution.assert_called_once_with(
-        QueryString="-- List of IP addresses that have been blocked by WAF\nSELECT \n    httpRequest.clientIp,\n    COUNT(*) as count\nFROM \n    waf_logs\nWHERE \n    action = 'BLOCK'\n    AND terminatingruleid NOT IN ('') \n    AND from_unixtime(timestamp/1000) >= date_add('day', -1, current_timestamp)\nGROUP BY \n    httpRequest.clientIp\nHAVING COUNT(*) > 20\nORDER BY count DESC",
-        QueryExecutionContext={"Database": "access_logs"},
-        ResultConfiguration={"OutputLocation": "s3://test_bucket/"},
-        WorkGroup="test_workgroup",
+    mock_athena_client.start_query_execution.assert_has_calls(
+        [
+            call(
+                QueryString="-- List of IP addresses that have triggered 4xx HTTP responses\nSELECT\n    client_ip,\n    COUNT(*) as count\nFROM\n    lb_logs\nWHERE\n    (\n        elb_status_code = 403\n        OR target_status_code LIKE '4__'\n    )\n    AND from_iso8601_timestamp(time) >= date_add('day', -1, current_timestamp)\nGROUP BY\n    client_ip\nHAVING COUNT(*) > 20\nORDER BY count DESC",
+                QueryExecutionContext={"Database": "access_logs"},
+                ResultConfiguration={"OutputLocation": "s3://test_bucket/"},
+                WorkGroup="test_workgroup",
+            ),
+            call(
+                QueryString="-- List of IP addresses that have been blocked by WAF\nSELECT \n    httpRequest.clientIp,\n    COUNT(*) as count\nFROM \n    waf_logs\nWHERE \n    action = 'BLOCK'\n    AND terminatingruleid NOT IN ('') \n    AND from_unixtime(timestamp/1000) >= date_add('day', -1, current_timestamp)\nGROUP BY \n    httpRequest.clientIp\nHAVING COUNT(*) > 20\nORDER BY count DESC",
+                QueryExecutionContext={"Database": "access_logs"},
+                ResultConfiguration={"OutputLocation": "s3://test_bucket/"},
+                WorkGroup="test_workgroup",
+            ),
+        ]
     )
-    mock_athena_client.get_query_execution.assert_called_once_with(
-        QueryExecutionId="test_query_id"
+    mock_athena_client.get_query_execution.assert_has_calls(
+        [
+            call(QueryExecutionId="test_query_lb_id"),
+            call(QueryExecutionId="test_query_waf_id"),
+        ]
     )
-    mock_athena_client.get_query_results.assert_called_once()
+    assert mock_athena_client.get_query_results.call_count == 2
+    mock_waf_client.update_ip_set.assert_not_called()
+
+
+@patch("blocklist.athena_client")
+@patch("blocklist.waf_client")
+@patch("blocklist.QUERY_WAF", False)
+def test_handler_with_only_lb_query(mock_waf_client, mock_athena_client):
+    # Setup
+    mock_athena_client.start_query_execution.side_effect = [
+        {"QueryExecutionId": "test_query_lb_id"},
+        {"QueryExecutionId": "test_query_waf_id"},
+    ]
+    mock_athena_client.get_query_execution.return_value = {
+        "QueryExecution": {"Status": {"State": "SUCCEEDED"}}
+    }
+    mock_athena_client.get_query_results.return_value = {
+        "ResultSet": {"Rows": [{"Data": [{"VarCharValue": "header"}]}]}
+    }
+
+    # Execute
+    blocklist.handler(None, None)
+
+    # Verify
+    mock_athena_client.start_query_execution.assert_has_calls(
+        [
+            call(
+                QueryString="-- List of IP addresses that have triggered 4xx HTTP responses\nSELECT\n    client_ip,\n    COUNT(*) as count\nFROM\n    lb_logs\nWHERE\n    (\n        elb_status_code = 403\n        OR target_status_code LIKE '4__'\n    )\n    AND from_iso8601_timestamp(time) >= date_add('day', -1, current_timestamp)\nGROUP BY\n    client_ip\nHAVING COUNT(*) > 20\nORDER BY count DESC",
+                QueryExecutionContext={"Database": "access_logs"},
+                ResultConfiguration={"OutputLocation": "s3://test_bucket/"},
+                WorkGroup="test_workgroup",
+            )
+        ]
+    )
+    mock_athena_client.get_query_execution.assert_has_calls(
+        [
+            call(QueryExecutionId="test_query_lb_id"),
+        ]
+    )
+    assert mock_athena_client.get_query_results.call_count == 1
     mock_waf_client.update_ip_set.assert_not_called()
 
 
@@ -116,20 +197,20 @@ def test_handler_athena_query_failure(mock_waf_client, mock_athena_client):
 
 def test_get_query_from_file_with_multiple_rule_ids():
     # Setup
-    query_template = "SELECT * FROM {waf_logs_table} WHERE rule_id NOT IN ({waf_rule_ids_skip}) AND count > {block_threshold};"
+    query_template = "SELECT * FROM {log_table} WHERE rule_id NOT IN ({skip_list}) AND count > {block_threshold};"
     with tempfile.NamedTemporaryFile(
         delete=False, mode="w", encoding="utf-8"
     ) as temp_file:
         temp_file.write(query_template)
         temp_file_path = temp_file.name
 
-    waf_logs_table = "test_table"
-    waf_rule_ids_skip = ["rule1", "rule2"]
+    log_table = "test_table"
+    skip_list = ["rule1", "rule2"]
     block_threshold = "10"
 
     # Execute
     query = blocklist.get_query_from_file(
-        temp_file_path, waf_logs_table, waf_rule_ids_skip, block_threshold
+        temp_file_path, log_table, skip_list, block_threshold
     )
 
     # Verify
@@ -142,20 +223,20 @@ def test_get_query_from_file_with_multiple_rule_ids():
 
 def test_get_query_from_file_with_empty_rule_ids():
     # Setup
-    query_template = "SELECT * FROM {waf_logs_table} WHERE rule_id NOT IN ({waf_rule_ids_skip}) AND count > {block_threshold};"
+    query_template = "SELECT * FROM {log_table} WHERE rule_id NOT IN ({skip_list}) AND count > {block_threshold};"
     with tempfile.NamedTemporaryFile(
         delete=False, mode="w", encoding="utf-8"
     ) as temp_file:
         temp_file.write(query_template)
         temp_file_path = temp_file.name
 
-    waf_logs_table = "test_table"
-    waf_rule_ids_skip = []
+    log_table = "test_table"
+    skip_list = []
     block_threshold = "10"
 
     # Execute
     query = blocklist.get_query_from_file(
-        temp_file_path, waf_logs_table, waf_rule_ids_skip, block_threshold
+        temp_file_path, log_table, skip_list, block_threshold
     )
 
     # Verify
@@ -168,20 +249,20 @@ def test_get_query_from_file_with_empty_rule_ids():
 
 def test_get_query_from_file_with_single_rule_id():
     # Setup
-    query_template = "SELECT * FROM {waf_logs_table} WHERE rule_id NOT IN ({waf_rule_ids_skip}) AND count > {block_threshold};"
+    query_template = "SELECT * FROM {log_table} WHERE rule_id NOT IN ({skip_list}) AND count > {block_threshold};"
     with tempfile.NamedTemporaryFile(
         delete=False, mode="w", encoding="utf-8"
     ) as temp_file:
         temp_file.write(query_template)
         temp_file_path = temp_file.name
 
-    waf_logs_table = "test_table"
-    waf_rule_ids_skip = ["rule1"]
+    log_table = "test_table"
+    skip_list = ["rule1"]
     block_threshold = "10"
 
     # Execute
     query = blocklist.get_query_from_file(
-        temp_file_path, waf_logs_table, waf_rule_ids_skip, block_threshold
+        temp_file_path, log_table, skip_list, block_threshold
     )
 
     # Verify

--- a/waf_ip_blocklist/lambda/query_lb.sql
+++ b/waf_ip_blocklist/lambda/query_lb.sql
@@ -1,0 +1,16 @@
+-- List of IP addresses that have triggered 4xx HTTP responses
+SELECT
+    client_ip,
+    COUNT(*) as count
+FROM
+    {log_table}
+WHERE
+    (
+        elb_status_code = 403
+        OR target_status_code LIKE '4__'
+    )
+    AND from_iso8601_timestamp(time) >= date_add('day', -1, current_timestamp)
+GROUP BY
+    client_ip
+HAVING COUNT(*) > {block_threshold}
+ORDER BY count DESC

--- a/waf_ip_blocklist/lambda/query_waf.sql
+++ b/waf_ip_blocklist/lambda/query_waf.sql
@@ -3,10 +3,10 @@ SELECT
     httpRequest.clientIp,
     COUNT(*) as count
 FROM 
-    {waf_logs_table}
+    {log_table}
 WHERE 
     action = 'BLOCK'
-    AND terminatingruleid NOT IN ({waf_rule_ids_skip}) 
+    AND terminatingruleid NOT IN ({skip_list}) 
     AND from_unixtime(timestamp/1000) >= date_add('day', -1, current_timestamp)
 GROUP BY 
     httpRequest.clientIp

--- a/waf_ip_blocklist/main.tf
+++ b/waf_ip_blocklist/main.tf
@@ -46,9 +46,12 @@ resource "aws_lambda_function" "ipv4_blocklist" {
     variables = {
       ATHENA_OUTPUT_BUCKET = var.athena_query_results_bucket
       ATHENA_DATABASE      = var.athena_database_name
-      ATHENA_TABLE         = var.athena_waf_table_name
+      ATHENA_LB_TABLE      = var.athena_lb_table_name
+      ATHENA_WAF_TABLE     = var.athena_waf_table_name
       ATHENA_WORKGROUP     = var.athena_workgroup_name
       BLOCK_THRESHOLD      = var.waf_block_threshold
+      QUERY_LB             = var.query_lb
+      QUERY_WAF            = var.query_waf
       WAF_IP_SET_ID        = aws_wafv2_ip_set.ipv4_blocklist.id
       WAF_IP_SET_NAME      = aws_wafv2_ip_set.ipv4_blocklist.name
       WAF_RULE_IDS_SKIP    = join(",", var.waf_rule_ids_skip)
@@ -72,8 +75,13 @@ data "archive_file" "ipv4_blocklist" {
   }
 
   source {
-    content  = file("${path.module}/lambda/query.sql")
-    filename = "query.sql"
+    content  = file("${path.module}/lambda/query_lb.sql")
+    filename = "query_lb.sql"
+  }
+
+  source {
+    content  = file("${path.module}/lambda/query_waf.sql")
+    filename = "query_waf.sql"
   }
 
   output_path = "/tmp/blocklist.zip"

--- a/waf_ip_blocklist/main.tf
+++ b/waf_ip_blocklist/main.tf
@@ -2,7 +2,7 @@
 * # WAF IP blocklist
 * This module creates a WAF IP blocklist that is automatically updated on a user-defined schedule. 
 * 
-* The automatic update is based on a service's WAF logs where an IP address exceeds the block threshold in a 24 hour period.
+* The automatic update is based on a service's WAF and load balancer logs where an IP address exceeds the block threshold in a 24 hour period.
 *
 * The IP block is temporary and the IP address will be removed once it has been at least 24 hours since it has exceeded
 * the block threshold.


### PR DESCRIPTION
# Summary
Update the module so that it can also optionally block IP addresses based on load balancer HTTP response codes:

- `403` from the load balancer
- `4xx` from the target group

# Related
- https://github.com/cds-snc/platform-core-services/issues/619