### PR TITLE
Adding core services tags for the auto revoke security group rules module

### DIFF
--- a/auto_revoke_sg_rules/README.md
+++ b/auto_revoke_sg_rules/README.md
@@ -39,6 +39,8 @@ No modules.
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | (Required) Name of the Lambda function. | `string` | `"security_group_change_auto_response"` | no |
 | <a name="input_sns_topic"></a> [sns\_topic](#input\_sns\_topic) | (Optional, default 'internal-sre-alert') The name of the sns topic to send alerts to | `string` | `"internal-sre-alert"` | no |
+| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Optional) The name of the SSC CBRID tag | `string` | `"ssc_cbrid"` | no |
+| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Optional) The value of the SSC CBRID tag. If empty, the SSC CBRID tag will not be applied. | `string` | `"22DH"` | no |
 
 ## Outputs
 

--- a/auto_revoke_sg_rules/iam.tf
+++ b/auto_revoke_sg_rules/iam.tf
@@ -1,6 +1,6 @@
 # IAM Role for Lambda Function
 resource "aws_iam_role" "group_change_auto_response_role" {
-  name                = "group_change_auto_response_role"
+  name                = "group_change_auto_response_role1"
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/auto_revoke_sg_rules/iam.tf
+++ b/auto_revoke_sg_rules/iam.tf
@@ -1,5 +1,5 @@
 # IAM Role for Lambda Function
-resource "aws_iam_role" "group_change_auto_response_role" {
+resource "aws_iam_role" "group_change_auto_response_role1" {
   name                = "group_change_auto_response_role1"
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
   assume_role_policy = jsonencode({
@@ -21,7 +21,7 @@ resource "aws_iam_role" "group_change_auto_response_role" {
 # IAM Policy for Lambda Function
 resource "aws_iam_role_policy" "security_group_modification" {
   name = "security_group_modification"
-  role = aws_iam_role.group_change_auto_response_role.id
+  role = aws_iam_role.group_change_auto_response_role1.id
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/auto_revoke_sg_rules/iam.tf
+++ b/auto_revoke_sg_rules/iam.tf
@@ -15,6 +15,7 @@ resource "aws_iam_role" "group_change_auto_response_role" {
       },
     ]
   })
+  tags = local.common_tags
 }
 
 # IAM Policy for Lambda Function

--- a/auto_revoke_sg_rules/iam.tf
+++ b/auto_revoke_sg_rules/iam.tf
@@ -1,6 +1,6 @@
 # IAM Role for Lambda Function
-resource "aws_iam_role" "group_change_auto_response_role1" {
-  name                = "group_change_auto_response_role1"
+resource "aws_iam_role" "group_change_auto_response_role" {
+  name                = "group_change_auto_response_role"
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -21,7 +21,7 @@ resource "aws_iam_role" "group_change_auto_response_role1" {
 # IAM Policy for Lambda Function
 resource "aws_iam_role_policy" "security_group_modification" {
   name = "security_group_modification"
-  role = aws_iam_role.group_change_auto_response_role1.id
+  role = aws_iam_role.group_change_auto_response_role.id
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/auto_revoke_sg_rules/input.tf
+++ b/auto_revoke_sg_rules/input.tf
@@ -15,6 +15,18 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "ssc_cbrid_tag_key" {
+  description = "(Optional) The name of the SSC CBRID tag"
+  type        = string
+  default     = "ssc_cbrid"
+}
+
+variable "ssc_cbrid_tag_value" {
+  description = "(Optional) The value of the SSC CBRID tag. If empty, the SSC CBRID tag will not be applied."
+  type        = string
+  default     = "22DH"
+}
+
 variable "function_name" {
   description = "(Required) Name of the Lambda function."
   type        = string

--- a/auto_revoke_sg_rules/locals.tf
+++ b/auto_revoke_sg_rules/locals.tf
@@ -1,8 +1,11 @@
 locals {
-  common_tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-    Terraform             = "true"
-  }
+  common_tags = merge(
+    {
+      (var.billing_tag_key) = var.billing_tag_value
+      Terraform             = "true"
+    },
+    var.ssc_cbrid_tag_value != "" ? { (var.ssc_cbrid_tag_key) = var.ssc_cbrid_tag_value } : {}
+  )
   account_id = data.aws_caller_identity.current.account_id
   region     = data.aws_region.current.name
 }

--- a/auto_revoke_sg_rules/main.tf
+++ b/auto_revoke_sg_rules/main.tf
@@ -37,7 +37,7 @@ resource "aws_lambda_function" "security_group_change_auto_response" {
     }
   }
   depends_on = [
-    aws_iam_role.group_change_auto_response_role
+    aws_iam_role.group_change_auto_response_role1
   ]
 }
 

--- a/auto_revoke_sg_rules/main.tf
+++ b/auto_revoke_sg_rules/main.tf
@@ -49,6 +49,7 @@ resource "aws_cloudwatch_event_rule" "sg_change_auto_response_event_rule" {
   name          = "security_group_change_auto_response"
   description   = "Responds to security group change events"
   is_enabled    = true
+  tags          = local.common_tags
   event_pattern = <<PATTERN
     {
         "detail-type": [

--- a/auto_revoke_sg_rules/main.tf
+++ b/auto_revoke_sg_rules/main.tf
@@ -20,7 +20,7 @@ data "archive_file" "sg_change_auto_response" {
 resource "aws_lambda_function" "security_group_change_auto_response" {
   function_name = var.function_name
   description   = "Responds to security group changes"
-  role          = aws_iam_role.group_change_auto_response_role1.arn
+  role          = aws_iam_role.group_change_auto_response_role.arn
   handler       = "sg_change_auto_response.lambda_handler"
   runtime       = "python3.13"
   timeout       = 60
@@ -37,7 +37,7 @@ resource "aws_lambda_function" "security_group_change_auto_response" {
     }
   }
   depends_on = [
-    aws_iam_role.group_change_auto_response_role1
+    aws_iam_role.group_change_auto_response_role 
   ]
 }
 

--- a/auto_revoke_sg_rules/main.tf
+++ b/auto_revoke_sg_rules/main.tf
@@ -37,7 +37,7 @@ resource "aws_lambda_function" "security_group_change_auto_response" {
     }
   }
   depends_on = [
-    aws_iam_role.group_change_auto_response_role 
+    aws_iam_role.group_change_auto_response_role
   ]
 }
 

--- a/auto_revoke_sg_rules/main.tf
+++ b/auto_revoke_sg_rules/main.tf
@@ -20,7 +20,7 @@ data "archive_file" "sg_change_auto_response" {
 resource "aws_lambda_function" "security_group_change_auto_response" {
   function_name = var.function_name
   description   = "Responds to security group changes"
-  role          = aws_iam_role.group_change_auto_response_role.arn
+  role          = aws_iam_role.group_change_auto_response_role1.arn
   handler       = "sg_change_auto_response.lambda_handler"
   runtime       = "python3.13"
   timeout       = 60


### PR DESCRIPTION
# Summary | Résumé

Adding core services tags to the appropriate resources in the auto revoke security group rules. 