### PR TITLE
Adding core services tags to lambda schedules module

### DIFF
--- a/lambda_schedule/README.md
+++ b/lambda_schedule/README.md
@@ -51,6 +51,8 @@ No requirements.
 | <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | (Optional, default 15 seconds) The timeout for the Lambda function in seconds | `number` | `15` | no |
 | <a name="input_lambda_vpc_config"></a> [lambda\_vpc\_config](#input\_lambda\_vpc\_config) | (Optional, default null) VPC configuration for the Lambda function | <pre>object({<br/>    subnet_ids         = list(string)<br/>    security_group_ids = list(string)<br/>  })</pre> | <pre>{<br/>  "security_group_ids": [],<br/>  "subnet_ids": []<br/>}</pre> | no |
 | <a name="input_s3_arn_write_path"></a> [s3\_arn\_write\_path](#input\_s3\_arn\_write\_path) | (Optional, default null) The ARN of the S3 bucket path to allow write access to.  This sould be in the format 'arn:aws:s3:::bucket-name/path/*' | `string` | `null` | no |
+| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input_ssc_cbrid_tag_key) | (Optional, default 'ssc_cbrid') The tag key for the SSC CBRID | `string` | `"ssc_cbrid"` | no |
+| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input_ssc_cbrid_tag_value) | (Optional) The value of the SSC CBRID tag | `string` | `"22DH"` | no |
 
 ## Outputs
 

--- a/lambda_schedule/README.md
+++ b/lambda_schedule/README.md
@@ -51,8 +51,8 @@ No requirements.
 | <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | (Optional, default 15 seconds) The timeout for the Lambda function in seconds | `number` | `15` | no |
 | <a name="input_lambda_vpc_config"></a> [lambda\_vpc\_config](#input\_lambda\_vpc\_config) | (Optional, default null) VPC configuration for the Lambda function | <pre>object({<br/>    subnet_ids         = list(string)<br/>    security_group_ids = list(string)<br/>  })</pre> | <pre>{<br/>  "security_group_ids": [],<br/>  "subnet_ids": []<br/>}</pre> | no |
 | <a name="input_s3_arn_write_path"></a> [s3\_arn\_write\_path](#input\_s3\_arn\_write\_path) | (Optional, default null) The ARN of the S3 bucket path to allow write access to.  This sould be in the format 'arn:aws:s3:::bucket-name/path/*' | `string` | `null` | no |
-| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input_ssc_cbrid_tag_key) | (Optional, default 'ssc_cbrid') The tag key for the SSC CBRID | `string` | `"ssc_cbrid"` | no |
-| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input_ssc_cbrid_tag_value) | (Optional) The value of the SSC CBRID tag | `string` | `"22DH"` | no |
+| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Optional, default 'ssc\_cbrid') The tag key for the SSC CBRID | `string` | `"ssc_cbrid"` | no |
+| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Optional) The value of the SSC CBRID tag | `string` | `"22DH"` | no |
 
 ## Outputs
 

--- a/lambda_schedule/ecr.tf
+++ b/lambda_schedule/ecr.tf
@@ -8,7 +8,10 @@ resource "aws_ecr_repository" "this" {
     scan_on_push = true
   }
 
-  tags = local.common_tags
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = "true"
+  }
 }
 
 resource "aws_ecr_lifecycle_policy" "this" {

--- a/lambda_schedule/input.tf
+++ b/lambda_schedule/input.tf
@@ -9,6 +9,18 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "ssc_cbrid_tag_key" {
+  description = "(Optional, default 'ssc_cbrid') The tag key for the SSC CBRID"
+  type        = string
+  default     = "ssc_cbrid"
+}
+
+variable "ssc_cbrid_tag_value" {
+  description = "(Optional) The value of the SSC CBRID tag"
+  type        = string
+  default     = "22DH"
+}
+
 variable "create_ecr_repository" {
   description = "(Optional, default true) Whether to create an ECR repository for the Lambda image"
   type        = bool

--- a/lambda_schedule/locals.tf
+++ b/lambda_schedule/locals.tf
@@ -1,9 +1,11 @@
-
 locals {
-  common_tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-    Terraform             = "true"
-  }
+  common_tags = merge(
+    {
+      (var.billing_tag_key) = var.billing_tag_value
+      Terraform             = "true"
+    },
+    var.ssc_cbrid_tag_value != "" ? { (var.ssc_cbrid_tag_key) = var.ssc_cbrid_tag_value } : {}
+  )
   lambda_ecr_arn   = var.create_ecr_repository ? aws_ecr_repository.this[0].arn : var.lambda_ecr_arn
   lambda_image_uri = "${var.create_ecr_repository ? aws_ecr_repository.this[0].repository_url : var.lambda_image_uri}:${var.lambda_image_tag}"
   policies         = var.s3_arn_write_path != null ? concat(var.lambda_policies, [data.aws_iam_policy_document.s3_write[0].json]) : var.lambda_policies

--- a/lambda_schedule/main.tf
+++ b/lambda_schedule/main.tf
@@ -8,7 +8,7 @@
 
 module "this_lambda" {
   #source = "github.com/cds-snc/terraform-modules//lambda?ref=v10.11.4"
-  source = "github.com/cds-snc/terraform-modules//lambda?ref=feat/add_core_services_tags_lambda"
+  source = "github.com/cds-snc/terraform-modules//lambda?ref=feat%2Fadd_core_services_tags_lambda"
 
   name      = var.lambda_name
   image_uri = local.lambda_image_uri

--- a/lambda_schedule/main.tf
+++ b/lambda_schedule/main.tf
@@ -7,8 +7,7 @@
 */
 
 module "this_lambda" {
-  #source = "github.com/cds-snc/terraform-modules//lambda?ref=v10.11.4"
-  source = "github.com/cds-snc/terraform-modules//lambda?ref=feat%2Fadd_core_services_tags_lambda"
+  source = "github.com/cds-snc/terraform-modules//lambda?ref=v10.11.4"
 
   name      = var.lambda_name
   image_uri = local.lambda_image_uri

--- a/lambda_schedule/main.tf
+++ b/lambda_schedule/main.tf
@@ -7,7 +7,8 @@
 */
 
 module "this_lambda" {
-  source = "github.com/cds-snc/terraform-modules//lambda?ref=v10.11.4"
+  #source = "github.com/cds-snc/terraform-modules//lambda?ref=v10.11.4"
+  source = "github.com/cds-snc/terraform-modules//lambda?ref=feat/add_core_services_tags_lambda"
 
   name      = var.lambda_name
   image_uri = local.lambda_image_uri


### PR DESCRIPTION
# Summary | Résumé

Adding core services tags to the lambda schedule module. 
