### PR TITLE
feat: add LB response code skip list

### DIFF
--- a/waf_ip_blocklist/README.md
+++ b/waf_ip_blocklist/README.md
@@ -58,6 +58,7 @@ No modules.
 | <a name="input_athena_workgroup_name"></a> [athena\_workgroup\_name](#input\_athena\_workgroup\_name) | (Optional, default 'primary') The name of the Athena workgroup. | `string` | `"primary"` | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
+| <a name="input_lb_status_code_skip"></a> [lb\_status\_code\_skip](#input\_lb\_status\_code\_skip) | (Optional, default []) A list of Load Balancer status codes to ignore when adding an IP address to the blocklist | `list(string)` | `[]` | no |
 | <a name="input_query_lb"></a> [query\_lb](#input\_query\_lb) | (Optional, default true) Should the Load Balancer logs be queried for 4xx responses? | `bool` | `true` | no |
 | <a name="input_query_waf"></a> [query\_waf](#input\_query\_waf) | (Optional, default true) Should the WAF logs be queried for BLOCK responses? | `bool` | `true` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | (Required) The name of the service | `string` | n/a | yes |

--- a/waf_ip_blocklist/input.tf
+++ b/waf_ip_blocklist/input.tf
@@ -43,6 +43,12 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "lb_status_code_skip" {
+  description = "(Optional, default []) A list of Load Balancer status codes to ignore when adding an IP address to the blocklist"
+  type        = list(string)
+  default     = []
+}
+
 variable "query_lb" {
   description = "(Optional, default true) Should the Load Balancer logs be queried for 4xx responses?"
   type        = bool

--- a/waf_ip_blocklist/lambda/blocklist.py
+++ b/waf_ip_blocklist/lambda/blocklist.py
@@ -22,6 +22,7 @@ ATHENA_DATABASE = os.getenv("ATHENA_DATABASE", "access_logs")
 ATHENA_LB_TABLE = os.getenv("ATHENA_LB_TABLE", "lb_logs")
 ATHENA_WAF_TABLE = os.getenv("ATHENA_WAF_TABLE", "waf_logs")
 BLOCK_THRESHOLD = os.getenv("BLOCK_THRESHOLD", "20")
+LB_STATUS_CODE_SKIP = os.getenv("LB_STATUS_CODE_SKIP", "").split(",")
 QUERY_LB = os.getenv("QUERY_LB", "true") == "true"
 QUERY_WAF = os.getenv("QUERY_WAF", "true") == "true"
 WAF_RULE_IDS_SKIP = os.getenv("WAF_RULE_IDS_SKIP", "").split(",")
@@ -31,7 +32,7 @@ WAF_SCOPE = os.getenv("WAF_SCOPE", "REGIONAL")
 def handler(_event, _context):
     """Query the WAF and LB logs and update the WAF IP set with the new IPs"""
     query_lb = get_query_from_file(
-        "./query_lb.sql", ATHENA_LB_TABLE, [], BLOCK_THRESHOLD
+        "./query_lb.sql", ATHENA_LB_TABLE, LB_STATUS_CODE_SKIP, BLOCK_THRESHOLD
     )
     query_waf = get_query_from_file(
         "./query_waf.sql", ATHENA_WAF_TABLE, WAF_RULE_IDS_SKIP, BLOCK_THRESHOLD

--- a/waf_ip_blocklist/lambda/blocklist_test.py
+++ b/waf_ip_blocklist/lambda/blocklist_test.py
@@ -55,7 +55,7 @@ def test_handler_with_ips_to_block(mock_waf_client, mock_athena_client, capsys):
     mock_athena_client.start_query_execution.assert_has_calls(
         [
             call(
-                QueryString="-- List of IP addresses that have triggered 4xx HTTP responses\nSELECT\n    client_ip,\n    COUNT(*) as count\nFROM\n    lb_logs\nWHERE\n    (\n        elb_status_code = 403\n        OR target_status_code LIKE '4__'\n    )\n    AND from_iso8601_timestamp(time) >= date_add('day', -1, current_timestamp)\nGROUP BY\n    client_ip\nHAVING COUNT(*) > 20\nORDER BY count DESC",
+                QueryString="-- List of IP addresses that have triggered 4xx HTTP responses\nSELECT\n    client_ip,\n    COUNT(*) as count\nFROM\n    lb_logs\nWHERE\n    (\n        elb_status_code = 403\n        OR target_status_code LIKE '4__'\n    )\n    AND target_status_code NOT IN ('')\n    AND from_iso8601_timestamp(time) >= date_add('day', -1, current_timestamp)\nGROUP BY\n    client_ip\nHAVING COUNT(*) > 20\nORDER BY count DESC",
                 QueryExecutionContext={"Database": "access_logs"},
                 ResultConfiguration={"OutputLocation": "s3://test_bucket/"},
                 WorkGroup="test_workgroup",
@@ -116,7 +116,7 @@ def test_handler_with_no_ips_to_block(mock_waf_client, mock_athena_client):
     mock_athena_client.start_query_execution.assert_has_calls(
         [
             call(
-                QueryString="-- List of IP addresses that have triggered 4xx HTTP responses\nSELECT\n    client_ip,\n    COUNT(*) as count\nFROM\n    lb_logs\nWHERE\n    (\n        elb_status_code = 403\n        OR target_status_code LIKE '4__'\n    )\n    AND from_iso8601_timestamp(time) >= date_add('day', -1, current_timestamp)\nGROUP BY\n    client_ip\nHAVING COUNT(*) > 20\nORDER BY count DESC",
+                QueryString="-- List of IP addresses that have triggered 4xx HTTP responses\nSELECT\n    client_ip,\n    COUNT(*) as count\nFROM\n    lb_logs\nWHERE\n    (\n        elb_status_code = 403\n        OR target_status_code LIKE '4__'\n    )\n    AND target_status_code NOT IN ('')\n    AND from_iso8601_timestamp(time) >= date_add('day', -1, current_timestamp)\nGROUP BY\n    client_ip\nHAVING COUNT(*) > 20\nORDER BY count DESC",
                 QueryExecutionContext={"Database": "access_logs"},
                 ResultConfiguration={"OutputLocation": "s3://test_bucket/"},
                 WorkGroup="test_workgroup",
@@ -162,7 +162,7 @@ def test_handler_with_only_lb_query(mock_waf_client, mock_athena_client):
     mock_athena_client.start_query_execution.assert_has_calls(
         [
             call(
-                QueryString="-- List of IP addresses that have triggered 4xx HTTP responses\nSELECT\n    client_ip,\n    COUNT(*) as count\nFROM\n    lb_logs\nWHERE\n    (\n        elb_status_code = 403\n        OR target_status_code LIKE '4__'\n    )\n    AND from_iso8601_timestamp(time) >= date_add('day', -1, current_timestamp)\nGROUP BY\n    client_ip\nHAVING COUNT(*) > 20\nORDER BY count DESC",
+                QueryString="-- List of IP addresses that have triggered 4xx HTTP responses\nSELECT\n    client_ip,\n    COUNT(*) as count\nFROM\n    lb_logs\nWHERE\n    (\n        elb_status_code = 403\n        OR target_status_code LIKE '4__'\n    )\n    AND target_status_code NOT IN ('')\n    AND from_iso8601_timestamp(time) >= date_add('day', -1, current_timestamp)\nGROUP BY\n    client_ip\nHAVING COUNT(*) > 20\nORDER BY count DESC",
                 QueryExecutionContext={"Database": "access_logs"},
                 ResultConfiguration={"OutputLocation": "s3://test_bucket/"},
                 WorkGroup="test_workgroup",

--- a/waf_ip_blocklist/lambda/query_lb.sql
+++ b/waf_ip_blocklist/lambda/query_lb.sql
@@ -9,6 +9,7 @@ WHERE
         elb_status_code = 403
         OR target_status_code LIKE '4__'
     )
+    AND target_status_code NOT IN ({skip_list})
     AND from_iso8601_timestamp(time) >= date_add('day', -1, current_timestamp)
 GROUP BY
     client_ip

--- a/waf_ip_blocklist/main.tf
+++ b/waf_ip_blocklist/main.tf
@@ -50,6 +50,7 @@ resource "aws_lambda_function" "ipv4_blocklist" {
       ATHENA_WAF_TABLE     = var.athena_waf_table_name
       ATHENA_WORKGROUP     = var.athena_workgroup_name
       BLOCK_THRESHOLD      = var.waf_block_threshold
+      LB_STATUS_CODE_SKIP  = join(",", var.lb_status_code_skip)
       QUERY_LB             = var.query_lb
       QUERY_WAF            = var.query_waf
       WAF_IP_SET_ID        = aws_wafv2_ip_set.ipv4_blocklist.id


### PR DESCRIPTION
# Summary 
Add the ability to prevent some LB target response codes from causing an IP to get added to the blocklist.

The use case for this is when normal service flow can generate 4XX status codes that should not result in a user block.