### PR TITLE
Adding ssc cbrid core services tags to the resolver_dns module 

### DIFF
--- a/resolver_dns/README.md
+++ b/resolver_dns/README.md
@@ -46,6 +46,8 @@ No modules.
 | <a name="input_block_action"></a> [block\_action](#input\_block\_action) | (Optional) Action to take for blocked domains. BLOCK prevents resolution; ALERT only logs the query without blocking. | `string` | `"BLOCK"` | no |
 | <a name="input_firewall_domain_redirection_action"></a> [firewall\_domain\_redirection\_action](#input\_firewall\_domain\_redirection\_action) | (Optional) Controls how CNAME redirection chains are evaluated by the allow rule. INSPECT\_REDIRECTION\_DOMAIN checks every domain in the chain; TRUST\_REDIRECTION\_DOMAIN only checks the originally queried domain. | `string` | `"INSPECT_REDIRECTION_DOMAIN"` | no |
 | <a name="input_firewall_enabled"></a> [firewall\_enabled](#input\_firewall\_enabled) | (Optional) Should the resolver DNS firewall be enabled | `bool` | `false` | no |
+| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Optional, default 'ssc\_cbrid') The tag key for the SSC CBRID | `string` | `"ssc_cbrid"` | no |
+| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Optional) The value of the SSC CBRID tag | `string` | `"22DH"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | (Required) The ID of the VPC to associate the query log and firewall with | `string` | n/a | yes |
 
 ## Outputs

--- a/resolver_dns/input.tf
+++ b/resolver_dns/input.tf
@@ -22,6 +22,18 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "ssc_cbrid_tag_key" {
+  description = "(Optional, default 'ssc_cbrid') The tag key for the SSC CBRID"
+  type        = string
+  default     = "ssc_cbrid"
+}
+
+variable "ssc_cbrid_tag_value" {
+  description = "(Optional) The value of the SSC CBRID tag"
+  type        = string
+  default     = "22DH"
+}
+
 variable "block_action" {
   description = "(Optional) Action to take for blocked domains. BLOCK prevents resolution; ALERT only logs the query without blocking."
   type        = string

--- a/resolver_dns/locals.tf
+++ b/resolver_dns/locals.tf
@@ -1,6 +1,9 @@
 locals {
-  common_tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-    Terraform             = "true"
-  }
+  common_tags = merge(
+    {
+      (var.billing_tag_key) = var.billing_tag_value
+      Terraform             = "true"
+    },
+    var.ssc_cbrid_tag_value != "" ? { (var.ssc_cbrid_tag_key) = var.ssc_cbrid_tag_value } : {}
+  )
 }

--- a/resolver_dns/main.tf
+++ b/resolver_dns/main.tf
@@ -61,7 +61,10 @@ resource "aws_route53_resolver_firewall_domain_list" "allowed" {
 
   name    = "AllowedDomains"
   domains = var.allowed_domains
-  tags    = local.common_tags
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = "true"
+  }
 }
 
 resource "aws_route53_resolver_firewall_domain_list" "blocked" {
@@ -69,14 +72,20 @@ resource "aws_route53_resolver_firewall_domain_list" "blocked" {
 
   name    = "BlockedDomains"
   domains = ["*."]
-  tags    = local.common_tags
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = "true"
+  }
 }
 
 resource "aws_route53_resolver_firewall_rule_group" "firewall_rules" {
   count = var.firewall_enabled ? 1 : 0
 
   name = "FirewallRules"
-  tags = local.common_tags
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = "true"
+  }
 }
 
 resource "aws_route53_resolver_firewall_rule" "allowed" {


### PR DESCRIPTION
# Summary | Résumé

Adding core services tags to the appropriate resources in the resolver dns module. 