### PR TITLE
fix: add Athena workgroup and database outputs

### DIFF
--- a/athena_access_logs/README.md
+++ b/athena_access_logs/README.md
@@ -44,4 +44,7 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_athena_database_name"></a> [athena\_database\_name](#output\_athena\_database\_name) | The name of the Athena database |
+| <a name="output_athena_workgroup_name"></a> [athena\_workgroup\_name](#output\_athena\_workgroup\_name) | The name of the Athena workgroup |

--- a/athena_access_logs/output.tf
+++ b/athena_access_logs/output.tf
@@ -1,0 +1,9 @@
+output "athena_workgroup_name" {
+  value       = aws_athena_workgroup.logs.name
+  description = "The name of the Athena workgroup"
+}
+
+output "athena_database_name" {
+  value       = aws_athena_database.logs.name
+  description = "The name of the Athena database"
+}


### PR DESCRIPTION
# Summary
Add outputs that provide the Athena workgroup and database. This will make it easier for dependant modules to manage the dependency graph during Terraform operations.
