### PR TITLE
fix: Terraform state for OIDC role

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,6 @@
 		"SHELL": "/bin/zsh"
 	},	
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/python:1": {
 			"version": "3.13",
 			"installTools": "false"

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -7,7 +7,7 @@ terraform {
   }
 
   backend "s3" {
-    bucket       = "tfstate-cds-snc-terraform-modules"
+    bucket       = "cds-snc-terraform-modules-tfstate"
     key          = "terraform-modules-tfstate/terraform.tfstate"
     region       = "ca-central-1"
     encrypt      = true


### PR DESCRIPTION
# Summary
Fix the Terraform state as it was accidentally deleted by the AWS cleanup task.