### PR TITLE
feat: add storage_type option for DocumentDB

### DIFF
--- a/DocumentDB/input.tf
+++ b/DocumentDB/input.tf
@@ -113,6 +113,12 @@ variable "instance_class" {
   description = "(Required, default `db.t3.medium`) The instance class to use for the instance For more information on instance classes, refer to https://docs.aws.amazon.com/documentdb/latest/developerguide/db-instance-classes.html#db-instance-class-specs."
 }
 
+variable "storage_type" {
+  type        = string
+  default     = "standard"
+  description = "(Optional, default `standard`) The storage type to associate with the DB cluster. Valid values: `standard`, `iopt1`. For more information on storage types, refer to https://docs.aws.amazon.com/documentdb/latest/developerguide/db-cluster-storage-configs.html."
+}
+
 variable "subnet_ids" {
   description = "(Required) List of VPC subnet IDs."
   type        = list(string)

--- a/DocumentDB/main.tf
+++ b/DocumentDB/main.tf
@@ -42,6 +42,7 @@ resource "aws_docdb_cluster" "this" {
   db_cluster_parameter_group_name = aws_docdb_cluster_parameter_group.this[0].name
   engine                          = var.engine
   engine_version                  = var.engine_version
+  storage_type                    = var.storage_type
 
   tags = local.common_tags
 }


### PR DESCRIPTION
# Summary | Résumé
Adds the `storage_type` option for DocumentDB clusters. Compared to standard storage, I/O-optimized storage offers better performance and cost efficiency for I/O-heavy workloads. For more information, see [Amazon DocumentDB cluster storage configurations](https://docs.aws.amazon.com/documentdb/latest/developerguide/db-cluster-storage-configs.html).