### PR TITLE
fix: WAF IP set for CloudFront

### DIFF
--- a/waf_ip_blocklist/README.md
+++ b/waf_ip_blocklist/README.md
@@ -6,6 +6,10 @@ The automatic update is based on a service's WAF and load balancer logs where an
 The IP block is temporary and the IP address will be removed once it has been at least 24 hours since it has exceeded
 the block threshold.
 
+## CloudFront WAF
+If you are using CloudFront, you need to set the `waf_scope` variable to `CLOUDFRONT`.  You must also pass a `us-east-1` provider to the
+module as the WAF IP set needs to be in `us-east-1` to work with CloudFront.
+
 ## Requirements
 
 No requirements.
@@ -54,6 +58,7 @@ No modules.
 | <a name="input_athena_lb_table_name"></a> [athena\_lb\_table\_name](#input\_athena\_lb\_table\_name) | (Optional, default 'lb\_logs') The name of the Load Balancer logs table in the Athena database. | `string` | `"lb_logs"` | no |
 | <a name="input_athena_query_results_bucket"></a> [athena\_query\_results\_bucket](#input\_athena\_query\_results\_bucket) | (Required) The name of the S3 bucket where the Athena query results are stored. | `string` | n/a | yes |
 | <a name="input_athena_query_source_bucket"></a> [athena\_query\_source\_bucket](#input\_athena\_query\_source\_bucket) | (Required) The name of the S3 bucket where the source data for the Athena query lives. | `string` | n/a | yes |
+| <a name="input_athena_region"></a> [athena\_region](#input\_athena\_region) | (Optional, default '') The AWS region where the Athena workgroup exists.  If left blank, this defaults to the current region. | `string` | `""` | no |
 | <a name="input_athena_waf_table_name"></a> [athena\_waf\_table\_name](#input\_athena\_waf\_table\_name) | (Optional, default 'waf\_logs') The name of the WAF logs table in the Athena database. | `string` | `"waf_logs"` | no |
 | <a name="input_athena_workgroup_name"></a> [athena\_workgroup\_name](#input\_athena\_workgroup\_name) | (Optional, default 'primary') The name of the Athena workgroup. | `string` | `"primary"` | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |

--- a/waf_ip_blocklist/data.tf
+++ b/waf_ip_blocklist/data.tf
@@ -2,6 +2,6 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 locals {
-  account_id = data.aws_caller_identity.current.account_id
-  region     = data.aws_region.current.name
+  account_id    = data.aws_caller_identity.current.account_id
+  athena_region = var.athena_region != "" ? var.athena_region : data.aws_region.current.name
 }

--- a/waf_ip_blocklist/examples/simple/provider.tf
+++ b/waf_ip_blocklist/examples/simple/provider.tf
@@ -1,3 +1,9 @@
 provider "aws" {
   region = "ca-central-1"
 }
+
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}
+

--- a/waf_ip_blocklist/examples/simple/simple.tf
+++ b/waf_ip_blocklist/examples/simple/simple.tf
@@ -1,4 +1,3 @@
-
 module "simple" {
   source = "../../"
 
@@ -9,3 +8,18 @@ module "simple" {
   billing_tag_value           = "test-app"
 }
 
+module "cloudfront" {
+  source = "../../"
+
+  service_name                = "test-app"
+  athena_query_results_bucket = "test-app-athena-bucket"
+  athena_query_source_bucket  = "test-app-waf-logs-bucket"
+  billing_tag_value           = "test-app"
+
+  waf_scope     = "CLOUDFRONT"
+  athena_region = "ca-central-1"
+
+  providers = {
+    aws = aws.us-east-1
+  }
+}

--- a/waf_ip_blocklist/iam.tf
+++ b/waf_ip_blocklist/iam.tf
@@ -61,7 +61,7 @@ data "aws_iam_policy_document" "athena" {
       "athena:GetQueryExecution"
     ]
     resources = [
-      "arn:aws:athena:${local.region}:${local.account_id}:workgroup/${var.athena_workgroup_name}"
+      "arn:aws:athena:${local.athena_region}:${local.account_id}:workgroup/${var.athena_workgroup_name}"
     ]
   }
 
@@ -74,8 +74,8 @@ data "aws_iam_policy_document" "athena" {
       "athena:GetTableMetadata"
     ]
     resources = [
-      "arn:aws:athena:${local.region}:${local.account_id}:catalog/AwsDataCatalog/database/${var.athena_database_name}",
-      "arn:aws:athena:${local.region}:${local.account_id}:catalog/AwsDataCatalog/database/${var.athena_database_name}/table/*"
+      "arn:aws:athena:${local.athena_region}:${local.account_id}:catalog/AwsDataCatalog/database/${var.athena_database_name}",
+      "arn:aws:athena:${local.athena_region}:${local.account_id}:catalog/AwsDataCatalog/database/${var.athena_database_name}/table/*"
     ]
   }
 
@@ -88,9 +88,9 @@ data "aws_iam_policy_document" "athena" {
       "glue:GetPartitions"
     ]
     resources = [
-      "arn:aws:glue:${local.region}:${local.account_id}:catalog",
-      "arn:aws:glue:${local.region}:${local.account_id}:database/${var.athena_database_name}",
-      "arn:aws:glue:${local.region}:${local.account_id}:table/${var.athena_database_name}/*"
+      "arn:aws:glue:${local.athena_region}:${local.account_id}:catalog",
+      "arn:aws:glue:${local.athena_region}:${local.account_id}:database/${var.athena_database_name}",
+      "arn:aws:glue:${local.athena_region}:${local.account_id}:table/${var.athena_database_name}/*"
     ]
   }
 }

--- a/waf_ip_blocklist/input.tf
+++ b/waf_ip_blocklist/input.tf
@@ -20,6 +20,12 @@ variable "athena_lb_table_name" {
   default     = "lb_logs"
 }
 
+variable "athena_region" {
+  description = "(Optional, default '') The AWS region where the Athena workgroup exists.  If left blank, this defaults to the current region."
+  type        = string
+  default     = ""
+}
+
 variable "athena_waf_table_name" {
   description = "(Optional, default 'waf_logs') The name of the WAF logs table in the Athena database."
   type        = string

--- a/waf_ip_blocklist/main.tf
+++ b/waf_ip_blocklist/main.tf
@@ -6,6 +6,10 @@
 *
 * The IP block is temporary and the IP address will be removed once it has been at least 24 hours since it has exceeded
 * the block threshold.
+*
+* ## CloudFront WAF
+* If you are using CloudFront, you need to set the `waf_scope` variable to `CLOUDFRONT`.  You must also pass a `us-east-1` provider to the
+* module as the WAF IP set needs to be in `us-east-1` to work with CloudFront.
 */
 
 #


### PR DESCRIPTION
# Summary
Update the module so that it works properly when being used with a CloudFront WAF ACL.  In this case, the resources are created in `us-east-1` but a new input variable allows for cross-region Athena queries.