### PR TITLE
Adding core services ssc cbr id tags to the exposed iam credentials module

### DIFF
--- a/exposed_iam_credentials_disabler/README.md
+++ b/exposed_iam_credentials_disabler/README.md
@@ -42,6 +42,8 @@ No modules.
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | (Required) Name of the Lambda function. | `string` | `"DisableExposedIAMCredential"` | no |
+| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Optional, default 'ssc_cbrid') The tag key for the SSC CBRID | `string` | `"ssc_cbrid"` | no |
+| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Optional) The value of the SSC CBRID tag | `string` | `"22DH"` | no |
 
 ## Outputs
 

--- a/exposed_iam_credentials_disabler/iam.tf
+++ b/exposed_iam_credentials_disabler/iam.tf
@@ -1,12 +1,16 @@
 resource "aws_iam_role" "disable_exposed_iam_credential_lambda" {
   name               = "DisableExposedIAMCredentialLambda-${var.function_name}"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_policy.json
+
+  tags = local.common_tags
 }
 
 resource "aws_iam_policy" "disable_exposed_iam_credential_lambda" {
   name   = "DisableExposedIAMCredentialLambda-${var.function_name}"
   path   = "/"
   policy = data.aws_iam_policy_document.disable_exposed_iam_credential_lambda.json
+
+  tags = local.common_tags
 }
 
 resource "aws_iam_role_policy_attachment" "disable_exposed_iam_credential_lambda" {

--- a/exposed_iam_credentials_disabler/input.tf
+++ b/exposed_iam_credentials_disabler/input.tf
@@ -10,6 +10,18 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "ssc_cbrid_tag_key" {
+  description = "(Optional, default 'ssc_cbrid') The tag key for the SSC CBRID"
+  type        = string
+  default     = "ssc_cbrid"
+}
+
+variable "ssc_cbrid_tag_value" {
+  description = "(Optional) The value of the SSC CBRID tag"
+  type        = string
+  default     = "22DH"
+}
+
 variable "function_name" {
   description = "(Required) Name of the Lambda function."
   type        = string

--- a/exposed_iam_credentials_disabler/locals.tf
+++ b/exposed_iam_credentials_disabler/locals.tf
@@ -1,6 +1,9 @@
 locals {
-  common_tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-    Terraform             = "true"
-  }
+  common_tags = merge(
+    {
+      (var.billing_tag_key) = var.billing_tag_value
+      Terraform             = "true"
+    },
+    var.ssc_cbrid_tag_value != "" ? { (var.ssc_cbrid_tag_key) = var.ssc_cbrid_tag_value } : {}
+  )
 }

--- a/exposed_iam_credentials_disabler/main.tf
+++ b/exposed_iam_credentials_disabler/main.tf
@@ -59,6 +59,8 @@ resource "aws_cloudwatch_event_rule" "exposed_iam_credential_found_rule" {
         }
     }
 PATTERN
+
+  tags = local.common_tags
 }
 
 resource "aws_lambda_permission" "disable_exposed_iam_credential_events" {
@@ -83,7 +85,5 @@ resource "aws_cloudwatch_log_group" "disable_exposed_iam_credential_lambda" {
   name              = "/aws/lambda/${var.function_name}"
   retention_in_days = "14"
 
-  tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-  }
+  tags = local.common_tags
 }


### PR DESCRIPTION
# Summary | Résumé

Adding ssc cbr core services tags to the exposed iam credentials disabler module. 