### PR TITLE
Adding ssc cbr tags to core services components for guardduty_malware_s3 module

### DIFF
--- a/guardduty_malware_s3/README.md
+++ b/guardduty_malware_s3/README.md
@@ -48,6 +48,8 @@ No modules.
 | <a name="input_billing_tag_value"></a> [billing\_tag\_value](#input\_billing\_tag\_value) | (Required) The value of the billing tag | `string` | n/a | yes |
 | <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | (Required) The name of the S3 bucket to scan objects in. | `string` | n/a | yes |
 | <a name="input_s3_object_prefixes"></a> [s3\_object\_prefixes](#input\_s3\_object\_prefixes) | (Optional) List of object prefixes to include. If empty, all objects are included. | `list(string)` | `[]` | no |
+| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Optional, default 'ssc\_cbrid') The tag key for the SSC CBRID | `string` | `"ssc_cbrid"` | no |
+| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Optional) The value of the SSC CBRID tag | `string` | `"22DH"` | no |
 | <a name="input_tagging_status"></a> [tagging\_status](#input\_tagging\_status) | (Optional, default 'ENABLED') Whether object tagging is enabled for malware findings. | `string` | `"ENABLED"` | no |
 
 ## Outputs

--- a/guardduty_malware_s3/cloudwatch.tf
+++ b/guardduty_malware_s3/cloudwatch.tf
@@ -19,6 +19,8 @@ resource "aws_cloudwatch_metric_alarm" "malware_completed_scan_count" {
 
   alarm_actions = var.alarm_sns_topic_alarm_arn != null ? [var.alarm_sns_topic_alarm_arn] : []
   ok_actions    = var.alarm_sns_topic_ok_arn != null ? [var.alarm_sns_topic_ok_arn] : []
+
+  tags = local.common_tags
 }
 
 resource "aws_cloudwatch_metric_alarm" "malware_completed_scan_bytes" {
@@ -42,4 +44,6 @@ resource "aws_cloudwatch_metric_alarm" "malware_completed_scan_bytes" {
 
   alarm_actions = var.alarm_sns_topic_alarm_arn != null ? [var.alarm_sns_topic_alarm_arn] : []
   ok_actions    = var.alarm_sns_topic_ok_arn != null ? [var.alarm_sns_topic_ok_arn] : []
+
+  tags = local.common_tags
 }

--- a/guardduty_malware_s3/input.tf
+++ b/guardduty_malware_s3/input.tf
@@ -40,6 +40,18 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "ssc_cbrid_tag_key" {
+  description = "(Optional, default 'ssc_cbrid') The tag key for the SSC CBRID"
+  type        = string
+  default     = "ssc_cbrid"
+}
+
+variable "ssc_cbrid_tag_value" {
+  description = "(Optional) The value of the SSC CBRID tag"
+  type        = string
+  default     = "22DH"
+}
+
 variable "s3_bucket_name" {
   description = "(Required) The name of the S3 bucket to scan objects in."
   type        = string

--- a/guardduty_malware_s3/locals.tf
+++ b/guardduty_malware_s3/locals.tf
@@ -6,9 +6,12 @@ locals {
   s3_bucket_arn = "arn:aws:s3:::${var.s3_bucket_name}"
   region        = data.aws_region.current.name
   account_id    = data.aws_caller_identity.current.account_id
-  common_tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-    Terraform             = "true"
-  }
+  common_tags = merge(
+    {
+      (var.billing_tag_key) = var.billing_tag_value
+      Terraform             = "true"
+    },
+    var.ssc_cbrid_tag_value != "" ? { (var.ssc_cbrid_tag_key) = var.ssc_cbrid_tag_value } : {}
+  )
 }
 


### PR DESCRIPTION
# Summary | Résumé

Adding ssc cbr tags to the appropriate core services components.  