### PR TITLE
Adding core services tags for SNS module

### DIFF
--- a/sns/README.md
+++ b/sns/README.md
@@ -60,6 +60,8 @@ No modules.
 | <a name="input_sqs_failure_feedback_role_arn"></a> [sqs\_failure\_feedback\_role\_arn](#input\_sqs\_failure\_feedback\_role\_arn) | (Optional) IAM role for failure feedback | `string` | `null` | no |
 | <a name="input_sqs_success_feedback_role_arn"></a> [sqs\_success\_feedback\_role\_arn](#input\_sqs\_success\_feedback\_role\_arn) | (Optional) The IAM role permitted to receive success feedback for this topic | `string` | `null` | no |
 | <a name="input_sqs_success_feedback_sample_rate"></a> [sqs\_success\_feedback\_sample\_rate](#input\_sqs\_success\_feedback\_sample\_rate) | (Optional) Percentage of success to sample | `number` | `null` | no |
+| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Optional, default 'ssc\_cbrid') The tag key for the SSC CBRID | `string` | `"ssc_cbrid"` | no |
+| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Optional) The value of the SSC CBRID tag | `string` | `"22DH"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Key-value map of resource tags. If configured with a provider default\_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level. | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/sns/input.tf
+++ b/sns/input.tf
@@ -11,6 +11,18 @@ variable "billing_tag_value" {
   default     = null
 }
 
+variable "ssc_cbrid_tag_key" {
+  description = "(Optional, default 'ssc_cbrid') The tag key for the SSC CBRID"
+  type        = string
+  default     = "ssc_cbrid"
+}
+
+variable "ssc_cbrid_tag_value" {
+  description = "(Optional) The value of the SSC CBRID tag"
+  type        = string
+  default     = "22DH"
+}
+
 variable "name" {
   description = "The name of the topic. Topic names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 256 characters long. For a FIFO (first-in-first-out) topic, the name must end with the .fifo suffix. If omitted, Terraform will assign a random, unique name. Conflicts with name_prefix"
   type        = string

--- a/sns/locals.tf
+++ b/sns/locals.tf
@@ -1,8 +1,11 @@
 
 locals {
-  common_tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-    Terraform             = "true"
-  }
+  common_tags = merge(
+    {
+      (var.billing_tag_key) = var.billing_tag_value
+      Terraform             = "true"
+    },
+    var.ssc_cbrid_tag_value != "" ? { (var.ssc_cbrid_tag_key) = var.ssc_cbrid_tag_value } : {}
+  )
 }
 

--- a/sns/main.tf
+++ b/sns/main.tf
@@ -121,4 +121,5 @@ resource "aws_kms_key" "sns_key" {
   count       = var.kms_master_key_id == null ? 1 : 0
   description = "SNS Key for ${var.name}"
   policy      = data.aws_iam_policy_document.kms_policies.json
+  tags        = local.common_tags
 }


### PR DESCRIPTION
# Summary | Résumé

Adding core services tags for the SNS module 