### PR TITLE
Adding core services tags to user login alarm module

### DIFF
--- a/user_login_alarm/README.md
+++ b/user_login_alarm/README.md
@@ -48,6 +48,8 @@ No modules.
 | <a name="input_log_group_name"></a> [log\_group\_name](#input\_log\_group\_name) | (required) The log group to search for cloudtrail ConsoleLogin events in. | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | The namespace for the metric | `string` | `"common-metrics"` | no |
 | <a name="input_num_attempts"></a> [num\_attempts](#input\_num\_attempts) | The number of failed attempts to login before the alarm triggers | `number` | `1` | no |
+| <a name="input_ssc_cbrid_tag_key"></a> [ssc\_cbrid\_tag\_key](#input\_ssc\_cbrid\_tag\_key) | (Optional, default 'ssc\_cbrid') The tag key for the SSC CBRID | `string` | `"ssc_cbrid"` | no |
+| <a name="input_ssc_cbrid_tag_value"></a> [ssc\_cbrid\_tag\_value](#input\_ssc\_cbrid\_tag\_value) | (Optional) The value of the SSC CBRID tag | `string` | `"22DH"` | no |
 
 ## Outputs
 

--- a/user_login_alarm/input.tf
+++ b/user_login_alarm/input.tf
@@ -1,3 +1,15 @@
+variable "ssc_cbrid_tag_key" {
+  description = "(Optional, default 'ssc_cbrid') The tag key for the SSC CBRID"
+  type        = string
+  default     = "ssc_cbrid"
+}
+
+variable "ssc_cbrid_tag_value" {
+  description = "(Optional) The value of the SSC CBRID tag"
+  type        = string
+  default     = "22DH"
+}
+
 variable "account_names" {
   description = "(required) The account name to alarm on if it's found"
   type        = set(string)

--- a/user_login_alarm/locals.tf
+++ b/user_login_alarm/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  common_tags = merge(
+    {
+      Terraform = "true"
+    },
+    var.ssc_cbrid_tag_value != "" ? { (var.ssc_cbrid_tag_key) = var.ssc_cbrid_tag_value } : {}
+  )
+}

--- a/user_login_alarm/main.tf
+++ b/user_login_alarm/main.tf
@@ -53,6 +53,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm_success" {
   threshold           = 1
   treat_missing_data  = "notBreaching"
   alarm_actions       = var.alarm_actions_success
+  tags                = local.common_tags
 }
 
 resource "aws_cloudwatch_log_metric_filter" "user_alarm_failure" {
@@ -83,4 +84,5 @@ resource "aws_cloudwatch_metric_alarm" "alarm_failure" {
   threshold           = var.num_attempts
   treat_missing_data  = "notBreaching"
   alarm_actions       = var.alarm_actions_failure
+  tags                = local.common_tags
 }


### PR DESCRIPTION
# Summary | Résumé

Adding core services tags to the user login alarm module. 
