### PR TITLE
fix: update the ECS service connect TLS role policy

### DIFF
--- a/ecs/README.md
+++ b/ecs/README.md
@@ -32,7 +32,6 @@ No requirements.
 | [aws_ecs_service.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_service.with_code_deploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_task_definition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
-| [aws_iam_policy.this_service_connect_tls_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.this_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.this_task_exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.this_service_connect_tls_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -44,7 +43,6 @@ No requirements.
 | [aws_service_discovery_service.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_service) | resource |
 | [aws_ssm_parameter.container_image_deployed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_cluster) | data source |
-| [aws_iam_policy_document.this_service_connect_tls_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.this_service_connect_tls_cert_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.this_task_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.this_task_combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/ecs/iam.tf
+++ b/ecs/iam.tf
@@ -137,29 +137,8 @@ data "aws_iam_policy_document" "this_service_connect_tls_cert_assume" {
   }
 }
 
-resource "aws_iam_policy" "this_service_connect_tls_cert" {
-  count  = var.service_connect_tls_enabled ? 1 : 0
-  name   = "${local.task_definition_family}_ecs_service_connect_tls_cert_policy"
-  path   = "/"
-  policy = data.aws_iam_policy_document.this_service_connect_tls_cert[0].json
-  tags   = local.common_tags_with_cbrid
-}
-
-data "aws_iam_policy_document" "this_service_connect_tls_cert" {
-  count = var.service_connect_tls_enabled ? 1 : 0
-  statement {
-    effect = "Allow"
-    actions = [
-      "acm-pca:RequestCertificate",
-      "acm-pca:GetCertificate"
-    ]
-    resources = [var.service_connect_tls_cert_authority_arn]
-  }
-}
-
-
 resource "aws_iam_role_policy_attachment" "this_service_connect_tls_cert" {
   count      = var.service_connect_tls_enabled ? 1 : 0
   role       = aws_iam_role.this_service_connect_tls_cert[0].name
-  policy_arn = aws_iam_policy.this_service_connect_tls_cert[0].arn
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSInfrastructureRolePolicyForServiceConnectTransportLayerSecurity"
 }

--- a/ecs/tests/unit.default.tftest.hcl
+++ b/ecs/tests/unit.default.tftest.hcl
@@ -193,18 +193,13 @@ run "plan_service_connect_tls" {
   }
 
   assert {
-    condition     = length(aws_iam_policy.this_service_connect_tls_cert) == 1
-    error_message = "Expected service connect TLS IAM policy to be created"
-  }
-
-  assert {
-    condition     = aws_iam_policy.this_service_connect_tls_cert[0].name == "nginx_ecs_service_connect_tls_cert_policy"
-    error_message = "Unexpected service connect TLS IAM policy name"
-  }
-
-  assert {
     condition     = length(aws_iam_role_policy_attachment.this_service_connect_tls_cert) == 1
     error_message = "Expected service connect TLS IAM role policy attachment to be created"
+  }
+
+  assert {
+    condition     = aws_iam_role_policy_attachment.this_service_connect_tls_cert[0].policy_arn == "arn:aws:iam::aws:policy/service-role/AmazonECSInfrastructureRolePolicyForServiceConnectTransportLayerSecurity"
+    error_message = "Expected service connect TLS role to use the AWS managed infrastructure policy"
   }
 
   assert {
@@ -231,11 +226,6 @@ run "plan_service_connect_tls_disabled" {
   assert {
     condition     = length(aws_iam_role.this_service_connect_tls_cert) == 0
     error_message = "Expected no TLS IAM role when service_connect_tls_enabled is false"
-  }
-
-  assert {
-    condition     = length(aws_iam_policy.this_service_connect_tls_cert) == 0
-    error_message = "Expected no TLS IAM policy when service_connect_tls_enabled is false"
   }
 
   assert {


### PR DESCRIPTION
# Summary
Update to use the managed AWS IAM policy for the ECS Service Connect TLS IAM Role.

# Related
- https://github.com/cds-snc/platform-core-services/issues/1028
