### PR TITLE
fix: add support for new ECS high resolution metrics

### DIFF
--- a/ecs/main.tf
+++ b/ecs/main.tf
@@ -318,6 +318,6 @@ resource "aws_appautoscaling_policy" "this" {
       predefined_metric_type = try(each.value.predefined_metric_type, null)
       resource_label         = try(each.value.resource_label, null)
     }
-    target_value = each.value.predefined_metric_type == "ECSServiceAverageCPUUtilization" ? var.ecs_scale_cpu_threshold : var.ecs_scale_memory_threshold
+    target_value = startswith(try(each.value.predefined_metric_type, ""), "ECSServiceAverageCPUUtilization") ? var.ecs_scale_cpu_threshold : var.ecs_scale_memory_threshold
   }
 }


### PR DESCRIPTION
# Summary 
Update the ECS scaling policy so that it now supports the two new high resolution metrics that track over a 20 second interval:

- ECSServiceAverageCPUUtilizationHighResolution
- ECSServiceAverageMemoryUtilizationHighResolution

This is blocked until https://github.com/hashicorp/terraform-provider-aws/issues/48669 lands.

# Related
- https://aws.amazon.com/blogs/aws/amazon-ecs-introduces-new-high-resolution-metrics-for-faster-service-auto-scaling/