### PR TITLE
feat: add service port to ECS module outputs

### DIFF
--- a/ecs/README.md
+++ b/ecs/README.md
@@ -119,6 +119,7 @@ No requirements.
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Name that identifies the cluster |
 | <a name="output_service_id"></a> [service\_id](#output\_service\_id) | ARN that identifies the service |
 | <a name="output_service_name"></a> [service\_name](#output\_service\_name) | Name of the service |
+| <a name="output_service_port"></a> [service\_port](#output\_service\_port) | Port of the service |
 | <a name="output_task_definition_arn"></a> [task\_definition\_arn](#output\_task\_definition\_arn) | Full ARN of the Task Definition (including both `family` and `revision`) |
 | <a name="output_task_definition_family"></a> [task\_definition\_family](#output\_task\_definition\_family) | The unique name of the task definition |
 | <a name="output_task_definition_revision"></a> [task\_definition\_revision](#output\_task\_definition\_revision) | Revision of the task in a particular family |

--- a/ecs/output.tf
+++ b/ecs/output.tf
@@ -31,6 +31,11 @@ output "service_name" {
   value       = aws_ecs_service.this.name
 }
 
+output "service_port" {
+  description = "Port of the service"
+  value       = var.container_port
+}
+
 ################################################################################
 # Task
 ################################################################################


### PR DESCRIPTION
# Summary | Résumé

- Adds service port to ECS module outputs. This will be useful for the service discovery feature when we need to build the URL to access a specific service `${service-name}.${dns-name}:${service-port}`.

Note:
As stated in the AWS documentation, we do not really need to output the host port as the container port is the one that matters the most.

> <ins>For task definitions that use the awsvpc network mode, only specify the containerPort.</ins> The hostPort can be left blank or it must be the same value as the containerPort.