### PR TITLE
chore: increase WAF IP Blocklist Lambda function timeout to 15 minutes

### DIFF
--- a/waf_ip_blocklist/main.tf
+++ b/waf_ip_blocklist/main.tf
@@ -45,7 +45,7 @@ resource "aws_lambda_function" "ipv4_blocklist" {
   filename    = data.archive_file.ipv4_blocklist.output_path
   handler     = "blocklist.handler"
   runtime     = "python3.13"
-  timeout     = 300
+  timeout     = 900
   memory_size = 1024
 
   role             = aws_iam_role.ipv4_blocklist.arn


### PR DESCRIPTION
# Summary | Résumé

- Increases WAF IP Blocklist Lambda function timeout from 5 to 15 minutes. If third party services for identifying whether IP addresses belong to SSC are down the logic may need to retry on multiple IPs and exceed the Lambda function timeout.