### PR TITLE
Update Readme to include VPC breaking v9.0.0 change

### DIFF
--- a/vpc/README.md
+++ b/vpc/README.md
@@ -22,15 +22,17 @@ Single Zone mode deployes in the first AZ in a region that is found by the avail
 ![Diagram of the Single Zone architecture](./docs/single\_zone.png)
 
 ### Breaking change with v9.0.0
-If you upgrade to v9.0.0 or above from a lower version, the ```high_availability``` flag is deprecated and no longer available. You will need to do the following in order to upgrade to a higher version:
-1. Remove the ```high_availability``` flag 
+If you upgrade to v9.0.0 or above from a lower version, the ```high_availability
+``` flag is deprecated and no longer available. You will need to do the following in order to upgrade to a higher version:
+1. Remove the ```high_availability
+``` flag
 2. Instead add the following to your code:
-  ```
-    availability_zones = 3
-    cidrsubnet_newbits = 8
+ ```
+   availability_zones = 3
+   cidrsubnet_newbits = 8
 ```
 3. Run terraform/terragrunt plan. You should have no changes in your infrastucture.
-   
+
 ## Requirements
 
 | Name | Version |

--- a/vpc/README.md
+++ b/vpc/README.md
@@ -18,8 +18,19 @@ High Availability mode deploys in each AZ in a region. This is what you should c
 **Please Note:** This should not be used in a PBMM Production environment.
 
 Single Zone mode deployes in the first AZ in a region that is found by the availability lookup. This will work for if you want to save money in dev.
+
 ![Diagram of the Single Zone architecture](./docs/single\_zone.png)
 
+### Breaking change with v9.0.0
+If you upgrade to v9.0.0 or above from a lower version, the ```high_availability``` flag is deprecated and no longer available. You will need to do the following in order to upgrade to a higher version:
+1. Remove the ```high_availability``` flag 
+2. Instead add the following to your code:
+  ```
+    availability_zones = 3
+    cidrsubnet_newbits = 8
+```
+3. Run terraform/terragrunt plan. You should have no changes in your infrastucture.
+   
 ## Requirements
 
 | Name | Version |

--- a/vpc/README.md
+++ b/vpc/README.md
@@ -22,10 +22,8 @@ Single Zone mode deployes in the first AZ in a region that is found by the avail
 ![Diagram of the Single Zone architecture](./docs/single\_zone.png)
 
 ### Breaking change with v9.0.0
-If you upgrade to v9.0.0 or above from a lower version, the ```high_availability
-``` flag is deprecated and no longer available. You will need to do the following in order to upgrade to a higher version:
-1. Remove the ```high_availability
-``` flag
+If you upgrade to v9.0.0 or above from a lower version, the `high_availability` flag is deprecated and no longer available. You will need to do the following in order to upgrade to a higher version:
+1. Remove the `high_availability` flag
 2. Instead add the following to your code:
  ```
    availability_zones = 3

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -24,8 +24,8 @@
 * 
 * 
 * ### Breaking change with v9.0.0
-* If you upgrade to v9.0.0 or above from a lower version, the ```high_availability``` flag is deprecated and no longer available. You will need to do the following in order to upgrade to a higher version: 
-* 1. Remove the ```high_availability``` flag 
+* If you upgrade to v9.0.0 or above from a lower version, the `high_availability` flag is deprecated and no longer available. You will need to do the following in order to upgrade to a higher version: 
+* 1. Remove the `high_availability` flag 
 * 2. Instead add the following to your code:
 *  ```
 *    availability_zones = 3

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -19,8 +19,20 @@
 * **Please Note:** This should not be used in a PBMM Production environment.
 *
 * Single Zone mode deployes in the first AZ in a region that is found by the availability lookup. This will work for if you want to save money in dev.
+*
 * ![Diagram of the Single Zone architecture](./docs/single_zone.png)
 * 
+* 
+* ### Breaking change with v9.0.0
+* If you upgrade to v9.0.0 or above from a lower version, the ```high_availability``` flag is deprecated and no longer available. You will need to do the following in order to upgrade to a higher version: 
+* 1. Remove the ```high_availability``` flag 
+* 2. Instead add the following to your code:
+*  ```
+*    availability_zones = 3
+*    cidrsubnet_newbits = 8
+* ```
+* 3. Run terraform/terragrunt plan. You should have no changes in your infrastucture.
+*
 */
 
 resource "aws_vpc" "main" {


### PR DESCRIPTION
# Summary | Résumé

Updating the readme to indicated that the high_availability flag has been deprecated in the VPC module after v9.0.0 and include fixes on how to resolve the issue.
