### PR TITLE
Adding core services tags to spend notifier

### DIFF
--- a/spend_notifier/README.md
+++ b/spend_notifier/README.md
@@ -46,6 +46,8 @@ No modules.
 | <a name="input_daily_spend_notifier_hook"></a> [daily\_spend\_notifier\_hook](#input\_daily\_spend\_notifier\_hook) | (Required) The identifier of the webhook to be used by the spend notifier lambda daily | `string` | n/a | yes |
 | <a name="input_enable_daily_spend_notification"></a> [enable\_daily\_spend\_notification](#input\_enable\_daily\_spend\_notification) | (Optional) Enable daily spend notification | `bool` | `true` | no |
 | <a name="input_enable_weekly_spend_notification"></a> [enable\_weekly\_spend\_notification](#input\_enable\_weekly\_spend\_notification) | (Optional) Enable weekly spend notification | `bool` | `true` | no |
+| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Optional, default 'ssc\_cbrid') The tag key for the SSC CBRID | `string` | `"ssc_cbrid"` | no |
+| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Optional) The value of the SSC CBRID tag | `string` | `"22DH"` | no |
 | <a name="input_weekly_schedule_expression"></a> [weekly\_schedule\_expression](#input\_weekly\_schedule\_expression) | (Optional) The schedule expression for the weekly spend notification | `string` | `"0 12 ? * SUN *"` | no |
 | <a name="input_weekly_spend_notifier_hook"></a> [weekly\_spend\_notifier\_hook](#input\_weekly\_spend\_notifier\_hook) | (Required) The identifier of the webhook to be used by the spend notifier lambda weekly | `string` | n/a | yes |
 

--- a/spend_notifier/inputs.tf
+++ b/spend_notifier/inputs.tf
@@ -16,6 +16,18 @@ variable "billing_tag_value" {
   default     = null
 }
 
+variable "ssc_cbrid_tag_key" {
+  description = "(Optional, default 'ssc_cbrid') The tag key for the SSC CBRID"
+  type        = string
+  default     = "ssc_cbrid"
+}
+
+variable "ssc_cbrid_tag_value" {
+  description = "(Optional) The value of the SSC CBRID tag"
+  type        = string
+  default     = "22DH"
+}
+
 variable "account_name" {
   description = "(Required) The name of the account"
   type        = string

--- a/spend_notifier/lambda.tf
+++ b/spend_notifier/lambda.tf
@@ -26,7 +26,10 @@ resource "aws_lambda_function" "spend_notifier" {
   }
   timeout = 30
 
-  tags = local.common_tags
+  tags = {
+    CostCentre = var.billing_tag_value
+    Terraform  = "true"
+  }
 }
 
 

--- a/spend_notifier/locals.tf
+++ b/spend_notifier/locals.tf
@@ -1,6 +1,9 @@
 locals {
-  common_tags = {
-    CostCentre = var.billing_tag_value
-    Terraform  = "true"
-  }
+  common_tags = merge(
+    {
+      CostCentre = var.billing_tag_value
+      Terraform  = "true"
+    },
+    var.ssc_cbrid_tag_value != "" ? { (var.ssc_cbrid_tag_key) = var.ssc_cbrid_tag_value } : {}
+  )
 }


### PR DESCRIPTION
# Summary | Résumé

Adding core services tags to the appropriate resources. 