### PR TITLE
fix: create partitioned log tables for WAF/ALB

### DIFF
--- a/athena_access_logs/sql/lb_create_table.sql
+++ b/athena_access_logs/sql/lb_create_table.sql
@@ -49,7 +49,7 @@ CREATE EXTERNAL TABLE IF NOT EXISTS `${database_name}.${table_name}` (
     (
         "projection.enabled" = "true",
         "projection.day.type" = "date",
-        "projection.day.range" = "2020/01/01,NOW",
+        "projection.day.range" = "2024/01/01,NOW",
         "projection.day.format" = "yyyy/MM/dd",
         "projection.day.interval" = "1",
         "projection.day.interval.unit" = "DAYS",

--- a/athena_access_logs/sql/lb_create_table.sql
+++ b/athena_access_logs/sql/lb_create_table.sql
@@ -34,9 +34,24 @@ CREATE EXTERNAL TABLE IF NOT EXISTS `${database_name}.${table_name}` (
     classification_reason string,
     conn_trace_id string
     )
+    PARTITIONED BY
+    (
+        day STRING
+    )
     ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.RegexSerDe'
     WITH SERDEPROPERTIES (
     'serialization.format' = '1',
     'input.regex' = 
-'([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*)[:-]([0-9]*) ([-.0-9]*) ([-.0-9]*) ([-.0-9]*) (|[-0-9]*) (-|[-0-9]*) ([-0-9]*) ([-0-9]*) \"([^ ]*) (.*) (- |[^ ]*)\" \"([^\"]*)\" ([A-Z0-9-_]+) ([A-Za-z0-9.-]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^\"]*)\" ([-.0-9]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^ ]*)\" \"([^\s]+?)\" \"([^\s]+)\" \"([^ ]*)\" \"([^ ]*)\" ?([^ ]*)?( .*)?')
-    LOCATION '${bucket_location}';
+'([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*)[:-]([0-9]*) ([-.0-9]*) ([-.0-9]*) ([-.0-9]*) (|[-0-9]*) (-|[-0-9]*) ([-0-9]*) ([-0-9]*) \"([^ ]*) (.*) (- |[^ ]*)\" \"([^\"]*)\" ([A-Z0-9-_]+) ([A-Za-z0-9.-]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^\"]*)\" ([-.0-9]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^ ]*)\" \"([^\\s]+?)\" \"([^\\s]+)\" \"([^ ]*)\" \"([^ ]*)\" ?([^ ]*)? ?( .*)?'
+    )
+    LOCATION '${bucket_location}'
+    TBLPROPERTIES
+    (
+        "projection.enabled" = "true",
+        "projection.day.type" = "date",
+        "projection.day.range" = "2020/01/01,NOW",
+        "projection.day.format" = "yyyy/MM/dd",
+        "projection.day.interval" = "1",
+        "projection.day.interval.unit" = "DAYS",
+        "storage.location.template" = "${bucket_location}/${day}"
+    )

--- a/athena_access_logs/sql/waf_create_table.sql
+++ b/athena_access_logs/sql/waf_create_table.sql
@@ -1,73 +1,42 @@
-CREATE EXTERNAL TABLE `${database_name}.${table_name}`(
+CREATE EXTERNAL TABLE IF NOT EXISTS `${database_name}.${table_name}`(
   `timestamp` bigint, 
   `formatversion` int, 
   `webaclid` string, 
   `terminatingruleid` string, 
   `terminatingruletype` string, 
   `action` string, 
-  `terminatingrulematchdetails` array<
-                                    struct<
-                                        conditiontype:string,
-                                        location:string,
-                                        matcheddata:array<string>
-                                           >
-                                    >, 
+  `terminatingrulematchdetails` array<struct<conditiontype:string,sensitivitylevel:string,location:string,matcheddata:array<string>>>, 
   `httpsourcename` string, 
   `httpsourceid` string, 
-  `rulegrouplist` array<
-                      struct<
-                          rulegroupid:string,
-                          terminatingrule:struct<
-                                              ruleid:string,
-                                              action:string,
-                                              rulematchdetails:string
-                                                >,
-                          nonterminatingmatchingrules:array<string>,
-                          excludedrules:string
-                            >
-                       >, 
- `ratebasedrulelist` array<
-                         struct<
-                             ratebasedruleid:string,
-                             limitkey:string,
-                             maxrateallowed:int
-                               >
-                          >, 
-  `nonterminatingmatchingrules` array<
-                                    struct<
-                                        ruleid:string,
-                                        action:string
-                                          >
-                                     >, 
-  `requestheadersinserted` string, 
+  `rulegrouplist` array<struct<rulegroupid:string,terminatingrule:struct<ruleid:string,action:string,rulematchdetails:array<struct<conditiontype:string,sensitivitylevel:string,location:string,matcheddata:array<string>>>>,nonterminatingmatchingrules:array<struct<ruleid:string,action:string,overriddenaction:string,rulematchdetails:array<struct<conditiontype:string,sensitivitylevel:string,location:string,matcheddata:array<string>>>,challengeresponse:struct<responsecode:string,solvetimestamp:string>,captcharesponse:struct<responsecode:string,solvetimestamp:string>>>,excludedrules:string>>, 
+  `ratebasedrulelist` array<struct<ratebasedruleid:string,limitkey:string,maxrateallowed:int>>, 
+  `nonterminatingmatchingrules` array<struct<ruleid:string,action:string,rulematchdetails:array<struct<conditiontype:string,sensitivitylevel:string,location:string,matcheddata:array<string>>>,challengeresponse:struct<responsecode:string,solvetimestamp:string>,captcharesponse:struct<responsecode:string,solvetimestamp:string>>>, 
+  `requestheadersinserted` array<struct<name:string,value:string>>, 
   `responsecodesent` string, 
-  `httprequest` struct<
-                    clientip:string,
-                    country:string,
-                    headers:array<
-                                struct<
-                                    name:string,
-                                    value:string
-                                      >
-                                 >,
-                    uri:string,
-                    args:string,
-                    httpversion:string,
-                    httpmethod:string,
-                    requestid:string
-                      >, 
-  `labels` array<
-               struct<
-                   name:string
-                     >
-                >, 
-  `captcharesponse` struct<
-                        responsecode:string,
-                        solvetimestamp:string,
-                        failureReason:string
-                          > 
-)
-ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
-STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'
-OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
-LOCATION '${bucket_location}'
+  `httprequest` struct<clientip:string,country:string,headers:array<struct<name:string,value:string>>,uri:string,args:string,httpversion:string,httpmethod:string,requestid:string,fragment:string,scheme:string,host:string>,
+  `labels` array<struct<name:string>>, 
+  `captcharesponse` struct<responsecode:string,solvetimestamp:string,failurereason:string>, 
+  `challengeresponse` struct<responsecode:string,solvetimestamp:string,failurereason:string>, 
+  `ja3fingerprint` string, 
+  `ja4fingerprint` string, 
+  `oversizefields` string, 
+  `requestbodysize` int, 
+  `requestbodysizeinspectedbywaf` int)
+  PARTITIONED BY ( 
+   `hour` string)
+ROW FORMAT SERDE 
+  'org.openx.data.jsonserde.JsonSerDe' 
+STORED AS INPUTFORMAT 
+  'org.apache.hadoop.mapred.TextInputFormat' 
+OUTPUTFORMAT 
+  'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+LOCATION
+  '${bucket_location}'
+TBLPROPERTIES (
+  'projection.enabled'='true',
+  'projection.hour.format'='yyyy/MM/dd/HH',
+  'projection.hour.interval'='1',
+  'projection.hour.interval.unit'='hours',
+  'projection.hour.range'='2020/01/01/00,NOW',
+  'projection.hour.type'='date',
+  'storage.location.template'='${bucket_location}/${hour}')

--- a/athena_access_logs/sql/waf_create_table.sql
+++ b/athena_access_logs/sql/waf_create_table.sql
@@ -23,7 +23,7 @@ CREATE EXTERNAL TABLE IF NOT EXISTS `${database_name}.${table_name}`(
   `requestbodysize` int, 
   `requestbodysizeinspectedbywaf` int)
   PARTITIONED BY ( 
-   `hour` string)
+   `day` string)
 ROW FORMAT SERDE 
   'org.openx.data.jsonserde.JsonSerDe' 
 STORED AS INPUTFORMAT 
@@ -34,9 +34,9 @@ LOCATION
   '${bucket_location}'
 TBLPROPERTIES (
   'projection.enabled'='true',
-  'projection.hour.format'='yyyy/MM/dd/HH',
-  'projection.hour.interval'='1',
-  'projection.hour.interval.unit'='hours',
-  'projection.hour.range'='2020/01/01/00,NOW',
-  'projection.hour.type'='date',
-  'storage.location.template'='${bucket_location}/${hour}')
+  'projection.day.format'='yyyy/MM/dd',
+  'projection.day.interval'='1',
+  'projection.day.interval.unit'='days',
+  'projection.day.range'='2024/01/01,NOW',
+  'projection.day.type'='date',
+  'storage.location.template'='${bucket_location}/${day}')


### PR DESCRIPTION
# Summary
Update the create table SQL queries to add partitions. This will allow for quicker querying and reduce the chance of getting a HIVE split error in the `waf_ip_blocklist` module when it queries these tables.

# Related
- https://github.com/cds-snc/platform-core-services/issues/978
