### PR TITLE
feat: add ability to remove client VPN DNS servers

### DIFF
--- a/client_vpn/README.md
+++ b/client_vpn/README.md
@@ -47,6 +47,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_group_id"></a> [access\_group\_id](#input\_access\_group\_id) | (Required) IAM Identity Center access group ID that is authorized to access the private subnets. | `string` | n/a | yes |
 | <a name="input_acm_certificate_arn"></a> [acm\_certificate\_arn](#input\_acm\_certificate\_arn) | (Required) The ARN of the ACM server certificate to use for VPN client connection encryption. | `string` | n/a | yes |
+| <a name="input_add_dns_servers"></a> [add\_dns\_servers](#input\_add\_dns\_servers) | (Optional, default true) Whether to add DNS servers in the VPN endpoint. If left blank, the connecting client will use its own DNS servers. | `bool` | `true` | no |
 | <a name="input_authentication_option"></a> [authentication\_option](#input\_authentication\_option) | (Optional, default 'federated-authentication') The authentication option to use for the VPN endpoint.  Valid values are 'federated-authentication' or 'certificate-authentication'. | `string` | `"federated-authentication"` | no |
 | <a name="input_banner_text"></a> [banner\_text](#input\_banner\_text) | The text to display on the banner page when a user connects to the Client VPN endpoint. | `string` | `"This is a private network.  Only authorized users may connect and should take care not to cause service disruptions."` | no |
 | <a name="input_billing_tag_key"></a> [billing\_tag\_key](#input\_billing\_tag\_key) | (Optional, default 'CostCentre') The name of the billing tag | `string` | `"CostCentre"` | no |

--- a/client_vpn/input.tf
+++ b/client_vpn/input.tf
@@ -9,6 +9,12 @@ variable "acm_certificate_arn" {
   type        = string
 }
 
+variable "add_dns_servers" {
+  description = "(Optional, default true) Whether to add DNS servers in the VPN endpoint. If left blank, the connecting client will use its own DNS servers."
+  type        = bool
+  default     = true
+}
+
 variable "banner_text" {
   description = "The text to display on the banner page when a user connects to the Client VPN endpoint."
   type        = string

--- a/client_vpn/locals.tf
+++ b/client_vpn/locals.tf
@@ -7,6 +7,6 @@ locals {
     },
     var.ssc_cbrid_tag_value != "" ? { (var.ssc_cbrid_tag_key) = var.ssc_cbrid_tag_value } : {}
   )
-  dns_host        = cidrhost(var.vpc_cidr_block, 2)
-  is_self_service = var.self_service_portal == "enabled"
+  vpc_dns_resolver = cidrhost(var.vpc_cidr_block, 2)
+  is_self_service  = var.self_service_portal == "enabled"
 }

--- a/client_vpn/main.tf
+++ b/client_vpn/main.tf
@@ -21,7 +21,7 @@ resource "aws_ec2_client_vpn_endpoint" "this" {
   split_tunnel          = var.split_tunnel
   transport_protocol    = var.transport_protocol
   security_group_ids    = [aws_security_group.this.id]
-  dns_servers           = concat([local.dns_host], var.public_dns_servers)
+  dns_servers           = var.add_dns_servers ? concat([local.vpc_dns_resolver], var.public_dns_servers) : null
 
   dynamic "authentication_options" {
     for_each = var.authentication_option == "federated-authentication" ? [1] : []
@@ -64,7 +64,7 @@ resource "aws_ec2_client_vpn_network_association" "this_subnets" {
 
 resource "aws_ec2_client_vpn_authorization_rule" "this_internal_dns" {
   client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.this.id
-  target_network_cidr    = "${local.dns_host}/32"
+  target_network_cidr    = "${local.vpc_dns_resolver}/32"
   authorize_all_groups   = true
   description            = "Authorization for ${var.endpoint_name} to DNS"
 }

--- a/client_vpn/tests/unit.customized.tftest.hcl
+++ b/client_vpn/tests/unit.customized.tftest.hcl
@@ -125,3 +125,16 @@ run "customized" {
     error_message = "aws_cloudwatch_log_group.this.name did not match expected value"
   }
 }
+
+run "add_dns_servers_disabled" {
+  command = plan
+
+  variables {
+    add_dns_servers = false
+  }
+
+  assert {
+    condition     = aws_ec2_client_vpn_endpoint.this.dns_servers == null
+    error_message = "aws_ec2_client_vpn_endpoint.this.dns_servers should be null when add_dns_servers is false"
+  }
+}

--- a/client_vpn/tests/unit.default.tftest.hcl
+++ b/client_vpn/tests/unit.default.tftest.hcl
@@ -76,6 +76,11 @@ run "default" {
   }
 
   assert {
+    condition     = length(aws_ec2_client_vpn_endpoint.this.dns_servers) == 2
+    error_message = "aws_ec2_client_vpn_endpoint.this.dns_servers should have 2 entries when add_dns_servers is true (default)"
+  }
+
+  assert {
     condition     = aws_ec2_client_vpn_endpoint.this.client_login_banner_options[0].banner_text == "This is a private network.  Only authorized users may connect and should take care not to cause service disruptions."
     error_message = "aws_ec2_client_vpn_endpoint.this.client_login_banner_options[0].banner_text did not match expected value"
   }


### PR DESCRIPTION
# Summary 
Update the client VPN module so that the DNS servers can be optionally removed, falling back to using the connected device's DNS servers.
