### PR TITLE
Adding the ssc_cbrid tags to the S3 module for the appropriate resources

### DIFF
--- a/S3/README.md
+++ b/S3/README.md
@@ -48,6 +48,8 @@ No modules.
 | <a name="input_object_lock_configuration"></a> [object\_lock\_configuration](#input\_object\_lock\_configuration) | (Optional, Forces new resource) Map containing S3 object locking configuration. | `any` | `{}` | no |
 | <a name="input_replication_configuration"></a> [replication\_configuration](#input\_replication\_configuration) | (Optional) Map containing cross-region replication configuration. | `any` | `{}` | no |
 | <a name="input_restrict_public_buckets"></a> [restrict\_public\_buckets](#input\_restrict\_public\_buckets) | (Optional, default 'true') Only the bucket owner and AWS Services can access this buckets if it has a public policy. | `bool` | `true` | no |
+| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Required: default 'ssc\_cbrid') The name of the SSC CBRID tag | `string` | `"ssc_cbrid"` | no |
+| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Required: default '22DH') The value of the SSC CBRID tag | `string` | `"22DH"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
 | <a name="input_versioning"></a> [versioning](#input\_versioning) | (Optional) Map containing versioning configuration. | `map(string)` | `{}` | no |
 

--- a/S3/README.md
+++ b/S3/README.md
@@ -48,8 +48,8 @@ No modules.
 | <a name="input_object_lock_configuration"></a> [object\_lock\_configuration](#input\_object\_lock\_configuration) | (Optional, Forces new resource) Map containing S3 object locking configuration. | `any` | `{}` | no |
 | <a name="input_replication_configuration"></a> [replication\_configuration](#input\_replication\_configuration) | (Optional) Map containing cross-region replication configuration. | `any` | `{}` | no |
 | <a name="input_restrict_public_buckets"></a> [restrict\_public\_buckets](#input\_restrict\_public\_buckets) | (Optional, default 'true') Only the bucket owner and AWS Services can access this buckets if it has a public policy. | `bool` | `true` | no |
-| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Required: default 'ssc\_cbrid') The name of the SSC CBRID tag | `string` | `"ssc_cbrid"` | no |
-| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Required: default '22DH') The value of the SSC CBRID tag | `string` | `"22DH"` | no |
+| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Optional) The name of the SSC CBRID tag | `string` | `"ssc_cbrid"` | no |
+| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Optional) The value of the SSC CBRID tag. If null, the SSC CBRID tag will not be applied. | `string` | `"22DH"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
 | <a name="input_versioning"></a> [versioning](#input\_versioning) | (Optional) Map containing versioning configuration. | `map(string)` | `{}` | no |
 

--- a/S3/input.tf
+++ b/S3/input.tf
@@ -18,6 +18,18 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "ssc_cbrid_tag_key" {
+  description = "(Required: default 'ssc_cbrid') The name of the SSC CBRID tag"
+  type        = string
+  default     = "ssc_cbrid"
+}
+
+variable "ssc_cbrid_tag_value" {
+  description = "(Required: default '22DH') The value of the SSC CBRID tag"
+  type        = string
+  default     = "22DH"
+}
+
 variable "critical_tag_key" {
   description = "(Optional) The name of the critical tag."
   type        = string

--- a/S3/input.tf
+++ b/S3/input.tf
@@ -19,13 +19,13 @@ variable "billing_tag_value" {
 }
 
 variable "ssc_cbrid_tag_key" {
-  description = "(Required: default 'ssc_cbrid') The name of the SSC CBRID tag"
+  description = "(Optional) The name of the SSC CBRID tag"
   type        = string
   default     = "ssc_cbrid"
 }
 
 variable "ssc_cbrid_tag_value" {
-  description = "(Required: default '22DH') The value of the SSC CBRID tag"
+  description = "(Optional) The value of the SSC CBRID tag. If null, the SSC CBRID tag will not be applied."
   type        = string
   default     = "22DH"
 }

--- a/S3/locals.tf
+++ b/S3/locals.tf
@@ -1,8 +1,8 @@
 locals {
   common_tags = {
-    (var.billing_tag_key)    = var.billing_tag_value
-    (var.ssc_cbrid_tag_key)  = var.ssc_cbrid_tag_value
-    Terraform                = "true"
-    (var.critical_tag_key)   = var.critical_tag_value ? "true" : "false"
+    (var.billing_tag_key)   = var.billing_tag_value
+    (var.ssc_cbrid_tag_key) = var.ssc_cbrid_tag_value
+    Terraform               = "true"
+    (var.critical_tag_key)  = var.critical_tag_value ? "true" : "false"
   }
 }

--- a/S3/locals.tf
+++ b/S3/locals.tf
@@ -1,8 +1,10 @@
 locals {
-  common_tags = {
-    (var.billing_tag_key)   = var.billing_tag_value
-    (var.ssc_cbrid_tag_key) = var.ssc_cbrid_tag_value
-    Terraform               = "true"
-    (var.critical_tag_key)  = var.critical_tag_value ? "true" : "false"
-  }
+  common_tags = merge(
+    {
+      (var.billing_tag_key)  = var.billing_tag_value
+      Terraform              = "true"
+      (var.critical_tag_key) = var.critical_tag_value ? "true" : "false"
+    },
+    var.ssc_cbrid_tag_value != "" ? { (var.ssc_cbrid_tag_key) = var.ssc_cbrid_tag_value } : {}
+  )
 }

--- a/S3/locals.tf
+++ b/S3/locals.tf
@@ -1,7 +1,8 @@
 locals {
   common_tags = {
-    (var.billing_tag_key)  = var.billing_tag_value
-    Terraform              = "true"
-    (var.critical_tag_key) = var.critical_tag_value ? "true" : "false"
+    (var.billing_tag_key)    = var.billing_tag_value
+    (var.ssc_cbrid_tag_key)  = var.ssc_cbrid_tag_value
+    Terraform                = "true"
+    (var.critical_tag_key)   = var.critical_tag_value ? "true" : "false"
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Adding the ssc_cbrid tag and value of 22DH for any resources in the core services set of infrastructure components. 