### PR TITLE
fix: sanitize domain name to remove dots in S3 bucket and WAF resource

### DIFF
--- a/simple_static_website/locals.tf
+++ b/simple_static_website/locals.tf
@@ -3,6 +3,7 @@ locals {
   domain_validation_options = var.is_create_certificate ? aws_acm_certificate.cloudfront[0].domain_validation_options : []
   hosted_zone_id            = var.is_create_hosted_zone ? aws_route53_zone.hosted_zone[0].zone_id : var.hosted_zone_id
   web_acl_arn               = var.web_acl_arn != null && var.web_acl_arn != "" ? var.web_acl_arn : aws_wafv2_web_acl.default.arn
+  domain_name_sanitized     = replace(var.domain_name_source, ".", "-")
 
   common_tags = {
     (var.billing_tag_key) = var.billing_tag_value

--- a/simple_static_website/main.tf
+++ b/simple_static_website/main.tf
@@ -56,7 +56,7 @@ resource "random_string" "suffix" {
 }
 
 resource "aws_s3_bucket" "this" {
-  bucket        = var.s3_bucket_name == "" ? "${local.domain_name_sanitized}-${random_string.suffix.result}" : var.s3_bucket_name
+  bucket        = var.s3_bucket_name == "" ? "${var.domain_name_source}-${random_string.suffix.result}" : var.s3_bucket_name
   force_destroy = var.force_destroy_s3_bucket
 
   lifecycle {

--- a/simple_static_website/main.tf
+++ b/simple_static_website/main.tf
@@ -31,9 +31,6 @@ terraform {
   }
 }
 
-locals {
-  domain_name_sanitized = replace(var.domain_name_source, ".", "-")
-}
 
 data "aws_iam_policy_document" "s3_policy" {
   statement {

--- a/simple_static_website/main.tf
+++ b/simple_static_website/main.tf
@@ -31,6 +31,10 @@ terraform {
   }
 }
 
+locals {
+  domain_name_sanitized = replace(var.domain_name_source, ".", "-")
+}
+
 data "aws_iam_policy_document" "s3_policy" {
   statement {
     actions   = ["s3:GetObject"]
@@ -52,7 +56,7 @@ resource "random_string" "suffix" {
 }
 
 resource "aws_s3_bucket" "this" {
-  bucket        = var.s3_bucket_name == "" ? "${var.domain_name_source}-${random_string.suffix.result}" : var.s3_bucket_name
+  bucket        = var.s3_bucket_name == "" ? "${local.domain_name_sanitized}-${random_string.suffix.result}" : var.s3_bucket_name
   force_destroy = var.force_destroy_s3_bucket
 
   lifecycle {

--- a/simple_static_website/waf.tf
+++ b/simple_static_website/waf.tf
@@ -2,8 +2,8 @@
 # Default AWS WAFv2 Web ACL for CloudFront if not provided in vars
 #
 
-resource "aws_wafv2_web_acl" "default" {
-  name        = "${var.domain_name_source}-cloudfront-waf"
+resource "aws_wafv2_web_acl" "default" {  
+  name        = "${local.domain_name_sanitized}-cloudfront-waf"
   description = "Default WAF for CloudFront distribution protecting ${var.domain_name_source}"
   scope       = "CLOUDFRONT"
   provider    = aws.us-east-1
@@ -83,7 +83,7 @@ resource "aws_wafv2_web_acl" "default" {
   }
   visibility_config {
     cloudwatch_metrics_enabled = true
-    metric_name                = "${var.domain_name_source}-cloudfront-waf"
+    metric_name                = "${local.domain_name_sanitized}-cloudfront-waf"
     sampled_requests_enabled   = true
   }
 

--- a/simple_static_website/waf.tf
+++ b/simple_static_website/waf.tf
@@ -2,7 +2,7 @@
 # Default AWS WAFv2 Web ACL for CloudFront if not provided in vars
 #
 
-resource "aws_wafv2_web_acl" "default" {  
+resource "aws_wafv2_web_acl" "default" {
   name        = "${local.domain_name_sanitized}-cloudfront-waf"
   description = "Default WAF for CloudFront distribution protecting ${var.domain_name_source}"
   scope       = "CLOUDFRONT"


### PR DESCRIPTION
# Summary | Résumé

In the module `simple_static_website`, `var.domain_name_source` is used directly in S3 bucket names and WAFv2 resource/metric names, without sanitation. This introduces two bugs, as described in #888.

These changes sanitize the domain name in `main.tf`:
```
locals {
  domain_name_sanitized = replace(var.domain_name_source, ".", "-")
}
```
And use `local.domain_name_sanitized` in the appropriate places.

Resolves #888 