### PR TITLE
fix: ECS port output should handle null value

### DIFF
--- a/ecs/output.tf
+++ b/ecs/output.tf
@@ -33,7 +33,7 @@ output "service_name" {
 
 output "service_port" {
   description = "Port of the service"
-  value       = var.container_port
+  value       = var.container_port == null ? "" : var.container_port
 }
 
 ################################################################################


### PR DESCRIPTION
# Summary | Résumé

- Fixes ECS port output so that it handles null value