### PR TITLE
Add param to set firewall_domain_redirection_action on resolver_dns module

### DIFF
--- a/resolver_dns/README.md
+++ b/resolver_dns/README.md
@@ -13,7 +13,7 @@ No requirements.
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
@@ -23,7 +23,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [aws_cloudwatch_log_group.route53_vpc_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_resource_policy.route53_vpc_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_resource_policy) | resource |
 | [aws_route53_resolver_firewall_domain_list.allowed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_firewall_domain_list) | resource |
@@ -39,7 +39,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_allowed_domains"></a> [allowed\_domains](#input\_allowed\_domains) | (Optional) List of domains to allow through the DNS firewall.  Required if `firewall_enabled` is true. | `list(string)` | <pre>[<br/>  "*."<br/>]</pre> | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |

--- a/resolver_dns/README.md
+++ b/resolver_dns/README.md
@@ -44,7 +44,7 @@ No modules.
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_firewall_enabled"></a> [firewall\_enabled](#input\_firewall\_enabled) | (Optional) Should the resolver DNS firewall be enabled | `bool` | `false` | no |
-| <a name="input_trust_redirection_domain_enabled"></a> [trust\_redirection\_domain\_enabled](#input\_trust\_redirection\_domain\_enabled) | (Optional) When true, sets the firewall_domain_redirection_action to TRUST_REDIRECTION_DOMAIN on the allow rule. When false, each domain in the CNAME redirection chain is checked against the firewall rules. When true, only the originally queried domain is checked and any domains it redirects to are automatically trusted. | `bool` | `false` | no |
+| <a name="input_firewall_domain_redirection_action"></a> [firewall\_domain\_redirection\_action](#input\_firewall\_domain\_redirection\_action) | (Optional) Controls how CNAME redirection chains are evaluated by the allow rule. INSPECT_REDIRECTION_DOMAIN checks every domain in the chain; TRUST_REDIRECTION_DOMAIN only checks the originally queried domain. | `string` | `"INSPECT_REDIRECTION_DOMAIN"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | (Required) The ID of the VPC to associate the query log and firewall with | `string` | n/a | yes |
 
 ## Outputs

--- a/resolver_dns/README.md
+++ b/resolver_dns/README.md
@@ -44,6 +44,7 @@ No modules.
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_firewall_enabled"></a> [firewall\_enabled](#input\_firewall\_enabled) | (Optional) Should the resolver DNS firewall be enabled | `bool` | `false` | no |
+| <a name="input_trust_redirection_domain_enabled"></a> [trust\_redirection\_domain\_enabled](#input\_trust\_redirection\_domain\_enabled) | (Optional) When true, sets the firewall_domain_redirection_action to TRUST_REDIRECTION_DOMAIN on the allow rule. When false, each domain in the CNAME redirection chain is checked against the firewall rules. When true, only the originally queried domain is checked and any domains it redirects to are automatically trusted. | `bool` | `false` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | (Required) The ID of the VPC to associate the query log and firewall with | `string` | n/a | yes |
 
 ## Outputs

--- a/resolver_dns/README.md
+++ b/resolver_dns/README.md
@@ -13,7 +13,7 @@ No requirements.
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
@@ -23,7 +23,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudwatch_log_group.route53_vpc_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_resource_policy.route53_vpc_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_resource_policy) | resource |
 | [aws_route53_resolver_firewall_domain_list.allowed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_firewall_domain_list) | resource |
@@ -39,12 +39,12 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_allowed_domains"></a> [allowed\_domains](#input\_allowed\_domains) | (Optional) List of domains to allow through the DNS firewall.  Required if `firewall_enabled` is true. | `list(string)` | <pre>[<br/>  "*."<br/>]</pre> | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
+| <a name="input_firewall_domain_redirection_action"></a> [firewall\_domain\_redirection\_action](#input\_firewall\_domain\_redirection\_action) | (Optional) Controls how CNAME redirection chains are evaluated by the allow rule. INSPECT\_REDIRECTION\_DOMAIN checks every domain in the chain; TRUST\_REDIRECTION\_DOMAIN only checks the originally queried domain. | `string` | `"INSPECT_REDIRECTION_DOMAIN"` | no |
 | <a name="input_firewall_enabled"></a> [firewall\_enabled](#input\_firewall\_enabled) | (Optional) Should the resolver DNS firewall be enabled | `bool` | `false` | no |
-| <a name="input_firewall_domain_redirection_action"></a> [firewall\_domain\_redirection\_action](#input\_firewall\_domain\_redirection\_action) | (Optional) Controls how CNAME redirection chains are evaluated by the allow rule. INSPECT_REDIRECTION_DOMAIN checks every domain in the chain; TRUST_REDIRECTION_DOMAIN only checks the originally queried domain. | `string` | `"INSPECT_REDIRECTION_DOMAIN"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | (Required) The ID of the VPC to associate the query log and firewall with | `string` | n/a | yes |
 
 ## Outputs

--- a/resolver_dns/input.tf
+++ b/resolver_dns/input.tf
@@ -28,10 +28,15 @@ variable "firewall_enabled" {
   default     = false
 }
 
-variable "trust_redirection_domain_enabled" {
-  description = "(Optional) When true, sets the firewall_domain_redirection_action to TRUST_REDIRECTION_DOMAIN on the allow rule. When false, each domain in the CNAME redirection chain is checked against the firewall rules. When true, only the originally queried domain is checked and any domains it redirects to are automatically trusted."
-  type        = bool
-  default     = false
+variable "firewall_domain_redirection_action" {
+  description = "(Optional) Controls how CNAME redirection chains are evaluated by the allow rule. INSPECT_REDIRECTION_DOMAIN checks every domain in the chain; TRUST_REDIRECTION_DOMAIN only checks the originally queried domain."
+  type        = string
+  default     = "INSPECT_REDIRECTION_DOMAIN"
+
+  validation {
+    condition     = contains(["INSPECT_REDIRECTION_DOMAIN", "TRUST_REDIRECTION_DOMAIN"], var.firewall_domain_redirection_action)
+    error_message = "Valid values are INSPECT_REDIRECTION_DOMAIN and TRUST_REDIRECTION_DOMAIN."
+  }
 }
 
 variable "vpc_id" {

--- a/resolver_dns/input.tf
+++ b/resolver_dns/input.tf
@@ -28,6 +28,12 @@ variable "firewall_enabled" {
   default     = false
 }
 
+variable "trust_redirection_domain_enabled" {
+  description = "(Optional) When true, sets the firewall_domain_redirection_action to TRUST_REDIRECTION_DOMAIN on the allow rule. When false, each domain in the CNAME redirection chain is checked against the firewall rules. When true, only the originally queried domain is checked and any domains it redirects to are automatically trusted."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
   description = "(Required) The ID of the VPC to associate the query log and firewall with"
   type        = string

--- a/resolver_dns/main.tf
+++ b/resolver_dns/main.tf
@@ -81,12 +81,12 @@ resource "aws_route53_resolver_firewall_rule_group" "firewall_rules" {
 resource "aws_route53_resolver_firewall_rule" "allowed" {
   count = var.firewall_enabled ? 1 : 0
 
-  name                              = "AllowedDomains"
-  action                            = "ALLOW"
-  firewall_domain_list_id           = aws_route53_resolver_firewall_domain_list.allowed[0].id
-  firewall_rule_group_id            = aws_route53_resolver_firewall_rule_group.firewall_rules[0].id
-  firewall_domain_redirection_action = var.trust_redirection_domain_enabled ? "TRUST_REDIRECTION_DOMAIN" : "INSPECT_REDIRECTION_DOMAIN"
-  priority                          = 100
+  name                               = "AllowedDomains"
+  action                             = "ALLOW"
+  firewall_domain_list_id            = aws_route53_resolver_firewall_domain_list.allowed[0].id
+  firewall_rule_group_id             = aws_route53_resolver_firewall_rule_group.firewall_rules[0].id
+  firewall_domain_redirection_action = var.firewall_domain_redirection_action
+  priority                           = 100
 }
 
 resource "aws_route53_resolver_firewall_rule" "blocked" {

--- a/resolver_dns/main.tf
+++ b/resolver_dns/main.tf
@@ -81,11 +81,12 @@ resource "aws_route53_resolver_firewall_rule_group" "firewall_rules" {
 resource "aws_route53_resolver_firewall_rule" "allowed" {
   count = var.firewall_enabled ? 1 : 0
 
-  name                    = "AllowedDomains"
-  action                  = "ALLOW"
-  firewall_domain_list_id = aws_route53_resolver_firewall_domain_list.allowed[0].id
-  firewall_rule_group_id  = aws_route53_resolver_firewall_rule_group.firewall_rules[0].id
-  priority                = 100
+  name                              = "AllowedDomains"
+  action                            = "ALLOW"
+  firewall_domain_list_id           = aws_route53_resolver_firewall_domain_list.allowed[0].id
+  firewall_rule_group_id            = aws_route53_resolver_firewall_rule_group.firewall_rules[0].id
+  firewall_domain_redirection_action = var.trust_redirection_domain_enabled ? "TRUST_REDIRECTION_DOMAIN" : "INSPECT_REDIRECTION_DOMAIN"
+  priority                          = 100
 }
 
 resource "aws_route53_resolver_firewall_rule" "blocked" {

--- a/resolver_dns/tests/unit.default.tftest.hcl
+++ b/resolver_dns/tests/unit.default.tftest.hcl
@@ -8,6 +8,52 @@ run "setup" {
   }
 }
 
+run "default_firewall_domain_redirection_action" {
+  command = plan
+
+  variables {
+    vpc_id           = run.setup.vpc_id
+    firewall_enabled = true
+    allowed_domains  = ["canada.ca.", "*.amazonaws.com."]
+  }
+
+  assert {
+    condition     = aws_route53_resolver_firewall_rule.allowed[0].firewall_domain_redirection_action == "INSPECT_REDIRECTION_DOMAIN"
+    error_message = "aws_route53_resolver_firewall_rule.allowed[0].firewall_domain_redirection_action did not match expected value"
+  }
+}
+
+run "trust_redirection_domain" {
+  command = plan
+
+  variables {
+    vpc_id                             = run.setup.vpc_id
+    firewall_enabled                   = true
+    allowed_domains                    = ["canada.ca.", "*.amazonaws.com."]
+    firewall_domain_redirection_action = "TRUST_REDIRECTION_DOMAIN"
+  }
+
+  assert {
+    condition     = aws_route53_resolver_firewall_rule.allowed[0].firewall_domain_redirection_action == "TRUST_REDIRECTION_DOMAIN"
+    error_message = "aws_route53_resolver_firewall_rule.allowed[0].firewall_domain_redirection_action did not match expected value"
+  }
+}
+
+run "invalid_firewall_domain_redirection_action" {
+  command = plan
+
+  variables {
+    vpc_id                             = run.setup.vpc_id
+    firewall_enabled                   = true
+    allowed_domains                    = ["canada.ca.", "*.amazonaws.com."]
+    firewall_domain_redirection_action = "INVALID_VALUE"
+  }
+
+  expect_failures = [
+    var.firewall_domain_redirection_action,
+  ]
+}
+
 run "apply" {
   # Smoke test to validate that the module can successfully be applied
   variables {


### PR DESCRIPTION
# Summary | Résumé

Closes https://github.com/cds-snc/terraform-modules/issues/838

This PR adds necessary configuration to set `firewall_domain_redirection_action` on the `dns_resolver` module.

Setting `firewall_domain_redirection_action ` to `TRUST_REDIRECTION_DOMAIN` will automatically trust domains in the CNAME chain without requiring them each to be in the allowlist. Only the originally queried domain is validated.

The param is optional and defaults to `INSPECT_REDIRECTION_DOMAIN` to maintain backwards compatibility.

# Test instructions | Instructions pour tester la modification

New `resolver_dns` tests were added that exercise the new parameter. Tests are passing in CI.
