### PR TITLE
chore: Add 5xx to lb query for waf_ip_blocklist

### DIFF
--- a/waf_ip_blocklist/README.md
+++ b/waf_ip_blocklist/README.md
@@ -64,7 +64,7 @@ No modules.
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_lb_status_code_skip"></a> [lb\_status\_code\_skip](#input\_lb\_status\_code\_skip) | (Optional, default []) A list of Load Balancer status codes to ignore when adding an IP address to the blocklist | `list(string)` | `[]` | no |
-| <a name="input_query_lb"></a> [query\_lb](#input\_query\_lb) | (Optional, default true) Should the Load Balancer logs be queried for 4xx responses? | `bool` | `true` | no |
+| <a name="input_query_lb"></a> [query\_lb](#input\_query\_lb) | (Optional, default true) Should the Load Balancer logs be queried for 4xx and 5xx responses? | `bool` | `true` | no |
 | <a name="input_query_waf"></a> [query\_waf](#input\_query\_waf) | (Optional, default true) Should the WAF logs be queried for BLOCK responses? | `bool` | `true` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | (Required) The name of the service | `string` | n/a | yes |
 | <a name="input_waf_block_threshold"></a> [waf\_block\_threshold](#input\_waf\_block\_threshold) | (Optional, default 20) The threshold of blocked requests for adding an IP address to the blocklist | `number` | `20` | no |

--- a/waf_ip_blocklist/input.tf
+++ b/waf_ip_blocklist/input.tf
@@ -56,7 +56,7 @@ variable "lb_status_code_skip" {
 }
 
 variable "query_lb" {
-  description = "(Optional, default true) Should the Load Balancer logs be queried for 4xx responses?"
+  description = "(Optional, default true) Should the Load Balancer logs be queried for 4xx and 5xx responses?"
   type        = bool
   default     = true
 }

--- a/waf_ip_blocklist/lambda/blocklist_test.py
+++ b/waf_ip_blocklist/lambda/blocklist_test.py
@@ -56,7 +56,7 @@ def test_handler_with_ips_to_block(mock_waf_client, mock_athena_client, capsys):
     mock_athena_client.start_query_execution.assert_has_calls(
         [
             call(
-                QueryString="-- List of IP addresses that have triggered 4xx HTTP responses\nSELECT\n    client_ip,\n    COUNT(*) as count\nFROM\n    lb_logs\nWHERE\n    (\n        elb_status_code = 403\n        OR target_status_code LIKE '4__'\n    )\n    AND target_status_code NOT IN ('')\n    AND from_iso8601_timestamp(time) >= date_add('day', -1, current_timestamp)\nGROUP BY\n    client_ip\nHAVING COUNT(*) > 20\nORDER BY count DESC",
+                QueryString="-- List of IP addresses that have triggered 4xx HTTP responses\nSELECT\n    client_ip,\n    COUNT(*) as count\nFROM\n    lb_logs\nWHERE\n    (\n        elb_status_code = 403\n        OR target_status_code LIKE '4__'\n        OR target_status_code LIKE '5__'\n    )\n    AND target_status_code NOT IN ('')\n    AND from_iso8601_timestamp(time) >= date_add('day', -1, current_timestamp)\nGROUP BY\n    client_ip\nHAVING COUNT(*) > 20\nORDER BY count DESC",
                 QueryExecutionContext={"Database": "access_logs"},
                 ResultConfiguration={"OutputLocation": "s3://test_bucket/"},
                 WorkGroup="test_workgroup",
@@ -117,7 +117,7 @@ def test_handler_with_no_ips_to_block(mock_waf_client, mock_athena_client):
     mock_athena_client.start_query_execution.assert_has_calls(
         [
             call(
-                QueryString="-- List of IP addresses that have triggered 4xx HTTP responses\nSELECT\n    client_ip,\n    COUNT(*) as count\nFROM\n    lb_logs\nWHERE\n    (\n        elb_status_code = 403\n        OR target_status_code LIKE '4__'\n    )\n    AND target_status_code NOT IN ('')\n    AND from_iso8601_timestamp(time) >= date_add('day', -1, current_timestamp)\nGROUP BY\n    client_ip\nHAVING COUNT(*) > 20\nORDER BY count DESC",
+                QueryString="-- List of IP addresses that have triggered 4xx HTTP responses\nSELECT\n    client_ip,\n    COUNT(*) as count\nFROM\n    lb_logs\nWHERE\n    (\n        elb_status_code = 403\n        OR target_status_code LIKE '4__'\n        OR target_status_code LIKE '5__'\n    )\n    AND target_status_code NOT IN ('')\n    AND from_iso8601_timestamp(time) >= date_add('day', -1, current_timestamp)\nGROUP BY\n    client_ip\nHAVING COUNT(*) > 20\nORDER BY count DESC",
                 QueryExecutionContext={"Database": "access_logs"},
                 ResultConfiguration={"OutputLocation": "s3://test_bucket/"},
                 WorkGroup="test_workgroup",
@@ -163,7 +163,7 @@ def test_handler_with_only_lb_query(mock_waf_client, mock_athena_client):
     mock_athena_client.start_query_execution.assert_has_calls(
         [
             call(
-                QueryString="-- List of IP addresses that have triggered 4xx HTTP responses\nSELECT\n    client_ip,\n    COUNT(*) as count\nFROM\n    lb_logs\nWHERE\n    (\n        elb_status_code = 403\n        OR target_status_code LIKE '4__'\n    )\n    AND target_status_code NOT IN ('')\n    AND from_iso8601_timestamp(time) >= date_add('day', -1, current_timestamp)\nGROUP BY\n    client_ip\nHAVING COUNT(*) > 20\nORDER BY count DESC",
+                QueryString="-- List of IP addresses that have triggered 4xx HTTP responses\nSELECT\n    client_ip,\n    COUNT(*) as count\nFROM\n    lb_logs\nWHERE\n    (\n        elb_status_code = 403\n        OR target_status_code LIKE '4__'\n        OR target_status_code LIKE '5__'\n    )\n    AND target_status_code NOT IN ('')\n    AND from_iso8601_timestamp(time) >= date_add('day', -1, current_timestamp)\nGROUP BY\n    client_ip\nHAVING COUNT(*) > 20\nORDER BY count DESC",
                 QueryExecutionContext={"Database": "access_logs"},
                 ResultConfiguration={"OutputLocation": "s3://test_bucket/"},
                 WorkGroup="test_workgroup",

--- a/waf_ip_blocklist/lambda/query_lb.sql
+++ b/waf_ip_blocklist/lambda/query_lb.sql
@@ -8,6 +8,7 @@ WHERE
     (
         elb_status_code = 403
         OR target_status_code LIKE '4__'
+        OR target_status_code LIKE '5__'
     )
     AND target_status_code NOT IN ({skip_list})
     AND from_iso8601_timestamp(time) >= date_add('day', -1, current_timestamp)


### PR DESCRIPTION
# Summary | Résumé
Adds the verifying of 5xx return status codes from the target to the load balancer query.

Ensures requests that are not handled properly by the application are also neutralized.
