### PR TITLE
fix: update failed IP lookup to warning

### DIFF
--- a/waf_ip_blocklist/lambda/blocklist.py
+++ b/waf_ip_blocklist/lambda/blocklist.py
@@ -321,7 +321,7 @@ def create_retrying_request(
 
 def gc_ip(ip):
     """Check if IP is owned by Government of Canada"""
-    session = create_retrying_request(total_retries=5, backoff_factor=1)
+    session = create_retrying_request(total_retries=6, backoff_factor=3)
     try:
         api_url = f"https://rdap.arin.net/registry/ip/{ip}"
         logging.info("Checking RDAP ownership for IP %s", ip)
@@ -342,7 +342,9 @@ def gc_ip(ip):
         logging.info("IP %s identified as GC-owned: %s", ip, is_gc_ip)
         return is_gc_ip
     except (urllib.error.URLError, OSError) as e:
-        logging.error(
+        # Updating to warning as this is not preventing a blocklist update and is being caused
+        # by the registry lookup intermittently failing.
+        logging.warning(
             "Could not successfully retrieve information about IP %s: %s",
             ip,
             e,

--- a/waf_ip_blocklist/lambda/blocklist_test.py
+++ b/waf_ip_blocklist/lambda/blocklist_test.py
@@ -417,7 +417,7 @@ def test_gc_ip_success_with_goc_ip(mock_create_session):
 
     # Verify
     assert result is True
-    mock_create_session.assert_called_once_with(total_retries=5, backoff_factor=1)
+    mock_create_session.assert_called_once_with(total_retries=6, backoff_factor=3)
     mock_session.get.assert_called_once_with(
         "https://rdap.arin.net/registry/ip/192.168.1.1", timeout=5
     )
@@ -474,7 +474,7 @@ def test_gc_ip_request_exception(mock_create_session, caplog):
     mock_create_session.return_value = mock_session
 
     # Test
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.WARNING):
         result = blocklist.gc_ip("192.168.1.1")
 
     # Verify


### PR DESCRIPTION
# Summary
Change the logging level severity to `WARNING` when an IP address lookup fails. These are being caused by intermittent failures from the upstream registry service and do not impact the blocklist updates. In an effort to help address these, the retry count and backoff factor have also been increased.
