### PR TITLE
Add core services tags to core services resources in RDS module

### DIFF
--- a/rds/cloudwatch.tf
+++ b/rds/cloudwatch.tf
@@ -4,7 +4,7 @@ resource "aws_cloudwatch_log_group" "proxy" {
   name              = "/aws/rds/proxy/${local.proxy_name}"
   retention_in_days = var.proxy_log_retention_in_days
 
-  tags = merge(local.common_tags, {
+  tags = merge(local.common_tags, local.cbrid_tags, {
     Name = "${var.name}_proxy_logs"
   })
 }
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_log_group" "log_exports" {
   name              = "/aws/rds/cluster/${local.identifier}/${each.value}"
   retention_in_days = var.cloudwatch_log_exports_retention_in_days
 
-  tags = merge(local.common_tags, {
+  tags = merge(local.common_tags, local.cbrid_tags, {
     Name = "${var.name}-cluster"
   })
 }

--- a/rds/locals.tf
+++ b/rds/locals.tf
@@ -19,4 +19,9 @@ locals {
 
   # Configure the database logs that are exported to CloudWatch.  Default to none for MySQL and `postgresql` for Postgres if no values are specified
   enabled_cloudwatch_logs_exports = length(var.enabled_cloudwatch_logs_exports) > 0 ? var.enabled_cloudwatch_logs_exports : (local.is_mysql ? [] : ["postgresql"])
+
+  # Tags required on IAM, Secrets Manager, CloudWatch, and VPC resources
+  cbrid_tags = {
+    ssc_cbrid = "22DH"
+  }
 }

--- a/rds/proxy_role.tf
+++ b/rds/proxy_role.tf
@@ -2,7 +2,7 @@ resource "aws_iam_role" "rds_proxy" {
   count = var.use_proxy ? 1 : 0
 
   name               = "${var.name}_rds_proxy"
-  tags               = local.common_tags
+  tags               = merge(local.common_tags, local.cbrid_tags)
   assume_role_policy = data.aws_iam_policy_document.assume_role[0].json
 }
 
@@ -63,7 +63,7 @@ resource "aws_iam_policy" "read_connection_string" {
   name   = "${var.name}ReadConnectionString"
   path   = "/"
   policy = data.aws_iam_policy_document.read_connection_string[0].json
-  tags   = local.common_tags
+  tags   = merge(local.common_tags, local.cbrid_tags)
 }
 
 resource "aws_iam_role_policy_attachment" "read_connection_string" {

--- a/rds/secret.tf
+++ b/rds/secret.tf
@@ -2,7 +2,7 @@ resource "aws_secretsmanager_secret" "connection_string" {
   count = var.use_proxy ? 1 : 0
 
   name = "${var.name}-${random_string.random.result}"
-  tags = local.common_tags
+  tags = merge(local.common_tags, local.cbrid_tags)
 }
 
 
@@ -22,7 +22,7 @@ resource "aws_secretsmanager_secret" "proxy_connection_string" {
   count = var.use_proxy ? 1 : 0
 
   name = "${var.name}-${random_string.random.result}-proxy-connection-string"
-  tags = local.common_tags
+  tags = merge(local.common_tags, local.cbrid_tags)
 }
 
 resource "aws_secretsmanager_secret_version" "proxy_connection_string" {

--- a/rds/security_group.tf
+++ b/rds/security_group.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "rds" {
 
   description = "The Security group that allows communication between the ${local.security_group_desc_target} and the database"
 
-  tags = merge(local.common_tags, {
+  tags = merge(local.common_tags, local.cbrid_tags, {
     Name = local.security_group_name
   })
 


### PR DESCRIPTION
# Summary | Résumé

Add the core services CBR tag to the appropriate resources in the RDS module. This will be used mostly for testing with the Backstage app to see how the tags are incorporated and I will not merge it until it is ready to be done (ie the procurement is gone through and testing is done)