### PR TITLE
Feat/static website add default waf

### DIFF
--- a/simple_static_website/README.md
+++ b/simple_static_website/README.md
@@ -52,6 +52,7 @@ No modules.
 | [aws_s3_bucket_policy.oai_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_website_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_website_configuration) | resource |
+| [aws_wafv2_web_acl.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
 | [random_string.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_iam_policy_document.s3_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 

--- a/simple_static_website/cloudfront.tf
+++ b/simple_static_website/cloudfront.tf
@@ -93,7 +93,7 @@ resource "aws_cloudfront_distribution" "simple_static_website" {
     minimum_protocol_version = "TLSv1.2_2021"
   }
 
-  web_acl_id = var.web_acl_arn
+  web_acl_id = local.web_acl_arn
 
   tags = local.common_tags
 }

--- a/simple_static_website/locals.tf
+++ b/simple_static_website/locals.tf
@@ -2,6 +2,7 @@ locals {
   acm_certificate_arn       = var.is_create_certificate ? aws_acm_certificate_validation.cloudfront[0].certificate_arn : var.acm_certificate_arn
   domain_validation_options = var.is_create_certificate ? aws_acm_certificate.cloudfront[0].domain_validation_options : []
   hosted_zone_id            = var.is_create_hosted_zone ? aws_route53_zone.hosted_zone[0].zone_id : var.hosted_zone_id
+  web_acl_arn               = var.web_acl_arn != null && var.web_acl_arn != "" ? var.web_acl_arn : aws_wafv2_web_acl.default.arn
 
   common_tags = {
     (var.billing_tag_key) = var.billing_tag_value

--- a/simple_static_website/waf.tf
+++ b/simple_static_website/waf.tf
@@ -66,7 +66,7 @@ resource "aws_wafv2_web_acl" "default" {
 
     statement {
       rate_based_statement {
-        limit              = 350
+        limit              = 500
         aggregate_key_type = "IP"
       }
     }

--- a/simple_static_website/waf.tf
+++ b/simple_static_website/waf.tf
@@ -1,0 +1,88 @@
+#
+# Default AWS WAFv2 Web ACL for CloudFront if not provided in vars
+#
+
+resource "aws_wafv2_web_acl" "default" {
+  name        = "${var.domain_name_source}-cloudfront-waf"
+  description = "Default WAF for CloudFront distribution protecting ${var.domain_name_source}"
+  scope       = "CLOUDFRONT"
+  provider    = aws.us-east-1
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesCommonRuleSet"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesAmazonIpReputationList"
+    priority = 2
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "RateLimit"
+    priority = 3
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 350
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.domain_name_source}-cloudfront-waf"
+    sampled_requests_enabled   = true
+  }
+
+  tags = local.common_tags
+}


### PR DESCRIPTION
# Summary | Résumé

This pull request adds support for a default AWS WAFv2 Web ACL to the simple static website module. If a Web ACL ARN is not provided, the module will now automatically create and attach a default WAF to the CloudFront distribution, improving security and flexibility. The main changes are grouped below:

**WAFv2 Web ACL Integration:**

* Added a new `aws_wafv2_web_acl.default` resource in `waf.tf` to create a default WAF for CloudFront with managed rule sets and a rate limiting rule.
* Updated `locals.tf` to set `local.web_acl_arn` to either the provided `var.web_acl_arn` or the ARN of the new default WAF.
* Modified `cloudfront.tf` so that the CloudFront distribution uses `local.web_acl_arn` instead of directly referencing the variable, enabling automatic attachment of the default WAF when needed.

**Documentation:**

* Updated `README.md` to include `aws_wafv2_web_acl.default` in the list of resources managed by the module.