### PR TITLE
feat: add cloudwatch log group name

### DIFF
--- a/lambda/README.md
+++ b/lambda/README.md
@@ -78,6 +78,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of the CloudWatch log group for the Lambda function. |
 | <a name="output_function_arn"></a> [function\_arn](#output\_function\_arn) | ARN of the Lambda function. |
 | <a name="output_function_name"></a> [function\_name](#output\_function\_name) | Name of the Lambda function. |
 | <a name="output_function_role_arn"></a> [function\_role\_arn](#output\_function\_role\_arn) | ARN of the Lambda function execution role. |

--- a/lambda/output.tf
+++ b/lambda/output.tf
@@ -22,3 +22,8 @@ output "invoke_arn" {
   description = "ARN used to invoke the Lambda function."
   value       = aws_lambda_function.this.invoke_arn
 }
+
+output "cloudwatch_log_group_name" {
+  description = "Name of the CloudWatch log group for the Lambda function."
+  value       = aws_cloudwatch_log_group.this.name
+}


### PR DESCRIPTION
# Summary | Résumé

Added a `cloudwatch_log_group_name` output to the `lambda` module.