### PR TITLE
Add block action parameter to the resolver_dns module

### DIFF
--- a/resolver_dns/README.md
+++ b/resolver_dns/README.md
@@ -43,6 +43,7 @@ No modules.
 | <a name="input_allowed_domains"></a> [allowed\_domains](#input\_allowed\_domains) | (Optional) List of domains to allow through the DNS firewall.  Required if `firewall_enabled` is true. | `list(string)` | <pre>[<br/>  "*."<br/>]</pre> | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
+| <a name="input_block_action"></a> [block\_action](#input\_block\_action) | (Optional) Action to take for blocked domains. BLOCK prevents resolution; ALERT only logs the query without blocking. | `string` | `"BLOCK"` | no |
 | <a name="input_firewall_domain_redirection_action"></a> [firewall\_domain\_redirection\_action](#input\_firewall\_domain\_redirection\_action) | (Optional) Controls how CNAME redirection chains are evaluated by the allow rule. INSPECT\_REDIRECTION\_DOMAIN checks every domain in the chain; TRUST\_REDIRECTION\_DOMAIN only checks the originally queried domain. | `string` | `"INSPECT_REDIRECTION_DOMAIN"` | no |
 | <a name="input_firewall_enabled"></a> [firewall\_enabled](#input\_firewall\_enabled) | (Optional) Should the resolver DNS firewall be enabled | `bool` | `false` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | (Required) The ID of the VPC to associate the query log and firewall with | `string` | n/a | yes |

--- a/resolver_dns/input.tf
+++ b/resolver_dns/input.tf
@@ -22,6 +22,17 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "block_action" {
+  description = "(Optional) Action to take for blocked domains. BLOCK prevents resolution; ALERT only logs the query without blocking."
+  type        = string
+  default     = "BLOCK"
+
+  validation {
+    condition     = contains(["BLOCK", "ALERT"], var.block_action)
+    error_message = "Valid values are BLOCK and ALERT."
+  }
+}
+
 variable "firewall_enabled" {
   description = "(Optional) Should the resolver DNS firewall be enabled"
   type        = bool

--- a/resolver_dns/main.tf
+++ b/resolver_dns/main.tf
@@ -93,8 +93,8 @@ resource "aws_route53_resolver_firewall_rule" "blocked" {
   count = var.firewall_enabled ? 1 : 0
 
   name                    = "BlockedDomains"
-  action                  = "BLOCK"
-  block_response          = "NODATA"
+  action                  = var.block_action
+  block_response          = var.block_action == "BLOCK" ? "NODATA" : null
   firewall_domain_list_id = aws_route53_resolver_firewall_domain_list.blocked[0].id
   firewall_rule_group_id  = aws_route53_resolver_firewall_rule_group.firewall_rules[0].id
   priority                = 200

--- a/resolver_dns/tests/unit.default.tftest.hcl
+++ b/resolver_dns/tests/unit.default.tftest.hcl
@@ -54,6 +54,62 @@ run "invalid_firewall_domain_redirection_action" {
   ]
 }
 
+run "default_block_action" {
+  command = plan
+
+  variables {
+    vpc_id           = run.setup.vpc_id
+    firewall_enabled = true
+    allowed_domains  = ["canada.ca.", "*.amazonaws.com."]
+  }
+
+  assert {
+    condition     = aws_route53_resolver_firewall_rule.blocked[0].action == "BLOCK"
+    error_message = "aws_route53_resolver_firewall_rule.blocked[0].action did not match expected value"
+  }
+
+  assert {
+    condition     = aws_route53_resolver_firewall_rule.blocked[0].block_response == "NODATA"
+    error_message = "aws_route53_resolver_firewall_rule.blocked[0].block_response did not match expected value"
+  }
+}
+
+run "alert_block_action" {
+  command = plan
+
+  variables {
+    vpc_id           = run.setup.vpc_id
+    firewall_enabled = true
+    allowed_domains  = ["canada.ca.", "*.amazonaws.com."]
+    block_action     = "ALERT"
+  }
+
+  assert {
+    condition     = aws_route53_resolver_firewall_rule.blocked[0].action == "ALERT"
+    error_message = "aws_route53_resolver_firewall_rule.blocked[0].action did not match expected value"
+  }
+
+  assert {
+    condition     = aws_route53_resolver_firewall_rule.blocked[0].block_response == null
+    error_message = "aws_route53_resolver_firewall_rule.blocked[0].block_response should be null when block_action is ALERT"
+  }
+}
+
+run "invalid_block_action" {
+  command = plan
+
+  variables {
+    vpc_id           = run.setup.vpc_id
+    firewall_enabled = true
+    allowed_domains  = ["canada.ca.", "*.amazonaws.com."]
+    block_action     = "DENY"
+  }
+
+  expect_failures = [
+    var.block_action,
+  ]
+}
+
 run "apply" {
   # Smoke test to validate that the module can successfully be applied
   variables {


### PR DESCRIPTION
# Summary | Résumé

This PR adds the `block_action` parameter to the `resolver_dns` module. This allows us to configure the firewall to use the `ALERT` action instead of `BLOCK` when rolling out the firewall in an important environment. This lets developers validate that the firewall is accurate and functioning properly before actually enforcing the firewall rules.

# Test instructions | Instructions pour tester la modification

Tests are added and run by CI.
