### PR TITLE
Restrict Lambda invoke permissions to CloudFront

### DIFF
--- a/lambda_response/README.md
+++ b/lambda_response/README.md
@@ -40,6 +40,7 @@ No modules.
 | [aws_route53_record.cloudfront_certificate_validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.hosted_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [archive_file.redirector_src](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.redirector_cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.service_principal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 

--- a/lambda_response/main.tf
+++ b/lambda_response/main.tf
@@ -5,6 +5,8 @@
 * This can be used to create 301 redirects or block access to a domain with a 403 response.
 */
 
+data "aws_caller_identity" "current" {}
+
 #
 # Redirector function invoked by CloudFront
 #
@@ -62,14 +64,16 @@ resource "aws_lambda_permission" "redirector_invoke_function_url" {
   action                 = "lambda:InvokeFunctionUrl"
   function_name          = aws_lambda_function.redirector.function_name
   function_url_auth_type = "NONE"
-  principal              = "*"
+  principal              = "cloudfront.amazonaws.com"
+  source_arn             = "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/*"
 }
 
 resource "aws_lambda_permission" "redirector_invoke_function" {
   statement_id  = "AllowInvokeFunction-${local.lambda_function_name}"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.redirector.function_name
-  principal     = "*"
+  principal     = "cloudfront.amazonaws.com"
+  source_arn    = "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/*"
 }
 
 #


### PR DESCRIPTION
# Summary | Résumé

Previously the lambda_response redirector allowed principal = "*" on both Lambda permissions, meaning anyone could invoke the function and its URL. This scopes invocation to CloudFront within the deploying account.

**Changes**

- redirector_invoke_function_url and redirector_invoke_function now use principal = "cloudfront.amazonaws.com" with source_arn restricted to arn:aws:cloudfront::<account_id>:distribution/*.
- Account ID is resolved automatically via the aws_caller_identity data source — no new module input required.
