### PR TITLE
feat: add GuardDuty Malware S3 alarms

### DIFF
--- a/guardduty_malware_s3/README.md
+++ b/guardduty_malware_s3/README.md
@@ -40,7 +40,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alarm_completed_scan_count_threshold"></a> [alarm\_completed\_scan\_count\_threshold](#input\_alarm\_completed\_scan\_count\_threshold) | (Optional, default 10000) The threshold for the number of completed scans in a day. | `number` | `10000` | no |
-| <a name="input_alarm_completed_scan_gigabytes_threshold"></a> [alarm\_completed\_scan\_gigabytes\_threshold](#input\_alarm\_completed\_scan\_gigabytes\_threshold) | (Optional, default 2) The threshold for the number of completed scan bytes in a day. | `number` | `2` | no |
+| <a name="input_alarm_completed_scan_gigabytes_threshold"></a> [alarm\_completed\_scan\_gigabytes\_threshold](#input\_alarm\_completed\_scan\_gigabytes\_threshold) | (Optional, default 2) The threshold for the number of completed scan gigabytes in a day. | `number` | `2` | no |
 | <a name="input_alarm_sns_topic_alarm_arn"></a> [alarm\_sns\_topic\_alarm\_arn](#input\_alarm\_sns\_topic\_alarm\_arn) | (Optional) The ARN of the SNS topic to notify when an alarm is in an Alarm state. If not provided, no notifications will be sent. | `string` | `null` | no |
 | <a name="input_alarm_sns_topic_ok_arn"></a> [alarm\_sns\_topic\_ok\_arn](#input\_alarm\_sns\_topic\_ok\_arn) | (Optional) The ARN of the SNS topic to notify when an alarm is in OK state. If not provided, no notifications will be sent. | `string` | `null` | no |
 | <a name="input_alarms_enabled"></a> [alarms\_enabled](#input\_alarms\_enabled) | (Optional, default true) Whether to create CloudWatch alarms for completed scans. | `bool` | `true` | no |

--- a/guardduty_malware_s3/README.md
+++ b/guardduty_malware_s3/README.md
@@ -24,6 +24,8 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_cloudwatch_metric_alarm.malware_completed_scan_bytes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.malware_completed_scan_count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_guardduty_malware_protection_plan.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_malware_protection_plan) | resource |
 | [aws_iam_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -37,6 +39,11 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_alarm_completed_scan_count_threshold"></a> [alarm\_completed\_scan\_count\_threshold](#input\_alarm\_completed\_scan\_count\_threshold) | (Optional, default 10000) The threshold for the number of completed scans in a day. | `number` | `10000` | no |
+| <a name="input_alarm_completed_scan_gigabytes_threshold"></a> [alarm\_completed\_scan\_gigabytes\_threshold](#input\_alarm\_completed\_scan\_gigabytes\_threshold) | (Optional, default 2) The threshold for the number of completed scan bytes in a day. | `number` | `2` | no |
+| <a name="input_alarm_sns_topic_alarm_arn"></a> [alarm\_sns\_topic\_alarm\_arn](#input\_alarm\_sns\_topic\_alarm\_arn) | (Optional) The ARN of the SNS topic to notify when an alarm is in an Alarm state. If not provided, no notifications will be sent. | `string` | `null` | no |
+| <a name="input_alarm_sns_topic_ok_arn"></a> [alarm\_sns\_topic\_ok\_arn](#input\_alarm\_sns\_topic\_ok\_arn) | (Optional) The ARN of the SNS topic to notify when an alarm is in OK state. If not provided, no notifications will be sent. | `string` | `null` | no |
+| <a name="input_alarms_enabled"></a> [alarms\_enabled](#input\_alarms\_enabled) | (Optional, default true) Whether to create CloudWatch alarms for completed scans. | `bool` | `true` | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | (Required) The name of the S3 bucket to scan objects in. | `string` | n/a | yes |

--- a/guardduty_malware_s3/cloudwatch.tf
+++ b/guardduty_malware_s3/cloudwatch.tf
@@ -1,0 +1,45 @@
+resource "aws_cloudwatch_metric_alarm" "malware_completed_scan_count" {
+  count = var.alarms_enabled ? 1 : 0
+
+  alarm_name          = "MalwareS3-ScanCount-${var.s3_bucket_name}"
+  alarm_description   = "Scanned more than ${var.alarm_completed_scan_count_threshold} objects in 1 day."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "CompletedScanCount"
+  namespace           = "AWS/GuardDuty/MalwareProtection"
+  period              = 86400
+  statistic           = "Sum"
+  threshold           = var.alarm_completed_scan_count_threshold
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    "Resource Name"              = var.s3_bucket_name
+    "Malware Protection Plan Id" = aws_guardduty_malware_protection_plan.this.id
+  }
+
+  alarm_actions = var.alarm_sns_topic_alarm_arn != null ? [var.alarm_sns_topic_alarm_arn] : []
+  ok_actions    = var.alarm_sns_topic_ok_arn != null ? [var.alarm_sns_topic_ok_arn] : []
+}
+
+resource "aws_cloudwatch_metric_alarm" "malware_completed_scan_bytes" {
+  count = var.alarms_enabled ? 1 : 0
+
+  alarm_name          = "MalwareS3-ScanBytes-${var.s3_bucket_name}"
+  alarm_description   = "Scanned more than ${var.alarm_completed_scan_gigabytes_threshold} GB in 1 day."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "CompletedScanBytes"
+  namespace           = "AWS/GuardDuty/MalwareProtection"
+  period              = 86400
+  statistic           = "Sum"
+  threshold           = var.alarm_completed_scan_gigabytes_threshold * 1024 * 1024 * 1024 # Convert GB to bytes
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    "Resource Name"              = var.s3_bucket_name
+    "Malware Protection Plan Id" = aws_guardduty_malware_protection_plan.this.id
+  }
+
+  alarm_actions = var.alarm_sns_topic_alarm_arn != null ? [var.alarm_sns_topic_alarm_arn] : []
+  ok_actions    = var.alarm_sns_topic_ok_arn != null ? [var.alarm_sns_topic_ok_arn] : []
+}

--- a/guardduty_malware_s3/examples/simple/simple.tf
+++ b/guardduty_malware_s3/examples/simple/simple.tf
@@ -6,6 +6,9 @@ module "guardduty_malware_s3" {
   s3_object_prefixes = ["only-scan-this-folder/"]
   tagging_status     = "ENABLED"
 
+  alarm_sns_topic_alarm_arn = aws_sns_topic.scan_alarm.arn
+  alarm_sns_topic_ok_arn    = aws_sns_topic.scan_ok.arn
+
   billing_tag_value = "testing"
 }
 
@@ -14,4 +17,12 @@ module "scan_bucket" {
 
   bucket_name       = "a-bucket-that-will-be-scanned-for-malware"
   billing_tag_value = "testing"
+}
+
+resource "aws_sns_topic" "scan_alarm" {
+  name = "MalwareS3-Alarm-${module.scan_bucket.s3_bucket_id}"
+}
+
+resource "aws_sns_topic" "scan_ok" {
+  name = "MalwareS3-Ok-${module.scan_bucket.s3_bucket_id}"
 }

--- a/guardduty_malware_s3/input.tf
+++ b/guardduty_malware_s3/input.tf
@@ -1,3 +1,34 @@
+variable "alarm_completed_scan_count_threshold" {
+  description = "(Optional, default 10000) The threshold for the number of completed scans in a day."
+  type        = number
+  default     = 10000
+
+}
+
+variable "alarm_completed_scan_gigabytes_threshold" {
+  description = "(Optional, default 2) The threshold for the number of completed scan bytes in a day."
+  type        = number
+  default     = 2
+}
+
+variable "alarms_enabled" {
+  description = "(Optional, default true) Whether to create CloudWatch alarms for completed scans."
+  type        = bool
+  default     = true
+}
+
+variable "alarm_sns_topic_alarm_arn" {
+  description = "(Optional) The ARN of the SNS topic to notify when an alarm is in an Alarm state. If not provided, no notifications will be sent."
+  type        = string
+  default     = null
+}
+
+variable "alarm_sns_topic_ok_arn" {
+  description = "(Optional) The ARN of the SNS topic to notify when an alarm is in OK state. If not provided, no notifications will be sent."
+  type        = string
+  default     = null
+}
+
 variable "billing_tag_key" {
   description = "(Optional, default 'CostCentre') The name of the billing tag"
   type        = string

--- a/guardduty_malware_s3/input.tf
+++ b/guardduty_malware_s3/input.tf
@@ -6,7 +6,7 @@ variable "alarm_completed_scan_count_threshold" {
 }
 
 variable "alarm_completed_scan_gigabytes_threshold" {
-  description = "(Optional, default 2) The threshold for the number of completed scan bytes in a day."
+  description = "(Optional, default 2) The threshold for the number of completed scan gigabytes in a day."
   type        = number
   default     = 2
 }

--- a/guardduty_malware_s3/tests/unit.main.tftest.hcl
+++ b/guardduty_malware_s3/tests/unit.main.tftest.hcl
@@ -6,7 +6,9 @@ run "test_defaults" {
   command = plan
 
   variables {
-    s3_bucket_name = "a-bucket-that-will-be-scanned-for-malware"
+    s3_bucket_name            = "a-bucket-that-will-be-scanned-for-malware"
+    alarm_sns_topic_alarm_arn = "arn:aws:sns:ca-central-1:123456789012:MalwareS3-Alarm-a-bucket-that-will-be-scanned-for-malware"
+    alarm_sns_topic_ok_arn    = "arn:aws:sns:ca-central-1:123456789012:MalwareS3-Ok-a-bucket-that-will-be-scanned-for-malware"
   }
 
   assert {
@@ -18,12 +20,33 @@ run "test_defaults" {
     condition     = aws_guardduty_malware_protection_plan.this.actions[0].tagging[0].status == "ENABLED"
     error_message = "aws_guardduty_malware_protection_plan.this.actions[0].tagging[0].status did not match expected value"
   }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.malware_completed_scan_count[0].threshold == 10000
+    error_message = "aws_cloudwatch_metric_alarm.malware_completed_scan_count[0].threshold did not match expected value"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.malware_completed_scan_count[0].alarm_actions == toset(["arn:aws:sns:ca-central-1:123456789012:MalwareS3-Alarm-a-bucket-that-will-be-scanned-for-malware"])
+    error_message = "aws_cloudwatch_metric_alarm.malware_completed_scan_count[0].alarm_actions did not match expected value"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.malware_completed_scan_count[0].ok_actions == toset(["arn:aws:sns:ca-central-1:123456789012:MalwareS3-Ok-a-bucket-that-will-be-scanned-for-malware"])
+    error_message = "aws_cloudwatch_metric_alarm.malware_completed_scan_count[0].ok_actions did not match expected value"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.malware_completed_scan_bytes[0].threshold == 2147483648
+    error_message = "aws_cloudwatch_metric_alarm.malware_completed_scan_bytes[0].threshold did not match expected value"
+  }
 }
 
 run "test_overrides" {
   command = plan
 
   variables {
+    alarms_enabled     = false
     s3_bucket_name     = "another-bucket-that-will-be-scanned-for-malware"
     s3_object_prefixes = ["only-scan-this-folder/"]
     tagging_status     = "DISABLED"
@@ -42,5 +65,15 @@ run "test_overrides" {
   assert {
     condition     = aws_guardduty_malware_protection_plan.this.actions[0].tagging[0].status == "DISABLED"
     error_message = "aws_guardduty_malware_protection_plan.this.actions[0].tagging[0].status did not match expected value"
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.malware_completed_scan_count) == 0
+    error_message = "aws_cloudwatch_metric_alarm.malware_completed_scan_count should not exist when alarms_enabled is false"
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.malware_completed_scan_bytes) == 0
+    error_message = "aws_cloudwatch_metric_alarm.malware_completed_scan_bytes should not exist when alarms_enabled is false"
   }
 }


### PR DESCRIPTION
# Summary
Add alarms that will trigger if more than 10,000 files or 2GB of data have been scanned in a single day.

# Related
- https://github.com/cds-snc/platform-core-services/issues/755