### PR TITLE
Adding core services tags to the right resources in the attach_tf_plan_policy module

### DIFF
--- a/attach_tf_plan_policy/README.md
+++ b/attach_tf_plan_policy/README.md
@@ -39,6 +39,8 @@ No modules.
 | <a name="input_policy_name"></a> [policy\_name](#input\_policy\_name) | (Optional) The name of the policy that will be attached to the role.<br/>    **Please Note:** This is only needed to be set if the default value conflicts with an existing policy name in this account. | `string` | `"TFPlan"` | no |
 | <a name="input_region"></a> [region](#input\_region) | (Optional) The region the resources are in | `string` | `"ca-central-1"` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | (Required) The name of the role to attach the policy to | `string` | n/a | yes |
+| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Optional) The name of the SSC CBRID tag | `string` | `"ssc_cbrid"` | no |
+| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Optional) The value of the SSC CBRID tag. If empty, the SSC CBRID tag will not be applied. | `string` | `"22DH"` | no |
 
 ## Outputs
 

--- a/attach_tf_plan_policy/input.tf
+++ b/attach_tf_plan_policy/input.tf
@@ -10,6 +10,18 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "ssc_cbrid_tag_key" {
+  description = "(Optional) The name of the SSC CBRID tag"
+  type        = string
+  default     = "ssc_cbrid"
+}
+
+variable "ssc_cbrid_tag_value" {
+  description = "(Optional) The value of the SSC CBRID tag. If empty, the SSC CBRID tag will not be applied."
+  type        = string
+  default     = "22DH"
+}
+
 variable "account_id" {
   description = "(Required) The ID of the AWS account to add permissions for"
   type        = string

--- a/attach_tf_plan_policy/locals.tf
+++ b/attach_tf_plan_policy/locals.tf
@@ -1,8 +1,11 @@
 
 locals {
-  common_tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-    Terraform             = "true"
-  }
+  common_tags = merge(
+    {
+      (var.billing_tag_key) = var.billing_tag_value
+      Terraform             = "true"
+    },
+    var.ssc_cbrid_tag_value != "" ? { (var.ssc_cbrid_tag_key) = var.ssc_cbrid_tag_value } : {}
+  )
 }
 

--- a/attach_tf_plan_policy/main.tf
+++ b/attach_tf_plan_policy/main.tf
@@ -13,6 +13,7 @@ resource "aws_iam_role_policy_attachment" "this" {
 resource "aws_iam_policy" "this" {
   name   = var.policy_name
   policy = data.aws_iam_policy_document.this.json
+  tags   = local.common_tags
 }
 
 data "aws_iam_policy_document" "this" {


### PR DESCRIPTION
# Summary | Résumé

Attaching the necessary ssc_cbrid tags to the module as is now required. 