### PR TITLE
feat: add Service Connect TLS encryption in transit

### DIFF
--- a/ecs/README.md
+++ b/ecs/README.md
@@ -32,15 +32,20 @@ No requirements.
 | [aws_ecs_service.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_service.with_code_deploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_task_definition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_iam_policy.this_service_connect_tls_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.this_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.this_task_exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.this_service_connect_tls_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.this_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.this_task_exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.this_service_connect_tls_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.this_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.this_task_exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_service_discovery_service.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_service) | resource |
 | [aws_ssm_parameter.container_image_deployed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_cluster) | data source |
+| [aws_iam_policy_document.this_service_connect_tls_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.this_service_connect_tls_cert_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.this_task_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.this_task_combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.this_task_exec_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -107,6 +112,8 @@ No requirements.
 | <a name="input_service_connect_client_only"></a> [service\_connect\_client\_only](#input\_service\_connect\_client\_only) | (Optional, default `false`) Determines if the service should be registered as a client-only service in Service Connect. Client-only services are not discoverable by other services, but can make requests to other services in the Service Connect namespace. | `bool` | `false` | no |
 | <a name="input_service_connect_enabled"></a> [service\_connect\_enabled](#input\_service\_connect\_enabled) | (Optional, default `false`) Determines if Service Connect should be enabled for the service. If enabled, you must also provide a `service_connect_namespace_arn`. | `bool` | `false` | no |
 | <a name="input_service_connect_namespace_arn"></a> [service\_connect\_namespace\_arn](#input\_service\_connect\_namespace\_arn) | (Optional, no default) The ARN of the Service Connect namespace to associate with the service. | `string` | `null` | no |
+| <a name="input_service_connect_tls_cert_authority_arn"></a> [service\_connect\_tls\_cert\_authority\_arn](#input\_service\_connect\_tls\_cert\_authority\_arn) | (Optional, no default) The ARN of the Service Connect TLS certificate authority to use for the service. | `string` | `null` | no |
+| <a name="input_service_connect_tls_enabled"></a> [service\_connect\_tls\_enabled](#input\_service\_connect\_tls\_enabled) | (Optional, default `false`) Determines if Service Connect TLS should be enabled for the service. If enabled, you must also provide a `service_connect_tls_cert_authority_arn`. | `bool` | `false` | no |
 | <a name="input_service_discovery_enabled"></a> [service\_discovery\_enabled](#input\_service\_discovery\_enabled) | (Optional, false) Determines if service discovery should be enabled for the ECS service.  If enabled you must also provide a `service_discovery_namespace_id`. | `bool` | `false` | no |
 | <a name="input_service_discovery_namespace_id"></a> [service\_discovery\_namespace\_id](#input\_service\_discovery\_namespace\_id) | (Optional, no default) Service discovery namespace ID to associate with the service.  This will allow the service to be discovered by other services within the namespace. | `string` | `null` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | (Required) Name of the service (up to 255 letters, numbers, hyphens, and underscores) | `string` | n/a | yes |

--- a/ecs/iam.tf
+++ b/ecs/iam.tf
@@ -114,3 +114,52 @@ resource "aws_iam_role_policy_attachment" "this_task" {
   role       = aws_iam_role.this_task.name
   policy_arn = aws_iam_policy.this_task[0].arn
 }
+
+################################################################################
+# Service Connect TLS role: used to receive a certificate from ACM PCA
+################################################################################
+
+resource "aws_iam_role" "this_service_connect_tls_cert" {
+  count              = var.service_connect_tls_enabled ? 1 : 0
+  name               = "${local.task_definition_family}_ecs_service_connect_tls_cert_role"
+  assume_role_policy = data.aws_iam_policy_document.this_service_connect_tls_cert_assume[0].json
+  tags               = local.common_tags
+}
+
+data "aws_iam_policy_document" "this_service_connect_tls_cert_assume" {
+  count = var.service_connect_tls_enabled ? 1 : 0
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "this_service_connect_tls_cert" {
+  count  = var.service_connect_tls_enabled ? 1 : 0
+  name   = "${local.task_definition_family}_ecs_service_connect_tls_cert_policy"
+  path   = "/"
+  policy = data.aws_iam_policy_document.this_service_connect_tls_cert[0].json
+  tags   = local.common_tags
+}
+
+data "aws_iam_policy_document" "this_service_connect_tls_cert" {
+  count = var.service_connect_tls_enabled ? 1 : 0
+  statement {
+    effect = "Allow"
+    actions = [
+      "acm-pca:RequestCertificate",
+      "acm-pca:GetCertificate"
+    ]
+    resources = [var.service_connect_tls_cert_authority_arn]
+  }
+}
+
+
+resource "aws_iam_role_policy_attachment" "this_service_connect_tls_cert" {
+  count      = var.service_connect_tls_enabled ? 1 : 0
+  role       = aws_iam_role.this_service_connect_tls_cert[0].name
+  policy_arn = aws_iam_policy.this_service_connect_tls_cert[0].arn
+}

--- a/ecs/input.tf
+++ b/ecs/input.tf
@@ -166,6 +166,18 @@ variable "service_connect_app_protocol" {
   }
 }
 
+variable "service_connect_tls_enabled" {
+  description = "(Optional, default `false`) Determines if Service Connect TLS should be enabled for the service. If enabled, you must also provide a `service_connect_tls_cert_authority_arn`."
+  type        = bool
+  default     = false
+}
+
+variable "service_connect_tls_cert_authority_arn" {
+  description = "(Optional, no default) The ARN of the Service Connect TLS certificate authority to use for the service."
+  type        = string
+  default     = null
+}
+
 variable "service_discovery_enabled" {
   description = "(Optional, false) Determines if service discovery should be enabled for the ECS service.  If enabled you must also provide a `service_discovery_namespace_id`."
   type        = bool

--- a/ecs/main.tf
+++ b/ecs/main.tf
@@ -93,6 +93,17 @@ resource "aws_ecs_service" "this" {
             port     = var.container_host_port
             dns_name = var.service_name
           }
+
+          dynamic "tls" {
+            for_each = var.service_connect_tls_enabled ? [1] : []
+
+            content {
+              issuer_cert_authority {
+                aws_pca_authority_arn = var.service_connect_tls_cert_authority_arn
+              }
+              role_arn = aws_iam_role.this_service_connect_tls_cert[0].arn
+            }
+          }
         }
       }
 

--- a/ecs/tests/unit.default.tftest.hcl
+++ b/ecs/tests/unit.default.tftest.hcl
@@ -168,6 +168,82 @@ run "plan_service_connect" {
   }
 }
 
+run "plan_service_connect_tls" {
+  command = plan
+
+  variables {
+    subnet_ids                             = ["subnet-12345678"]
+    security_group_ids                     = ["sg-12345678"]
+    container_host_port                    = 8080
+    container_port                         = 8080
+    service_connect_enabled                = true
+    service_connect_namespace_arn          = "arn:aws:servicediscovery:ca-central-1:123456789012:namespace/ns-abc123"
+    service_connect_tls_enabled            = true
+    service_connect_tls_cert_authority_arn = "arn:aws:acm-pca:ca-central-1:123456789012:certificate-authority/abc12345-1234-1234-1234-abc123456789"
+  }
+
+  assert {
+    condition     = length(aws_iam_role.this_service_connect_tls_cert) == 1
+    error_message = "Expected service connect TLS IAM role to be created"
+  }
+
+  assert {
+    condition     = aws_iam_role.this_service_connect_tls_cert[0].name == "nginx_ecs_service_connect_tls_cert_role"
+    error_message = "Unexpected service connect TLS IAM role name"
+  }
+
+  assert {
+    condition     = length(aws_iam_policy.this_service_connect_tls_cert) == 1
+    error_message = "Expected service connect TLS IAM policy to be created"
+  }
+
+  assert {
+    condition     = aws_iam_policy.this_service_connect_tls_cert[0].name == "nginx_ecs_service_connect_tls_cert_policy"
+    error_message = "Unexpected service connect TLS IAM policy name"
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy_attachment.this_service_connect_tls_cert) == 1
+    error_message = "Expected service connect TLS IAM role policy attachment to be created"
+  }
+
+  assert {
+    condition     = length([for s in [for cfg in aws_ecs_service.this[0].service_connect_configuration : cfg][0].service : s][0].tls) == 1
+    error_message = "Expected TLS block to be set on the service connect service"
+  }
+
+  assert {
+    condition     = [for t in [for s in [for cfg in aws_ecs_service.this[0].service_connect_configuration : cfg][0].service : s][0].tls : t][0].issuer_cert_authority[0].aws_pca_authority_arn == "arn:aws:acm-pca:ca-central-1:123456789012:certificate-authority/abc12345-1234-1234-1234-abc123456789"
+    error_message = "Unexpected service connect TLS certificate authority ARN"
+  }
+}
+
+run "plan_service_connect_tls_disabled" {
+  command = plan
+
+  variables {
+    subnet_ids              = ["subnet-12345678"]
+    security_group_ids      = ["sg-12345678"]
+    container_host_port     = 8080
+    service_connect_enabled = false
+  }
+
+  assert {
+    condition     = length(aws_iam_role.this_service_connect_tls_cert) == 0
+    error_message = "Expected no TLS IAM role when service_connect_tls_enabled is false"
+  }
+
+  assert {
+    condition     = length(aws_iam_policy.this_service_connect_tls_cert) == 0
+    error_message = "Expected no TLS IAM policy when service_connect_tls_enabled is false"
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy_attachment.this_service_connect_tls_cert) == 0
+    error_message = "Expected no TLS IAM role policy attachment when service_connect_tls_enabled is false"
+  }
+}
+
 run "apply" {
   # Smoke test to validate that the module can successfully be applied
   variables {


### PR DESCRIPTION
# Summary 
Add the ability for Service Connect to encrypt its inter-service requests in transit.

# Related
- https://github.com/cds-snc/platform-core-services/issues/1028
- https://github.com/cds-snc/platform-core-services/issues/997