### PR TITLE
Adding core services cbrid tags for the codebuild runner module

### DIFF
--- a/codebuild_github_runner/README.md
+++ b/codebuild_github_runner/README.md
@@ -52,8 +52,6 @@ No modules.
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_build_timeout"></a> [build\_timeout](#input\_build\_timeout) | (Optional, default '30') Build timeout for the CodeBuild project. | `number` | `30` | no |
-| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Optional) The name of the SSC CBRID tag | `string` | `"ssc_cbrid"` | no |
-| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Optional) The value of the SSC CBRID tag. If empty, the SSC CBRID tag will not be applied. | `string` | `"22DH"` | no |
 | <a name="input_environment_compute_type"></a> [environment\_compute\_type](#input\_environment\_compute\_type) | (Optional, default 'BUILD\_GENERAL1\_SMALL') Compute type for the CodeBuild environment. | `string` | `"BUILD_GENERAL1_SMALL"` | no |
 | <a name="input_environment_image"></a> [environment\_image](#input\_environment\_image) | (Optional, default 'aws/codebuild/amazonlinux2-x86\_64-standard:5.0') Image for the CodeBuild environment. | `string` | `"aws/codebuild/amazonlinux2-x86_64-standard:5.0"` | no |
 | <a name="input_environment_image_pull_credentials_type"></a> [environment\_image\_pull\_credentials\_type](#input\_environment\_image\_pull\_credentials\_type) | (Optional, default 'CODEBUILD') Image pull credentials type for the CodeBuild environment. | `string` | `"CODEBUILD"` | no |
@@ -64,6 +62,8 @@ No modules.
 | <a name="input_github_repository_url"></a> [github\_repository\_url](#input\_github\_repository\_url) | (Required) GitHub repository URL for the CodeBuild source. | `string` | n/a | yes |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | (Required) Name of the CodeBuild project. | `string` | n/a | yes |
 | <a name="input_queued_timeout"></a> [queued\_timeout](#input\_queued\_timeout) | (Optional, default '5') Queued timeout for the CodeBuild project. | `number` | `5` | no |
+| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Optional) The name of the SSC CBRID tag | `string` | `"ssc_cbrid"` | no |
+| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Optional) The value of the SSC CBRID tag. If empty, the SSC CBRID tag will not be applied. | `string` | `"22DH"` | no |
 
 ## Outputs
 

--- a/codebuild_github_runner/README.md
+++ b/codebuild_github_runner/README.md
@@ -52,6 +52,8 @@ No modules.
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_build_timeout"></a> [build\_timeout](#input\_build\_timeout) | (Optional, default '30') Build timeout for the CodeBuild project. | `number` | `30` | no |
+| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Optional) The name of the SSC CBRID tag | `string` | `"ssc_cbrid"` | no |
+| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Optional) The value of the SSC CBRID tag. If empty, the SSC CBRID tag will not be applied. | `string` | `"22DH"` | no |
 | <a name="input_environment_compute_type"></a> [environment\_compute\_type](#input\_environment\_compute\_type) | (Optional, default 'BUILD\_GENERAL1\_SMALL') Compute type for the CodeBuild environment. | `string` | `"BUILD_GENERAL1_SMALL"` | no |
 | <a name="input_environment_image"></a> [environment\_image](#input\_environment\_image) | (Optional, default 'aws/codebuild/amazonlinux2-x86\_64-standard:5.0') Image for the CodeBuild environment. | `string` | `"aws/codebuild/amazonlinux2-x86_64-standard:5.0"` | no |
 | <a name="input_environment_image_pull_credentials_type"></a> [environment\_image\_pull\_credentials\_type](#input\_environment\_image\_pull\_credentials\_type) | (Optional, default 'CODEBUILD') Image pull credentials type for the CodeBuild environment. | `string` | `"CODEBUILD"` | no |

--- a/codebuild_github_runner/iam.tf
+++ b/codebuild_github_runner/iam.tf
@@ -1,6 +1,7 @@
 resource "aws_iam_role" "this" {
   name               = "CodeBuildRunner-${var.project_name}"
   assume_role_policy = data.aws_iam_policy_document.this_assume.json
+  tags               = local.common_tags
 }
 
 resource "aws_iam_role_policy" "this" {

--- a/codebuild_github_runner/input.tf
+++ b/codebuild_github_runner/input.tf
@@ -9,6 +9,18 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "ssc_cbrid_tag_key" {
+  description = "(Optional) The name of the SSC CBRID tag"
+  type        = string
+  default     = "ssc_cbrid"
+}
+
+variable "ssc_cbrid_tag_value" {
+  description = "(Optional) The value of the SSC CBRID tag. If empty, the SSC CBRID tag will not be applied."
+  type        = string
+  default     = "22DH"
+}
+
 variable "build_timeout" {
   description = "(Optional, default '30') Build timeout for the CodeBuild project."
   type        = number

--- a/codebuild_github_runner/locals.tf
+++ b/codebuild_github_runner/locals.tf
@@ -2,9 +2,12 @@
 locals {
   is_github_codeconnection = var.github_codeconnection_name != ""
   is_github_pat            = var.github_personal_access_token != ""
-  common_tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-    Terraform             = "true"
-  }
+  common_tags = merge(
+    {
+      (var.billing_tag_key) = var.billing_tag_value
+      Terraform             = "true"
+    },
+    var.ssc_cbrid_tag_value != "" ? { (var.ssc_cbrid_tag_key) = var.ssc_cbrid_tag_value } : {}
+  )
 }
 

--- a/codebuild_github_runner/main.tf
+++ b/codebuild_github_runner/main.tf
@@ -99,4 +99,5 @@ resource "aws_codebuild_webhook" "this" {
 resource "aws_cloudwatch_log_group" "this" {
   name              = "/aws/codebuild/${var.project_name}"
   retention_in_days = "14"
+  tags              = local.common_tags
 }


### PR DESCRIPTION
# Summary | Résumé

Adding core services cbrid tags to the appropriate resources. 