### PR TITLE
Add allow effect to Route53 resolver logging policy

### DIFF
--- a/resolver_dns/main.tf
+++ b/resolver_dns/main.tf
@@ -20,6 +20,7 @@ resource "aws_cloudwatch_log_group" "route53_vpc_dns" {
 
 data "aws_iam_policy_document" "route53_resolver_logging_policy" {
   statement {
+    effect = "Allow"
     actions = [
       "logs:CreateLogStream",
       "logs:PutLogEvents",


### PR DESCRIPTION
Added effect = "Allow" to IAM policy document to pass CDS OPA security checks.