### PR TITLE
Adding core services tags to the schedule_shutdown module

### DIFF
--- a/schedule_shutdown/README.md
+++ b/schedule_shutdown/README.md
@@ -57,6 +57,8 @@ No modules.
 | <a name="input_route53_healthcheck_arns"></a> [route53\_healthcheck\_arns](#input\_route53\_healthcheck\_arns) | (Optional) Route53 healthcheck ARNs to enable/disable. | `list(string)` | `[]` | no |
 | <a name="input_schedule_shutdown"></a> [schedule\_shutdown](#input\_schedule\_shutdown) | (Optional, every day at 10pm UTC) The schedule expression for when resources should be stopped. | `string` | `"cron(0 22 * * ? *)"` | no |
 | <a name="input_schedule_startup"></a> [schedule\_startup](#input\_schedule\_startup) | (Optional, Monday-Friday at 10am UTC) The schedule expression for when resources should be started. | `string` | `"cron(0 10 ? * MON-FRI *)"` | no |
+| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Optional, default 'ssc\_cbrid') The tag key for the SSC CBRID | `string` | `"ssc_cbrid"` | no |
+| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Optional) The value of the SSC CBRID tag | `string` | `"22DH"` | no |
 
 ## Outputs
 

--- a/schedule_shutdown/input.tf
+++ b/schedule_shutdown/input.tf
@@ -9,6 +9,18 @@ variable "billing_tag_value" {
   type        = string
 }
 
+variable "ssc_cbrid_tag_key" {
+  description = "(Optional, default 'ssc_cbrid') The tag key for the SSC CBRID"
+  type        = string
+  default     = "ssc_cbrid"
+}
+
+variable "ssc_cbrid_tag_value" {
+  description = "(Optional) The value of the SSC CBRID tag"
+  type        = string
+  default     = "22DH"
+}
+
 variable "cloudwatch_alarm_arns" {
   description = "(Optional) CloudWatch alarm ARNs to enable/disable."
   type        = list(string)

--- a/schedule_shutdown/locals.tf
+++ b/schedule_shutdown/locals.tf
@@ -11,9 +11,12 @@ locals {
     "startup" : var.schedule_startup,
   }
 
-  common_tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-    Terraform             = "true"
-  }
+  common_tags = merge(
+    {
+      (var.billing_tag_key) = var.billing_tag_value
+      Terraform             = "true"
+    },
+    var.ssc_cbrid_tag_value != "" ? { (var.ssc_cbrid_tag_key) = var.ssc_cbrid_tag_value } : {}
+  )
 }
 

--- a/schedule_shutdown/main.tf
+++ b/schedule_shutdown/main.tf
@@ -35,7 +35,10 @@ resource "aws_lambda_function" "schedule" {
     mode = "Active"
   }
 
-  tags = local.common_tags
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = "true"
+  }
 }
 
 data "archive_file" "schedule" {


### PR DESCRIPTION
# Summary | Résumé

Adding core services tags to the schedule shutdown module. 
