### PR TITLE
fix: set region for Athena boto client

### DIFF
--- a/waf_ip_blocklist/lambda/blocklist.py
+++ b/waf_ip_blocklist/lambda/blocklist.py
@@ -8,11 +8,9 @@ import os
 import time
 import boto3
 
-athena_client = boto3.client("athena")
-waf_client = boto3.client("wafv2")
-
 # Required
 ATHENA_OUTPUT_BUCKET = os.environ["ATHENA_OUTPUT_BUCKET"]
+ATHENA_REGION = os.environ["ATHENA_REGION"]
 ATHENA_WORKGROUP = os.environ["ATHENA_WORKGROUP"]
 WAF_IP_SET_ID = os.environ["WAF_IP_SET_ID"]
 WAF_IP_SET_NAME = os.environ["WAF_IP_SET_NAME"]
@@ -27,6 +25,9 @@ QUERY_LB = os.getenv("QUERY_LB", "true") == "true"
 QUERY_WAF = os.getenv("QUERY_WAF", "true") == "true"
 WAF_RULE_IDS_SKIP = os.getenv("WAF_RULE_IDS_SKIP", "").split(",")
 WAF_SCOPE = os.getenv("WAF_SCOPE", "REGIONAL")
+
+athena_client = boto3.client("athena", region_name=ATHENA_REGION)
+waf_client = boto3.client("wafv2")
 
 
 def handler(_event, _context):

--- a/waf_ip_blocklist/lambda/blocklist_test.py
+++ b/waf_ip_blocklist/lambda/blocklist_test.py
@@ -5,6 +5,7 @@ from unittest.mock import call, patch
 
 os.environ["AWS_DEFAULT_REGION"] = "ca-central-1"
 os.environ["ATHENA_OUTPUT_BUCKET"] = "test_bucket"
+os.environ["ATHENA_REGION"] = "ca-central-1"
 os.environ["ATHENA_WORKGROUP"] = "test_workgroup"
 os.environ["WAF_IP_SET_ID"] = "test_ip_set_id"
 os.environ["WAF_IP_SET_NAME"] = "test_ip_set_name"

--- a/waf_ip_blocklist/main.tf
+++ b/waf_ip_blocklist/main.tf
@@ -51,6 +51,7 @@ resource "aws_lambda_function" "ipv4_blocklist" {
       ATHENA_OUTPUT_BUCKET = var.athena_query_results_bucket
       ATHENA_DATABASE      = var.athena_database_name
       ATHENA_LB_TABLE      = var.athena_lb_table_name
+      ATHENA_REGION        = local.athena_region
       ATHENA_WAF_TABLE     = var.athena_waf_table_name
       ATHENA_WORKGROUP     = var.athena_workgroup_name
       BLOCK_THRESHOLD      = var.waf_block_threshold


### PR DESCRIPTION
# Summary
Set the target Athena region for the boto client.  This will avoid permission errors if Athena exists in a different region from the Lambda function.