### PR TITLE
Adding ssc cbrid tags to the core services components for the empty log alarm

### DIFF
--- a/empty_log_group_alarm/README.md
+++ b/empty_log_group_alarm/README.md
@@ -46,7 +46,7 @@ No modules.
 | <a name="input_alarm_sns_topic_arn"></a> [alarm\_sns\_topic\_arn](#input\_alarm\_sns\_topic\_arn) | (Required) The ARN to send the alarm to | `string` | n/a | yes |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
-| <a name="input_log_group_names"></a> [log\_group\_names](#input\_log\_group\_names) | (Required) The list of log group names to monitor | `list(string)` | `[]` | yes |
+| <a name="input_log_group_names"></a> [log\_group\_names](#input\_log\_group\_names) | (Required) The list of log group names to monitor | `list(string)` | n/a | yes |
 | <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Optional) The name of the SSC CBRID tag | `string` | `"ssc_cbrid"` | no |
 | <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Optional) The value of the SSC CBRID tag. If empty, the SSC CBRID tag will not be applied. | `string` | `"22DH"` | no |
 | <a name="input_time_period_minutes"></a> [time\_period\_minutes](#input\_time\_period\_minutes) | (Optional, default 5) The time period in minutes to check for incoming logs | `number` | `5` | no |

--- a/empty_log_group_alarm/README.md
+++ b/empty_log_group_alarm/README.md
@@ -47,6 +47,8 @@ No modules.
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_log_group_names"></a> [log\_group\_names](#input\_log\_group\_names) | (Required) The list of log group names to monitor | `list(string)` | `[]` | no |
+| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Optional) The name of the SSC CBRID tag | `string` | `"ssc_cbrid"` | no |
+| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Optional) The value of the SSC CBRID tag. If empty, the SSC CBRID tag will not be applied. | `string` | `"22DH"` | no |
 | <a name="input_time_period_minutes"></a> [time\_period\_minutes](#input\_time\_period\_minutes) | (Optional, default 5) The time period in minutes to check for incoming logs | `number` | `5` | no |
 | <a name="input_use_anomaly_detection"></a> [use\_anomaly\_detection](#input\_use\_anomaly\_detection) | n/a | `bool` | `false` | no |
 

--- a/empty_log_group_alarm/README.md
+++ b/empty_log_group_alarm/README.md
@@ -46,7 +46,7 @@ No modules.
 | <a name="input_alarm_sns_topic_arn"></a> [alarm\_sns\_topic\_arn](#input\_alarm\_sns\_topic\_arn) | (Required) The ARN to send the alarm to | `string` | n/a | yes |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
-| <a name="input_log_group_names"></a> [log\_group\_names](#input\_log\_group\_names) | (Required) The list of log group names to monitor | `list(string)` | `[]` | no |
+| <a name="input_log_group_names"></a> [log\_group\_names](#input\_log\_group\_names) | (Required) The list of log group names to monitor | `list(string)` | `[]` | yes |
 | <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Optional) The name of the SSC CBRID tag | `string` | `"ssc_cbrid"` | no |
 | <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Optional) The value of the SSC CBRID tag. If empty, the SSC CBRID tag will not be applied. | `string` | `"22DH"` | no |
 | <a name="input_time_period_minutes"></a> [time\_period\_minutes](#input\_time\_period\_minutes) | (Optional, default 5) The time period in minutes to check for incoming logs | `number` | `5` | no |

--- a/empty_log_group_alarm/input.tf
+++ b/empty_log_group_alarm/input.tf
@@ -30,7 +30,6 @@ variable "ssc_cbrid_tag_value" {
 variable "log_group_names" {
   description = "(Required) The list of log group names to monitor"
   type        = list(string)
-  default     = []
 }
 
 variable "time_period_minutes" {

--- a/empty_log_group_alarm/input.tf
+++ b/empty_log_group_alarm/input.tf
@@ -15,6 +15,18 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "ssc_cbrid_tag_key" {
+  description = "(Optional) The name of the SSC CBRID tag"
+  type        = string
+  default     = "ssc_cbrid"
+}
+
+variable "ssc_cbrid_tag_value" {
+  description = "(Optional) The value of the SSC CBRID tag. If empty, the SSC CBRID tag will not be applied."
+  type        = string
+  default     = "22DH"
+}
+
 variable "log_group_names" {
   description = "(Required) The list of log group names to monitor"
   type        = list(string)

--- a/empty_log_group_alarm/locals.tf
+++ b/empty_log_group_alarm/locals.tf
@@ -1,8 +1,11 @@
 
 locals {
-  common_tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-    Terraform             = "true"
-  }
+  common_tags = merge(
+    {
+      (var.billing_tag_key) = var.billing_tag_value
+      Terraform             = "true"
+    },
+    var.ssc_cbrid_tag_value != "" ? { (var.ssc_cbrid_tag_key) = var.ssc_cbrid_tag_value } : {}
+  )
 }
 

--- a/empty_log_group_alarm/main.tf
+++ b/empty_log_group_alarm/main.tf
@@ -67,6 +67,14 @@ resource "aws_cloudwatch_metric_alarm" "empty_log_group_metric_alarm_using_anoma
       stat        = "Sum"
     }
   }
+  metric_query {
+    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
+    id          = "ad1"
+    label       = "IncomingLogEvents (expected)"
+    period      = 0
+    return_data = true
+  }
+
   alarm_actions             = [var.alarm_sns_topic_arn]
   insufficient_data_actions = [var.alarm_sns_topic_arn]
   ok_actions                = [var.alarm_sns_topic_arn]

--- a/empty_log_group_alarm/main.tf
+++ b/empty_log_group_alarm/main.tf
@@ -36,6 +36,8 @@ resource "aws_cloudwatch_metric_alarm" "empty_log_group_metric_alarm" {
 
   alarm_description = "Alarm when there are no incoming log events for ${var.time_period_minutes} minutes"
 
+  tags = local.common_tags
+
   alarm_actions             = [var.alarm_sns_topic_arn]
   insufficient_data_actions = [var.alarm_sns_topic_arn]
   ok_actions                = [var.alarm_sns_topic_arn]
@@ -65,15 +67,9 @@ resource "aws_cloudwatch_metric_alarm" "empty_log_group_metric_alarm_using_anoma
       stat        = "Sum"
     }
   }
-  metric_query {
-    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
-    id          = "ad1"
-    label       = "IncomingLogEvents (expected)"
-    period      = 0
-    return_data = true
-  }
-
   alarm_actions             = [var.alarm_sns_topic_arn]
   insufficient_data_actions = [var.alarm_sns_topic_arn]
   ok_actions                = [var.alarm_sns_topic_arn]
+
+  tags = local.common_tags
 }


### PR DESCRIPTION
# Summary | Résumé

Adding ssc_cbrid tags to the core services components. 