### PR TITLE
Adding ssc cbr id tags to core services components in the guardduty module

### DIFF
--- a/guardduty/README.md
+++ b/guardduty/README.md
@@ -36,6 +36,8 @@ No modules.
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | The AWS organization to enable GuardDuty in. | `string` | n/a | yes |
 | <a name="input_publishing_bucket_arn"></a> [publishing\_bucket\_arn](#input\_publishing\_bucket\_arn) | (Required) The ARN of the S3 bucket to publish findings to | `string` | n/a | yes |
 | <a name="input_publishing_frequency"></a> [publishing\_frequency](#input\_publishing\_frequency) | Specifies the frequency of notifications sent for subsequent finding occurrences. | `string` | `"FIFTEEN_MINUTES"` | no |
+| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Optional, default 'ssc\_cbrid') The tag key for the SSC CBRID | `string` | `"ssc_cbrid"` | no |
+| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Optional) The value of the SSC CBRID tag | `string` | `"22DH"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Key-value map of resource tags. If configured with a provider default\_tags configuration block present,<br/>  tags with matching keys will overwrite those defined at the provider-level." | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/guardduty/input.tf
+++ b/guardduty/input.tf
@@ -10,6 +10,18 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "ssc_cbrid_tag_key" {
+  description = "(Optional, default 'ssc_cbrid') The tag key for the SSC CBRID"
+  type        = string
+  default     = "ssc_cbrid"
+}
+
+variable "ssc_cbrid_tag_value" {
+  description = "(Optional) The value of the SSC CBRID tag"
+  type        = string
+  default     = "22DH"
+}
+
 variable "delegated_admin_account_id" {
   description = "The account id of the delegated admin."
   type        = string

--- a/guardduty/locals.tf
+++ b/guardduty/locals.tf
@@ -1,10 +1,11 @@
 
 locals {
-  common_tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-    Terraform             = "true"
-  }
-
-  # tags = merge(var.tags, common_tags)
+  common_tags = merge(
+    {
+      (var.billing_tag_key) = var.billing_tag_value
+      Terraform             = "true"
+    },
+    var.ssc_cbrid_tag_value != "" ? { (var.ssc_cbrid_tag_key) = var.ssc_cbrid_tag_value } : {}
+  )
 }
 


### PR DESCRIPTION
# Summary | Résumé

Adding ssc cbr tags to the core services components in the guarduty module. 