### PR TITLE
feat: add ability to set Lambda architectures

### DIFF
--- a/lambda_schedule/README.md
+++ b/lambda_schedule/README.md
@@ -38,6 +38,7 @@ No requirements.
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_create_ecr_repository"></a> [create\_ecr\_repository](#input\_create\_ecr\_repository) | (Optional, default true) Whether to create an ECR repository for the Lambda image | `bool` | `true` | no |
+| <a name="input_lambda_architectures"></a> [lambda\_architectures](#input\_lambda\_architectures) | (Optional, default ['x86\_64']) The architectures of the Lambda function | `list(string)` | <pre>[<br/>  "x86_64"<br/>]</pre> | no |
 | <a name="input_lambda_ecr_arn"></a> [lambda\_ecr\_arn](#input\_lambda\_ecr\_arn) | (Optional, defaults to null) The ARN of the ECR repository containing the Lambda image | `string` | `null` | no |
 | <a name="input_lambda_environment_variables"></a> [lambda\_environment\_variables](#input\_lambda\_environment\_variables) | (Optional, defaults to empty map) Environment variables for the Lambda function | `map(string)` | `{}` | no |
 | <a name="input_lambda_image_tag"></a> [lambda\_image\_tag](#input\_lambda\_image\_tag) | (Optional, defaults to 'latest') The image tag to use for the Lambda function | `string` | `"latest"` | no |

--- a/lambda_schedule/ecr_lifecycle.json
+++ b/lambda_schedule/ecr_lifecycle.json
@@ -2,27 +2,11 @@
   "rules": [
     {
       "rulePriority": 10,
-      "description": "Keep last 10 git SHA tagged images",
+      "description": "Keep most recent 10 images",
       "selection": {
-        "tagStatus": "tagged",
-        "tagPrefixList": [
-          "sha-"
-        ],
+        "tagStatus": "any",
         "countType": "imageCountMoreThan",
         "countNumber": 10
-      },
-      "action": {
-        "type": "expire"
-      }
-    },
-    {
-      "rulePriority": 20,
-      "description": "Expire untagged images older than 7 days",
-      "selection": {
-        "tagStatus": "untagged",
-        "countType": "sinceImagePushed",
-        "countUnit": "days",
-        "countNumber": 7
       },
       "action": {
         "type": "expire"

--- a/lambda_schedule/input.tf
+++ b/lambda_schedule/input.tf
@@ -15,6 +15,12 @@ variable "create_ecr_repository" {
   default     = true
 }
 
+variable "lambda_architectures" {
+  description = "(Optional, default ['x86_64']) The architectures of the Lambda function"
+  type        = list(string)
+  default     = ["x86_64"]
+}
+
 variable "lambda_ecr_arn" {
   description = "(Optional, defaults to null) The ARN of the ECR repository containing the Lambda image"
   type        = string

--- a/lambda_schedule/main.tf
+++ b/lambda_schedule/main.tf
@@ -15,6 +15,7 @@ module "this_lambda" {
 
   timeout               = var.lambda_timeout
   memory                = var.lambda_memory
+  architectures         = var.lambda_architectures
   environment_variables = var.lambda_environment_variables
   vpc                   = var.lambda_vpc_config
   policies              = local.policies


### PR DESCRIPTION
# Summary
Add an input that allows the user to configure the architectures of the Lambda function.

Update the ECR policy to only keep the 10 most recently pushed images.