### PR TITLE
fix: retry SSC IP check on connection timeout (waf-ip-blocklist)

### DIFF
--- a/waf_ip_blocklist/lambda/blocklist.py
+++ b/waf_ip_blocklist/lambda/blocklist.py
@@ -10,8 +10,8 @@ import os
 import time
 import urllib.error
 import urllib.request
-import boto3
 import socket
+import boto3
 
 logging.getLogger().setLevel(logging.INFO)
 
@@ -164,7 +164,8 @@ def update_waf_ip_set(ip_addresses, waf_ip_set_name, waf_ip_set_id, waf_scope):
     # Truncate the IP address list if it has more than 10,000 addresses.
     # This is the max number of addresses an IP set can hold.
     if len(ip_addresses) > 10000:
-        # Logging as error because this could potentially mean that there is something going on (attack, major bug in the service that lives underneath the firewall)
+        # Logging as error because this could potentially mean that there is something
+        # going on (attack, major bug in the service that lives underneath the firewall)
         logging.error("Reducing %d addresses to 10,000 addresses.", len(ip_addresses))
         ip_addresses = ip_addresses[:10000]
 

--- a/waf_ip_blocklist/lambda/blocklist.py
+++ b/waf_ip_blocklist/lambda/blocklist.py
@@ -11,6 +11,7 @@ import time
 import urllib.error
 import urllib.request
 import boto3
+import socket
 
 logging.getLogger().setLevel(logging.INFO)
 
@@ -163,7 +164,8 @@ def update_waf_ip_set(ip_addresses, waf_ip_set_name, waf_ip_set_id, waf_scope):
     # Truncate the IP address list if it has more than 10,000 addresses.
     # This is the max number of addresses an IP set can hold.
     if len(ip_addresses) > 10000:
-        logging.info("Reducing %d addresses to 10,000 addresses.", len(ip_addresses))
+        # Logging as error because this could potentially mean that there is something going on (attack, major bug in the service that lives underneath the firewall)
+        logging.error("Reducing %d addresses to 10,000 addresses.", len(ip_addresses))
         ip_addresses = ip_addresses[:10000]
 
     # Remove any ip addresses known to be owned by the Government of Canada
@@ -255,7 +257,7 @@ class _RetryingSession:  # pylint: disable=too-few-public-methods
                 if exc.code not in self.status_forcelist:
                     return _Response(exc)
                 last_error = exc
-            except urllib.error.URLError as exc:
+            except (urllib.error.URLError, socket.timeout, TimeoutError) as exc:
                 last_error = exc
         raise last_error if last_error else OSError("Request failed")
 

--- a/waf_ip_blocklist/lambda/blocklist_test.py
+++ b/waf_ip_blocklist/lambda/blocklist_test.py
@@ -2,8 +2,8 @@ import io
 import logging
 import tempfile
 import os
-import json
 import urllib.error
+import socket
 
 from unittest.mock import call, patch, Mock, MagicMock
 
@@ -685,6 +685,49 @@ def test_retrying_session_get_retries_on_url_error_and_raises(mock_urlopen, mock
 
     assert mock_urlopen.call_count == 3  # initial + 2 retries
     assert mock_sleep.call_count == 2
+
+
+@patch("blocklist.time.sleep")
+@patch("urllib.request.urlopen")
+def test_retrying_session_get_retries_on_timeout_and_raises(mock_urlopen, mock_sleep):
+    """Test _RetryingSession.get() retries on timeout and raises after all retries fail"""
+    mock_urlopen.side_effect = socket.timeout("Request timed out")
+
+    session = blocklist._RetryingSession(total_retries=2, backoff_factor=0.5)
+
+    try:
+        session.get("https://example.com")
+        assert False, "Expected exception to be raised"
+    except socket.timeout:
+        pass
+
+    assert mock_urlopen.call_count == 3  # initial + 2 retries
+    assert mock_sleep.call_count == 2
+
+
+@patch("blocklist.time.sleep")
+@patch("urllib.request.urlopen")
+def test_retrying_session_get_retries_on_urlerror_timeout_then_succeeds(
+    mock_urlopen, mock_sleep
+):
+    """Test _RetryingSession.get() retries after a URLError (timeout) and succeeds on next attempt"""
+    mock_urlopen.side_effect = [
+        urllib.error.URLError("Request timed out"),
+        MagicMock(
+            __enter__=MagicMock(
+                return_value=MagicMock(
+                    status=200, read=MagicMock(return_value=b'{"result": "ok"}')
+                )
+            )
+        ),
+    ]
+
+    session = blocklist._RetryingSession(total_retries=3, backoff_factor=0.5)
+    response = session.get("https://example.com")
+
+    assert response.ok is True
+    assert mock_urlopen.call_count == 2
+    mock_sleep.assert_called_once_with(0.5)
 
 
 # ==============================


### PR DESCRIPTION
# Summary | Résumé

- Connects retry logic to the request that checks if an IP address belongs to SSC when it gets interrupted because of a connection timeout
- Converts log level from `info` to `error` for when we detect more than 10000 IP addresses that should be blocked