### PR TITLE
Adding read only lock to sentinel instance

### DIFF
--- a/sentinel_instance/input.tf
+++ b/sentinel_instance/input.tf
@@ -25,3 +25,9 @@ variable "retention_in_days" {
   type        = number
   default     = 120
 }
+
+variable "enable_log_analytics_lock" {
+  description = "Whether to enable a lock on the Log Analytics Workspace."
+  type        = bool
+  default     = true
+}

--- a/sentinel_instance/main.tf
+++ b/sentinel_instance/main.tf
@@ -8,6 +8,14 @@ resource "azurerm_log_analytics_workspace" "this" {
   tags = merge(var.tags, local.common_tags)
 }
 
+resource "azurerm_management_lock" "log_analytics_readonly" {
+  count      = var.enable_log_analytics_lock ? 1 : 0
+  name       = "${azurerm_log_analytics_workspace.this.name}-readonly-lock"
+  scope      = azurerm_log_analytics_workspace.this.id
+  lock_level = "ReadOnly"
+  notes      = "Read-only lock for Log Analytics Workspace"
+}
+
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "this" {
   workspace_id = azurerm_log_analytics_workspace.this.id
 }


### PR DESCRIPTION
# Summary | Résumé

To comply with azure guardrails, this resource requires a read-only lock. This PR adds a lock, and a toggle in case it needs to be removed temporarily.