### PR TITLE
fix: give the TF state a unique name

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 			"installTools": "false"
 		},
 		"ghcr.io/devcontainers/features/terraform:1": {
-			"version": "1.7.0",
+			"version": "1.10.5",
 			"terragrunt": "0.31.1"
 		},
 		"ghcr.io/dhoeric/features/terraform-docs:1": {

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.7.0
+  TERRAFORM_VERSION: 1.10.5
   CONFTEST_VERSION: 0.42.1
   TF_VAR_account_id: 124044056575
   TF_VAR_billing_code: SRE

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.7.0
+  TERRAFORM_VERSION: 1.10.5
   CONFTEST_VERSION: 0.42.1
   TF_VAR_account_id: 124044056575
   TF_VAR_billing_code: SRE

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -8,7 +8,7 @@ terraform {
 
   backend "s3" {
     bucket       = "tfstate-cds-snc-terraform-modules"
-    key          = "terraform-modules/terraform.tfstate"
+    key          = "terraform-modules-tfstate/terraform.tfstate"
     region       = "ca-central-1"
     encrypt      = true
     use_lockfile = true

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -7,11 +7,11 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "tfstate-cds-snc-terraform-modules"
-    key            = "tfstate/terraform.tfstate"
-    region         = "ca-central-1"
-    encrypt        = true
-    dynamodb_table = "tfstate-lock"
+    bucket       = "tfstate-cds-snc-terraform-modules"
+    key          = "terraform-modules/terraform.tfstate"
+    region       = "ca-central-1"
+    encrypt      = true
+    use_lockfile = true
   }
 }
 


### PR DESCRIPTION
# Summary
Update the TF state to have a unique name so that it can more easily be ignored by the AWS Nuke job.

Also updates Terraform and switches to use a lockfile so we can remove the DynamoDB dependency.
